### PR TITLE
Fix broken links on sign-in form

### DIFF
--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -14,7 +14,13 @@ object ViewRenderer {
 
   def renderSignIn(configuration: Configuration, errorIds: Seq[String], email: String, returnUrl: Option[String], skipConfirmation: Option[Boolean])(implicit messages: Messages) = {
     val errors = errorIds.map(ErrorViewModel.apply)
-    val attrs = LayoutViewModel(configuration).toMap ++ SignInViewModel(errors = errors, email = email, returnUrl = returnUrl.getOrElse(""), skipConfirmation = skipConfirmation.getOrElse(true)).toMap
+    val attrs = LayoutViewModel(configuration).toMap ++
+      SignInViewModel(
+        errors = errors,
+        email = email,
+        returnUrl = returnUrl,
+        skipConfirmation = skipConfirmation
+      ).toMap
     render("signin-page", attrs)
   }
 }

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -67,6 +67,22 @@ case class SignInViewModel(showPrelude: Boolean = false,
       "actions" -> actions)
 }
 
+object SignInViewModel {
+  def apply(errors: Seq[ErrorViewModel], email: String, returnUrl: Option[String], skipConfirmation: Option[Boolean]): SignInViewModel = {
+    val urlParams: Seq[(String, String)] = Seq(returnUrl.map(("returnUrl", _)), skipConfirmation.map(bool => ("skipConfirmation", bool.toString))).flatten
+
+    SignInViewModel(
+      errors = errors,
+      email = email,
+      returnUrl = returnUrl.getOrElse(""),
+      skipConfirmation = skipConfirmation.getOrElse(false),
+      registerUrl = UrlBuilder("/register", urlParams),
+      forgotPasswordUrl = UrlBuilder("/reset", urlParams),
+      links = SignInLinksViewModel(urlParams)
+    )
+  }
+}
+
 object UrlBuilder {
 
   def apply(baseUrl: String, params: Seq[(String, String)]) = {

--- a/public/signin-page.hbs
+++ b/public/signin-page.hbs
@@ -29,9 +29,8 @@
       <div class="signin-form__control--password">
         <label class="signin-form__label--password" for="signin_field_password">{{signInPageText.password}}</label>
         <input class="signin-form__field--password" id="signin_field_password" type="password" name="password" />
-        <p class="signin-form__cta--reset"><a href="{{forgotPasswordUrl}}"> {{signInPageText.forgottenPassword}} </a></p>
       </div>
-
+      <div class="signin-form__cta--reset"><a href="{{forgotPasswordUrl}}">{{signInPageText.forgottenPassword}}</a></div>
 
       <div class="signin-form__control--remember-me">
         <input class="signin-form__checkbox--remember-me" id="signin_field_remember_me" type="checkbox" name="keepMeSignedIn" checked="checked" value="true"/>


### PR DESCRIPTION
Fixes for:
- Forgot password link was in the wrong spot
- Register and Forgot password links were not resolving

Due to merge conflicts in #30

