### PR TITLE
Tell Prout to disable SSL verification for CODE

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,6 +1,10 @@
 {
   "checkpoints": {
-    "CODE": { "url": "https://profile-origin.code.dev-theguardian.com/management/manifest", "overdue": "15M" },
+    "CODE": {
+      "url": "https://profile-origin.code.dev-theguardian.com/management/manifest",
+      "overdue": "15M",
+      "disableSSLVerification": true
+    },
     "PROD": { "url": "https://profile-beta.theguardian.com/management/manifest", "overdue": "1H" }
   }
 }


### PR DESCRIPTION
...so that it can hit the manifest endpoint https://profile-origin.code.dev-theguardian.com/management/manifest - and doesn't say that https://github.com/guardian/identity-frontend/pull/38 is overdue.

![image](https://cloud.githubusercontent.com/assets/52038/11847931/ac8f5f1c-a417-11e5-9c96-28e504fc7520.png)

See also https://github.com/guardian/prout/pull/16

cc @mario-galic 