### PR TITLE
Enable upload to riffraff on Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,10 +32,9 @@ test:
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - find . -type f -regex ".*/target/test-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
-    - sbt riffRaffArtifact
 
-#deployment:
-#  riffraff_upload:
-#    branch: /.*/
-#    commands:
-#      - sbt riffRaffUpload
+deployment:
+ riffraff_upload:
+   branch: /.*/
+   commands:
+     - sbt riffRaffUpload


### PR DESCRIPTION
Use `sbt riffRaffUpload` to package and upload artifact to S3 for riffraff deployment.