### PR TITLE
Fix Return URL encoding for links

### DIFF
--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -63,12 +63,18 @@ object SignInViewModel {
 
 object UrlBuilder {
 
-  def apply(baseUrl: String, params: Seq[(String, String)]) = {
-    val paramString = params.map(x => s"${x._1}=${x._2}").mkString("&")
-     paramString match {
-       case "" => baseUrl
-       case paramString => s"$baseUrl?$paramString"
-     }
+  private def encode = java.net.URLEncoder.encode(_: String, "UTF8")
 
-  }
+  def apply(baseUrl: String, params: Seq[(String, String)]) =
+    params.headOption match {
+      case None => baseUrl
+      case _ => {
+        val paramString = params.map {
+          case (key, value) => s"$key=${encode(value)}"
+        }.mkString("&")
+
+        s"$baseUrl?$paramString"
+      }
+    }
+
 }

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -2,7 +2,7 @@ package com.gu.identity.frontend.models
 
 import org.scalatest.{Matchers, FlatSpec}
 
-class ReturnUrl$Test extends FlatSpec with Matchers {
+class ReturnUrlSpec extends FlatSpec with Matchers {
 
   import ReturnUrl._
 

--- a/test/com/gu/identity/frontend/views/models/UrlBuilderSpec.scala
+++ b/test/com/gu/identity/frontend/views/models/UrlBuilderSpec.scala
@@ -2,7 +2,7 @@ package com.gu.identity.frontend.views.models
 
 import org.scalatest.{FlatSpec, Matchers}
 
-class UrlBuilder$Test extends FlatSpec with Matchers{
+class UrlBuilderSpec extends FlatSpec with Matchers{
 
   it should "create url register with return url" in {
     UrlBuilder("register", Seq(("returnUrl", "www.test.com"))) should be ("register?returnUrl=www.test.com")
@@ -15,4 +15,16 @@ class UrlBuilder$Test extends FlatSpec with Matchers{
   it should "create a register url with 'returnUrl=www.test.com' and ignore any None objects" in {
     UrlBuilder("register", Seq(("returnUrl", "www.test.com"))) should be ("register?returnUrl=www.test.com")
   }
+
+  it should "create a url with return url params encoded" in {
+    val params = Seq(
+      "returnUrl" -> "https://subscribe.theguardian.com/?INTCMP=NGW_HEADER_UK_GU_SUBSCRIBE&yes=no",
+      "another" -> "hello"
+    )
+
+    UrlBuilder("/register", params) should be (
+      "/register?returnUrl=https%3A%2F%2Fsubscribe.theguardian.com%2F%3FINTCMP%3DNGW_HEADER_UK_GU_SUBSCRIBE%26yes%3Dno&another=hello"
+    )
+  }
+
 }


### PR DESCRIPTION
Ensures the Return URL and other parameters are encoded when appended to links in the views, such as the Social Sign in links.