### PR TITLE
Route assets on /static

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -10,4 +10,4 @@ POST       /actions/signin                @com.gu.identity.frontend.controllers.
 
 GET        /management/healthcheck        @com.gu.identity.frontend.controllers.HealthCheck.healthCheck
 
-GET        /assets/*file                  @controllers.Assets.at(path="/public", file)
+GET        /static/*file                  @controllers.Assets.at(path="/public", file)

--- a/postcss.json
+++ b/postcss.json
@@ -9,7 +9,7 @@
   "output": "target/web/build/bundle.css",
   "postcss-assets": {
     "basePath": "public/",
-    "baseUrl": "/assets/"
+    "baseUrl": "/static/"
   },
   "cssnext": {
     "messages": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, 'target/web/build/'),
-    publicPath: "/assets/",
+    publicPath: "/static/",
     filename: "[name].bundle.js"
   },
   devtool: "#source-map",


### PR DESCRIPTION
Renamed `/assets` route to `/static` to avoid potential collisions with old app.