### PR TITLE
Referer return url

### DIFF
--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -1,9 +1,8 @@
 package com.gu.identity.frontend.controllers
 
-import javax.inject.Inject
-
 import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.logging.Logging
+import com.gu.identity.frontend.models.ReturnUrl
 import com.gu.identity.frontend.views.ViewRenderer.renderSignIn
 import play.api.i18n.{MessagesApi, I18nSupport}
 import play.api.mvc._

--- a/app/com/gu/identity/frontend/controllers/SigninAction.scala
+++ b/app/com/gu/identity/frontend/controllers/SigninAction.scala
@@ -7,7 +7,7 @@ import play.api.data.Form
 import play.api.data.Forms.{boolean, default, mapping, optional, text}
 import play.api.i18n.{MessagesApi, I18nSupport}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import play.api.mvc.{Request, AnyContent, Action, Controller}
+import play.api.mvc.{Action, Controller}
 
 import scala.util.control.NonFatal
 import play.api.i18n.Messages.Implicits._
@@ -34,7 +34,7 @@ class SigninAction(identityService: IdentityService, val messagesApi: MessagesAp
     NoCache {
       val formParams = signInFormBody.bindFromRequest()(request).get
       val trackingData = TrackingData(request, formParams.returnUrl)
-      val returnUrl = ReturnUrl(request.headers.get("Referer"), formParams.returnUrl)
+      val returnUrl = ReturnUrl(formParams.returnUrl, request.headers.get("Referer"))
 
       identityService.authenticate(formParams.email, formParams.password, formParams.rememberMe, trackingData).map {
         case Left(errors) => redirectToSigninPageWithErrorsAndEmail(errors, formParams.email, returnUrl, formParams.skipConfirmation)

--- a/app/com/gu/identity/frontend/controllers/SigninAction.scala
+++ b/app/com/gu/identity/frontend/controllers/SigninAction.scala
@@ -34,7 +34,7 @@ class SigninAction(identityService: IdentityService, val messagesApi: MessagesAp
     NoCache {
       val formParams = signInFormBody.bindFromRequest()(request).get
       val trackingData = TrackingData(request, formParams.returnUrl)
-      val returnUrl = ReturnUrl(request, formParams.returnUrl)
+      val returnUrl = ReturnUrl(request.headers.get("Referer"), formParams.returnUrl)
 
       identityService.authenticate(formParams.email, formParams.password, formParams.rememberMe, trackingData).map {
         case Left(errors) => redirectToSigninPageWithErrorsAndEmail(errors, formParams.email, returnUrl, formParams.skipConfirmation)

--- a/app/com/gu/identity/frontend/models/ReturnUrl.scala
+++ b/app/com/gu/identity/frontend/models/ReturnUrl.scala
@@ -26,7 +26,7 @@ object ReturnUrl {
 
   def profileDomain(returnUrl: ReturnUrl): Boolean = {
     val hostname = host(returnUrl)
-    profile.exists(s".$hostname".endsWith(_))
+    profile.exists(_ == hostname)
   }
 
   def host(returnUrl: ReturnUrl): String = Try(new URI(returnUrl.url)).map(_.getHost).getOrElse("")

--- a/app/com/gu/identity/frontend/models/ReturnUrl.scala
+++ b/app/com/gu/identity/frontend/models/ReturnUrl.scala
@@ -1,0 +1,28 @@
+package com.gu.identity.frontend.models
+
+import play.api.mvc.{AnyContent, Request}
+
+case class ReturnUrl(url: String)
+
+object ReturnUrl {
+
+  private val urlRegex = """^https?://([^/]+).*$""".r
+  val default = ReturnUrl("http://www.theguardian.com")
+
+  def apply(request: Request[AnyContent], returnUrl: Option[String]): ReturnUrl =
+    returnUrl.orElse(refererUrl(request)).map(ReturnUrl(_)).getOrElse(default)
+
+  def refererUrl(request: Request[AnyContent]): Option[String] = request.headers.get("Referer")
+
+  private def normaliseReturnUrl(returnUrl: Option[String]) =
+    returnUrl
+      .filter(validateReturnUrl)
+      .getOrElse("https://www.theguardian.com") // default
+
+  private def validateReturnUrl(returnUrl: String) =
+    returnUrl match {
+      case urlRegex(domain) if domain.endsWith(".theguardian.com") => true
+      case _ => false
+    }
+
+}

--- a/app/com/gu/identity/frontend/models/ReturnUrl.scala
+++ b/app/com/gu/identity/frontend/models/ReturnUrl.scala
@@ -9,17 +9,24 @@ object ReturnUrl {
 
   val default = ReturnUrl("http://www.theguardian.com")
   val domains = List(".theguardian.com", ".code.dev-theguardian.com", ".thegulocal.com")
+  val profile = List("profile.theguardian.com", "profile.code.dev-theguardian.com", "profile-origin.thegulocal.com")
 
   def apply(returnUrl: Option[String], referer: Option[String]): ReturnUrl = {
     returnUrl.map(ReturnUrl(_))
       .orElse(referer.map(ReturnUrl(_)))
       .filter(validDomain(_))
+      .filterNot(profileDomain(_))
       .getOrElse(default)
   }
 
   def validDomain(returnUrl: ReturnUrl): Boolean = {
     val hostname = host(returnUrl)
     domains.exists(s".$hostname".endsWith(_))
+  }
+
+  def profileDomain(returnUrl: ReturnUrl): Boolean = {
+    val hostname = host(returnUrl)
+    profile.exists(s".$hostname".endsWith(_))
   }
 
   def host(returnUrl: ReturnUrl): String = Try(new URI(returnUrl.url)).map(_.getHost).getOrElse("")

--- a/app/com/gu/identity/frontend/models/ReturnUrl.scala
+++ b/app/com/gu/identity/frontend/models/ReturnUrl.scala
@@ -9,24 +9,17 @@ object ReturnUrl {
 
   val default = ReturnUrl("http://www.theguardian.com")
   val domains = List(".theguardian.com", ".code.dev-theguardian.com", ".thegulocal.com")
-  val profile = List("profile.theguardian.com", "profile.code.dev-theguardian.com", "profile-origin.thegulocal.com")
 
   def apply(returnUrl: Option[String], referer: Option[String]): ReturnUrl = {
     returnUrl.map(ReturnUrl(_))
       .orElse(referer.map(ReturnUrl(_)))
       .filter(validDomain(_))
-      .filterNot(profileDomain(_))
       .getOrElse(default)
   }
 
   def validDomain(returnUrl: ReturnUrl): Boolean = {
     val hostname = host(returnUrl)
     domains.exists(s".$hostname".endsWith(_))
-  }
-
-  def profileDomain(returnUrl: ReturnUrl): Boolean = {
-    val hostname = host(returnUrl)
-    profile.exists(_ == hostname)
   }
 
   def host(returnUrl: ReturnUrl): String = Try(new URI(returnUrl.url)).map(_.getHost).getOrElse("")

--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -1,7 +1,6 @@
 package com.gu.identity.frontend.views
 
 import com.gu.identity.frontend.configuration.Configuration
-import com.gu.identity.frontend.models.ReturnUrl
 import com.gu.identity.frontend.views.models.{ErrorViewModel, LayoutViewModel, SignInViewModel}
 import jp.co.bizreach.play2handlebars.HBS
 import play.api.i18n.Messages

--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -4,6 +4,7 @@ import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.views.models.{ErrorViewModel, LayoutViewModel, SignInViewModel}
 import jp.co.bizreach.play2handlebars.HBS
 import play.api.i18n.Messages
+import play.api.mvc.RequestHeader
 
 /**
  * Adapter for Handlebars view renderer
@@ -12,7 +13,7 @@ object ViewRenderer {
   def render(view: String, attributes: Map[String, Any] = Map.empty) =
     HBS(view, attributes)
 
-  def renderSignIn(configuration: Configuration, errorIds: Seq[String], email: String, returnUrl: Option[String], skipConfirmation: Option[Boolean])(implicit messages: Messages) = {
+  def renderSignIn(configuration: Configuration, errorIds: Seq[String], email: String, returnUrl: Option[String], skipConfirmation: Option[Boolean])(implicit request: RequestHeader, messages: Messages) = {
     val errors = errorIds.map(ErrorViewModel.apply)
     val attrs = LayoutViewModel(configuration).toMap ++
       SignInViewModel(
@@ -20,7 +21,7 @@ object ViewRenderer {
         email = email,
         returnUrl = returnUrl,
         skipConfirmation = skipConfirmation
-      ).toMap
+      )(request).toMap
     render("signin-page", attrs)
   }
 }

--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -1,6 +1,7 @@
 package com.gu.identity.frontend.views
 
 import com.gu.identity.frontend.configuration.Configuration
+import com.gu.identity.frontend.models.ReturnUrl
 import com.gu.identity.frontend.views.models.{ErrorViewModel, LayoutViewModel, SignInViewModel}
 import jp.co.bizreach.play2handlebars.HBS
 import play.api.i18n.Messages

--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -22,7 +22,7 @@ object ViewRenderer {
         email = email,
         returnUrl = ReturnUrl(returnUrl, request.headers.get("Referer")),
         skipConfirmation = skipConfirmation
-      )(request).toMap
+      ).toMap
     render("signin-page", attrs)
   }
 }

--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -1,6 +1,7 @@
 package com.gu.identity.frontend.views
 
 import com.gu.identity.frontend.configuration.Configuration
+import com.gu.identity.frontend.models.ReturnUrl
 import com.gu.identity.frontend.views.models.{ErrorViewModel, LayoutViewModel, SignInViewModel}
 import jp.co.bizreach.play2handlebars.HBS
 import play.api.i18n.Messages
@@ -19,7 +20,7 @@ object ViewRenderer {
       SignInViewModel(
         errors = errors,
         email = email,
-        returnUrl = returnUrl,
+        returnUrl = ReturnUrl(returnUrl, request.headers.get("Referer")),
         skipConfirmation = skipConfirmation
       )(request).toMap
     render("signin-page", attrs)

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -1,7 +1,6 @@
 package com.gu.identity.frontend.views.models
 
 import com.gu.identity.frontend.controllers.routes
-import com.gu.identity.frontend.models.ReturnUrl
 import com.gu.identity.frontend.models.Text._
 import play.api.i18n.Messages
 

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -1,6 +1,7 @@
 package com.gu.identity.frontend.views.models
 
 import com.gu.identity.frontend.controllers.routes
+import com.gu.identity.frontend.models.ReturnUrl
 import com.gu.identity.frontend.models.Text._
 import play.api.i18n.Messages
 

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -1,8 +1,10 @@
 package com.gu.identity.frontend.views.models
 
 import com.gu.identity.frontend.controllers.routes
+import com.gu.identity.frontend.models.ReturnUrl
 import com.gu.identity.frontend.models.Text._
 import play.api.i18n.Messages
+import play.api.mvc.{RequestHeader, Request}
 
 case class SignInLinksViewModel(socialFacebook: String = "https://oauth.theguardian.com/facebook/signin",
                                 socialGoogle: String = "https://oauth.theguardian.com/google/signin") extends ViewModel {
@@ -68,13 +70,13 @@ case class SignInViewModel(showPrelude: Boolean = false,
 }
 
 object SignInViewModel {
-  def apply(errors: Seq[ErrorViewModel], email: String, returnUrl: Option[String], skipConfirmation: Option[Boolean]): SignInViewModel = {
+  def apply(errors: Seq[ErrorViewModel], email: String, returnUrl: Option[String], skipConfirmation: Option[Boolean])(implicit request: RequestHeader): SignInViewModel = {
     val urlParams: Seq[(String, String)] = Seq(returnUrl.map(("returnUrl", _)), skipConfirmation.map(bool => ("skipConfirmation", bool.toString))).flatten
 
     SignInViewModel(
       errors = errors,
       email = email,
-      returnUrl = returnUrl.getOrElse(""),
+      returnUrl = ReturnUrl(returnUrl, request.headers.get("Referer")).url,
       skipConfirmation = skipConfirmation.getOrElse(false),
       registerUrl = UrlBuilder("/register", urlParams),
       forgotPasswordUrl = UrlBuilder("/reset", urlParams),

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -70,7 +70,7 @@ case class SignInViewModel(showPrelude: Boolean = false,
 }
 
 object SignInViewModel {
-  def apply(errors: Seq[ErrorViewModel], email: String, returnUrl: ReturnUrl, skipConfirmation: Option[Boolean])(implicit request: RequestHeader): SignInViewModel = {
+  def apply(errors: Seq[ErrorViewModel], email: String, returnUrl: ReturnUrl, skipConfirmation: Option[Boolean]): SignInViewModel = {
     val urlParams: Seq[(String, String)] = Seq(Some("returnUrl" -> returnUrl.url), skipConfirmation.map(bool => ("skipConfirmation", bool.toString))).flatten
 
     SignInViewModel(

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -70,13 +70,13 @@ case class SignInViewModel(showPrelude: Boolean = false,
 }
 
 object SignInViewModel {
-  def apply(errors: Seq[ErrorViewModel], email: String, returnUrl: Option[String], skipConfirmation: Option[Boolean])(implicit request: RequestHeader): SignInViewModel = {
-    val urlParams: Seq[(String, String)] = Seq(returnUrl.map(("returnUrl", _)), skipConfirmation.map(bool => ("skipConfirmation", bool.toString))).flatten
+  def apply(errors: Seq[ErrorViewModel], email: String, returnUrl: ReturnUrl, skipConfirmation: Option[Boolean])(implicit request: RequestHeader): SignInViewModel = {
+    val urlParams: Seq[(String, String)] = Seq(Some("returnUrl" -> returnUrl.url), skipConfirmation.map(bool => ("skipConfirmation", bool.toString))).flatten
 
     SignInViewModel(
       errors = errors,
       email = email,
-      returnUrl = ReturnUrl(returnUrl, request.headers.get("Referer")).url,
+      returnUrl = returnUrl.url,
       skipConfirmation = skipConfirmation.getOrElse(false),
       registerUrl = UrlBuilder("/register", urlParams),
       forgotPasswordUrl = UrlBuilder("/reset", urlParams),

--- a/test/com/gu/identity/frontend/models/ReturnUrl$Test.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrl$Test.scala
@@ -28,6 +28,9 @@ class ReturnUrl$Test extends FlatSpec with Matchers {
 
     ReturnUrl(Some("http://baddomain.com"), None) should be(ReturnUrl("http://www.theguardian.com"))
     ReturnUrl(None, Some("http://baddomain.com")) should be(ReturnUrl("http://www.theguardian.com"))
+
+    ReturnUrl(Some("http://profile.theguardian.com"), None) should be(ReturnUrl("http://www.theguardian.com"))
+    ReturnUrl(None, Some("http://profile.theguardian.com")) should be(ReturnUrl("http://www.theguardian.com"))
   }
 
 }

--- a/test/com/gu/identity/frontend/models/ReturnUrl$Test.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrl$Test.scala
@@ -31,6 +31,8 @@ class ReturnUrl$Test extends FlatSpec with Matchers {
 
     ReturnUrl(Some("http://profile.theguardian.com"), None) should be(ReturnUrl("http://www.theguardian.com"))
     ReturnUrl(None, Some("http://profile.theguardian.com")) should be(ReturnUrl("http://www.theguardian.com"))
+
+    ReturnUrl(None, Some("http://profile-origin2.thegulocal.com")) should be(ReturnUrl("http://profile-origin2.thegulocal.com"))
   }
 
 }

--- a/test/com/gu/identity/frontend/models/ReturnUrl$Test.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrl$Test.scala
@@ -1,0 +1,32 @@
+package com.gu.identity.frontend.models
+
+import org.scalatest.{Matchers, FlatSpec}
+
+class ReturnUrl$Test extends FlatSpec with Matchers {
+
+  import ReturnUrl._
+
+  it should "determine valid domain" in {
+
+    validDomain(ReturnUrl("http://www.theguardian.com")) should be(true)
+    validDomain(ReturnUrl("http://jobs.theguardian.com")) should be(true)
+    validDomain(ReturnUrl("http://code.dev-theguardian.com")) should be(true)
+    validDomain(ReturnUrl("http://thegulocal.com")) should be(true)
+    validDomain(ReturnUrl("http://baddomain.com")) should be(false)
+  }
+
+  it should "construct return url" in {
+
+    ReturnUrl(Some("http://www.theguardian.com/uk"), None) should be(ReturnUrl("http://www.theguardian.com/uk"))
+    ReturnUrl(None, Some("http://www.theguardian.com/uk")) should be(ReturnUrl("http://www.theguardian.com/uk"))
+
+    ReturnUrl(Some("http://jobs.theguardian.com/apply"), None) should be(ReturnUrl("http://jobs.theguardian.com/apply"))
+    ReturnUrl(None, Some("http://jobs.theguardian.com/apply")) should be(ReturnUrl("http://jobs.theguardian.com/apply"))
+
+    ReturnUrl(None, None) should be(ReturnUrl("http://www.theguardian.com"))
+
+    ReturnUrl(Some("http://baddomain.com"), None) should be(ReturnUrl("http://www.theguardian.com"))
+    ReturnUrl(None, Some("http://baddomain.com")) should be(ReturnUrl("http://www.theguardian.com"))
+  }
+
+}

--- a/test/com/gu/identity/frontend/models/ReturnUrl$Test.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrl$Test.scala
@@ -23,6 +23,7 @@ class ReturnUrl$Test extends FlatSpec with Matchers {
     ReturnUrl(Some("http://jobs.theguardian.com/apply"), None) should be(ReturnUrl("http://jobs.theguardian.com/apply"))
     ReturnUrl(None, Some("http://jobs.theguardian.com/apply")) should be(ReturnUrl("http://jobs.theguardian.com/apply"))
 
+    ReturnUrl(None, Some("http://www.thegulocal.com/")) should be(ReturnUrl("http://www.thegulocal.com/"))
     ReturnUrl(None, None) should be(ReturnUrl("http://www.theguardian.com"))
 
     ReturnUrl(Some("http://baddomain.com"), None) should be(ReturnUrl("http://www.theguardian.com"))

--- a/test/com/gu/identity/frontend/models/ReturnUrl$Test.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrl$Test.scala
@@ -29,9 +29,6 @@ class ReturnUrl$Test extends FlatSpec with Matchers {
     ReturnUrl(Some("http://baddomain.com"), None) should be(ReturnUrl("http://www.theguardian.com"))
     ReturnUrl(None, Some("http://baddomain.com")) should be(ReturnUrl("http://www.theguardian.com"))
 
-    ReturnUrl(Some("http://profile.theguardian.com"), None) should be(ReturnUrl("http://www.theguardian.com"))
-    ReturnUrl(None, Some("http://profile.theguardian.com")) should be(ReturnUrl("http://www.theguardian.com"))
-
     ReturnUrl(None, Some("http://profile-origin2.thegulocal.com")) should be(ReturnUrl("http://profile-origin2.thegulocal.com"))
   }
 


### PR DESCRIPTION
This PR implements redirecting the user back to the Referer when the returnUrl is not set by query parameter.  This is the same behaviour that exists on the existing dotcom::identity solution.

