### PR TITLE
Ensure body params are URL encoded

### DIFF
--- a/app/com/gu/identity/service/client/ApiRequests.scala
+++ b/app/com/gu/identity/service/client/ApiRequests.scala
@@ -16,13 +16,19 @@ object ApiRequest {
 
   def apiEndpoint(path: String)(implicit configuration: IdentityClientConfiguration) =
     s"https://${configuration.host}/$path"
+
+  private[client] def encodeBody(params: (String, String)*) = {
+    def encode = java.net.URLEncoder.encode(_: String, "UTF8")
+
+    params.map(p => s"${p._1}=${encode(p._2)}").mkString("&")
+  }
 }
 
 case class AuthenticateCookiesRequest(url: String, email: String, password: String, rememberMe: Boolean, trackingData: TrackingData, extraHeaders: HttpParameters = Nil) extends ApiRequest {
   override val method = POST
   override val headers = Seq("Content-Type" -> "application/x-www-form-urlencoded") ++ extraHeaders
   override val parameters = Seq("format" -> "cookies", "persistent" -> rememberMe.toString) ++ trackingData.parameters
-  override val body = Some(s"email=$email&password=$password")
+  override val body = Some(ApiRequest.encodeBody("email" -> email, "password" -> password))
 }
 
 

--- a/test/com/gu/identity/service/client/AuthenticateCookiesRequestSpec.scala
+++ b/test/com/gu/identity/service/client/AuthenticateCookiesRequestSpec.scala
@@ -33,6 +33,19 @@ class AuthenticateCookiesRequestSpec extends WordSpec with Matchers with Mockito
       result.right.get.parameters should contain("persistent" -> "false")
     }
 
+    "Parse correctly with a valid email address and password that requires encoded params" in {
+      val email = Some("test@guardian.co.uk")
+      val password = Some("some%thing")
+
+      val result = AuthenticateCookiesRequest.from(email, password, rememberMe = false, trackingData)
+
+      result.isRight shouldBe true
+      result.right.get.email should equal (email.get)
+      result.right.get.password should equal(password.get)
+      result.right.get.parameters should contain("persistent" -> "false")
+      result.right.get.body should equal(Some("email=test%40guardian.co.uk&password=some%25thing"))
+    }
+
     "Set persistent parameter on request" in {
       val email = Some("test@guardian.co.uk")
       val password = Some("god")


### PR DESCRIPTION
Fixes issues with % signs in passwords.