### PR TITLE
Add Facebook registration test

### DIFF
--- a/functional-tests/build.sbt
+++ b/functional-tests/build.sbt
@@ -11,5 +11,7 @@ libraryDependencies ++= Seq(
   "org.seleniumhq.selenium" % "selenium-java" % "2.48.2" % "test",
   "com.gu" %% "identity-test-users" % "0.5",
   "com.squareup.okhttp" % "okhttp" % "2.7.2",
-  "com.typesafe.play" %% "play-json" % "2.4.4"
+  "com.typesafe.play" %% "play-json" % "2.4.4",
+  "org.scalatestplus" %% "play" % "1.4.0-M3" % "test",
+  ws
 )

--- a/functional-tests/build.sbt
+++ b/functional-tests/build.sbt
@@ -9,5 +9,7 @@ libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.1.3",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "org.seleniumhq.selenium" % "selenium-java" % "2.48.2" % "test",
-  "com.gu" %% "identity-test-users" % "0.5"
+  "com.gu" %% "identity-test-users" % "0.5",
+  "com.squareup.okhttp" % "okhttp" % "2.7.2",
+  "com.typesafe.play" %% "play-json" % "2.4.4"
 )

--- a/functional-tests/src/test/resources/application.conf
+++ b/functional-tests/src/test/resources/application.conf
@@ -11,8 +11,9 @@ identity.test.users.secret = ${?IDENTITY_TEST_USER_SECRET}
 
 webDriverRemoteUrl = ${?WEBDRIVER_REMOTE_URL}
 
-facebook.test {
-  email = ${?FACEBOOK_TEST_EMAIL}
-  password = ${?FACEBOOK_TEST_PASSWORD}
-  name = ${?FACEBOOK_TEST_NAME}
+facebook {
+  app {
+    id = ${?FACEBOOK_APP_ID}
+    secret = ${?FACEBOOK_APP_SECRET}
+  }
 }

--- a/functional-tests/src/test/resources/logback.xml
+++ b/functional-tests/src/test/resources/logback.xml
@@ -1,0 +1,19 @@
+<configuration debug="false">
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+      <Pattern>%date %level %class - %m%n</Pattern>
+    </encoder>
+  </appender>
+
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>logs/functional-tests.log</file>
+    <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+      <pattern>%date %level %class - %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="FILE"/>
+  </root>
+</configuration>

--- a/functional-tests/src/test/scala/SigninSpec.scala
+++ b/functional-tests/src/test/scala/SigninSpec.scala
@@ -1,15 +1,14 @@
 package test
 
-import _root_.util.user.FacebookTestUserService
+import test.util.user.{FacebookTestUserService, EmailTestUser}
 import test.pages.{FacebookAuthDialog, FacebookLogin, RegisterConfirm}
 import test.util._
 import org.scalatest.selenium.WebBrowser
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfter, FeatureSpec, GivenWhenThen}
 import org.slf4j.LoggerFactory
-import test.util.user.EmailTestUser
 
 class SigninSpec extends FeatureSpec with WebBrowser with Browser
-  with GivenWhenThen with BeforeAndAfter with BeforeAndAfterAll  {
+  with GivenWhenThen with BeforeAndAfter with BeforeAndAfterAll {
 
   def logger = LoggerFactory.getLogger(this.getClass)
 

--- a/functional-tests/src/test/scala/SigninSpec.scala
+++ b/functional-tests/src/test/scala/SigninSpec.scala
@@ -1,10 +1,12 @@
 package test
 
-import test.pages.{FacebookLogin, RegisterConfirm}
-import test.util.{TestUser, Browser, Config, Driver}
+import _root_.util.user.FacebookTestUserService
+import test.pages.{FacebookAuthDialog, FacebookLogin, RegisterConfirm}
+import test.util._
 import org.scalatest.selenium.WebBrowser
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfter, FeatureSpec, GivenWhenThen}
 import org.slf4j.LoggerFactory
+import test.util.user.EmailTestUser
 
 class SigninSpec extends FeatureSpec with WebBrowser with Browser
   with GivenWhenThen with BeforeAndAfter with BeforeAndAfterAll  {
@@ -22,72 +24,89 @@ class SigninSpec extends FeatureSpec with WebBrowser with Browser
   override def afterAll() = Driver.quit()
 
   feature("Sign in") {
-    scenario("User signs in with newly created Identity account") {
-      val testUser = new TestUser
+    scenario("Users register with Email") {
+      val testUser = new EmailTestUser
 
-      When("I visit 'Sign in' page ")
+      Given("users have not registered with email before,")
+
+      When("they visit 'Sign in' page,")
       val signin = new pages.Signin(testUser)
       go.to(signin)
       assert(signin.pageHasLoaded())
 
-      And("I click on 'Sign up' link")
+      And("click on 'Sign up' link,")
       signin.signUp()
 
-      Then("I should land on 'Register' page.")
+      Then("they should land on 'Register' page.")
       val register = new pages.Register(testUser)
-      assert(register.pageHasLoaded())
+      assert(register.hasLoaded())
 
-      When("I fill in personal details")
+      When("Users fill in personal details,")
       register.fillInPersonalDetails()
 
-      And("I submit the form to create my new Identity account")
+      And("click on 'Create account' button,")
       register.submit()
 
-      Then("I should land on 'Registration Confirmation' page")
+      Then("they should land on 'Registration Confirmation' page,")
       val registerConfirm = new RegisterConfirm
-      assert(registerConfirm.pageHasLoaded())
+      assert(registerConfirm.hasLoaded())
 
-      And("I should have Identity cookies.")
+      And("they should have Identity cookies.")
       Seq("GU_U", "SC_GU_U", "SC_GU_LA").foreach { idCookie =>
         assert(Driver.cookiesSet.map(_.getName).contains(idCookie))
       }
 
-      When("I click 'Confirm Registration' button")
+      When("Users click on 'Confirm Registration' button,")
       registerConfirm.confirmRegistration()
 
-      Then("I should land on 'Guardian Homepage'")
+      Then("they should land on 'Guardian Homepage',")
       val homepage = new pages.Homepage
-      assert(homepage.pageHasLoaded())
+      assert(homepage.hasLoaded())
 
-      And("I should be signed in.")
-      assert(elementHasText(className("js-profile-info"), testUser.username))
+      And("should be signed in.")
+      assert(elementHasText(className("js-profile-info"), testUser.name))
     }
 
-    scenario("User signs in with Facebook") {
-      When("I visit 'Sign in' page ")
-      val signin = new pages.Signin(new TestUser)
+    scenario("Users register with Facebook") {
+      val fbTestUser = FacebookTestUserService.createUser()
+      assert(fbTestUser.created)
+
+      Given("users have not registered with Facebook before,")
+
+      When("they visit 'Sign in' page")
+      val signin = new pages.Signin(new EmailTestUser)
       go.to(signin)
       assert(signin.pageHasLoaded())
 
-      And("I click on 'Sign in with Facebook' button")
+      And("click on 'Sign in with Facebook' button")
       signin.signInWithFacebook()
 
-      Then("I should land on 'Facebook Login' page.")
+      Then("they should land on 'Facebook Login' page.")
       val facebookLogin = new FacebookLogin()
-      assert(facebookLogin.pageHasLoaded())
+      assert(facebookLogin.hasLoaded())
 
-      When("I fill in Facebook credentials")
-      facebookLogin.fillInCredentials()
+      When("users fill in Facebook credentials")
+      facebookLogin.fillInCredentials(fbTestUser)
 
-      And("I click on 'Log In' button")
+      And("click on 'Log In' button")
       facebookLogin.logIn()
 
-      Then("I should land on 'Guardian Homepage'")
-      val homepage = new pages.Homepage
-      assert(homepage.pageHasLoaded())
+      Then("Facebook auth dialog should open.")
+      val facebookAuthDialog = new FacebookAuthDialog
+      assert(facebookAuthDialog.hasLoaded())
 
-      And("I should be signed in.")
-      assert(elementHasText(className("js-profile-info"), Config.FacebookCredentials.name))
+      When("users clicks on 'Okay' button")
+      facebookAuthDialog.confirm()
+
+      Then("they should land on 'Guardian Homepage'")
+      val homepage = new pages.Homepage
+      assert(homepage.hasLoaded())
+
+      And("should be signed in.")
+      assert(elementHasText(className("js-profile-info"), fbTestUser.name))
+
+      val fbTestUserIsDeleted = FacebookTestUserService.deleteUser(fbTestUser)
+      assert(fbTestUserIsDeleted)
     }
   }
 }

--- a/functional-tests/src/test/scala/pages/FacebookAuthDialog.scala
+++ b/functional-tests/src/test/scala/pages/FacebookAuthDialog.scala
@@ -1,0 +1,19 @@
+package test.pages
+
+import test.util.{LoadablePage, Browser}
+
+class FacebookAuthDialog extends LoadablePage with Browser {
+  val url = "https://www.facebook.com/v2.2/dialog/oauth"
+
+  def hasLoaded(): Boolean = {
+    pageHasElement(confirmButton)
+  }
+
+  def confirm(): Unit = {
+    assert(pageHasElement(confirmButton))
+    click.on(confirmButton)
+  }
+
+  private lazy val confirmButton = name("__CONFIRM__")
+}
+

--- a/functional-tests/src/test/scala/pages/FacebookLogin.scala
+++ b/functional-tests/src/test/scala/pages/FacebookLogin.scala
@@ -1,7 +1,7 @@
 package test.pages
 
+import test.util.user.FacebookTestUser
 import test.util.{LoadablePage, Browser}
-import util.user.FacebookTestUser
 
 class FacebookLogin extends LoadablePage with Browser {
   val url = "https://www.facebook.com/login.php"
@@ -12,7 +12,7 @@ class FacebookLogin extends LoadablePage with Browser {
 
   (fbTestUser.email, fbTestUser.password) match {
       case (Some(email), Some(password)) => CredentialsFields.fillIn(email, password)
-      case _ => new IllegalStateException("FacebookTestUser missing password.")
+      case _ => throw new IllegalStateException("FacebookTestUser missing password.")
     }
   }
 

--- a/functional-tests/src/test/scala/pages/FacebookLogin.scala
+++ b/functional-tests/src/test/scala/pages/FacebookLogin.scala
@@ -1,14 +1,20 @@
 package test.pages
 
-import test.util.{Browser, Config}
-import org.scalatest.selenium.Page
+import test.util.{LoadablePage, Browser}
+import util.user.FacebookTestUser
 
-class FacebookLogin extends Page with Browser {
+class FacebookLogin extends LoadablePage with Browser {
   val url = "https://www.facebook.com/login.php"
 
-  def pageHasLoaded(): Boolean = pageHasElement(logInButton)
+  def hasLoaded(): Boolean = pageHasElement(logInButton)
 
-  def fillInCredentials(): Unit = CredentialsFields.fillIn()
+  def fillInCredentials(fbTestUser: FacebookTestUser): Unit = {
+
+  (fbTestUser.email, fbTestUser.password) match {
+      case (Some(email), Some(password)) => CredentialsFields.fillIn(email, password)
+      case _ => new IllegalStateException("FacebookTestUser missing password.")
+    }
+  }
 
   def logIn(): Unit = click.on(logInButton)
 
@@ -16,14 +22,12 @@ class FacebookLogin extends Page with Browser {
     val email = textField(id("email"))
     val password = pwdField(id("pass"))
 
-    def fillIn() = {
-      assert(pageHasElement(logInButton))
-
-      email.value = Config.FacebookCredentials.email
-      password.value = Config.FacebookCredentials.password
+    def fillIn(email: String, password: String) = {
+      this.email.value = email
+      this.password.value = password
     }
   }
 
-  private lazy val logInButton = id("u_0_2")
+  private lazy val logInButton = name("login")
 }
 

--- a/functional-tests/src/test/scala/pages/Homepage.scala
+++ b/functional-tests/src/test/scala/pages/Homepage.scala
@@ -1,12 +1,11 @@
 package test.pages
 
-import test.util.Browser
-import org.scalatest.selenium.Page
+import test.util.{LoadablePage, Browser}
 
-class Homepage extends Page with Browser {
+class Homepage extends LoadablePage with Browser {
   val url = "www.theguardian.com"
 
-  def pageHasLoaded(): Boolean = {
+  def hasLoaded(): Boolean = {
     pageHasElement(signInName)
   }
 

--- a/functional-tests/src/test/scala/pages/Register.scala
+++ b/functional-tests/src/test/scala/pages/Register.scala
@@ -1,9 +1,9 @@
 package test.pages
 
-import test.util.{Browser, TestUser, Config}
-import org.scalatest.selenium.Page
+import test.util.user.EmailTestUser
+import test.util.{LoadablePage, Browser, Config}
 
-class Register(val testUser: TestUser) extends Page with Browser {
+class Register(val testUser: EmailTestUser) extends LoadablePage with Browser {
   val url = s"${Config.baseUrl}/register"
 
   def fillInPersonalDetails(): Unit = RegisterFields.fillIn()
@@ -11,11 +11,16 @@ class Register(val testUser: TestUser) extends Page with Browser {
   def submit(): Unit = {
     val selector = className("submit-input")
     assert(pageHasElement(selector))
-    click.on(selector)
+    click on selector
   }
 
-  def pageHasLoaded(): Boolean = {
+  def hasLoaded(): Boolean = {
     pageHasElement(className("submit-input"))
+  }
+
+  def registerWithFacebook(): Unit = {
+    assert(pageHasElement(registerWithFacebookButton))
+    click.on(registerWithFacebookButton)
   }
 
   private object RegisterFields {
@@ -28,11 +33,14 @@ class Register(val testUser: TestUser) extends Page with Browser {
     def fillIn() = {
       assert(pageHasElement(id("user_password")))
 
-      firstName.value = testUser.username
-      lastName.value = testUser.username
-      email.value = s"${testUser.username}@gu.com"
-      username.value = testUser.username
-      password.value = testUser.username
+      firstName.value = testUser.name
+      lastName.value = testUser.name
+      email.value = s"${testUser.name}@gu.com"
+      username.value = testUser.name
+      password.value = testUser.name
     }
   }
+
+  private lazy val registerWithFacebookButton =
+    cssSelector("a[data-test-id='facebook-sign-in']")
 }

--- a/functional-tests/src/test/scala/pages/RegisterConfirm.scala
+++ b/functional-tests/src/test/scala/pages/RegisterConfirm.scala
@@ -1,9 +1,8 @@
 package test.pages
 
-import test.util.{Browser, Config}
-import org.scalatest.selenium.{Page, WebBrowser}
+import test.util.{LoadablePage, Browser, Config}
 
-class RegisterConfirm extends Page with WebBrowser with Browser {
+class RegisterConfirm extends LoadablePage with Browser {
   val url = s"""${Config.baseUrl}/register/confirm?returnUrl=${Config.baseUrl}/register"""
 
   def confirmRegistration() = {
@@ -11,7 +10,7 @@ class RegisterConfirm extends Page with WebBrowser with Browser {
     click.on(confirmRegistrationButton)
   }
 
-  def pageHasLoaded(): Boolean = {
+  def hasLoaded(): Boolean = {
     pageHasElement(confirmRegistrationButton)
   }
 

--- a/functional-tests/src/test/scala/pages/Signin.scala
+++ b/functional-tests/src/test/scala/pages/Signin.scala
@@ -1,9 +1,10 @@
 package test.pages
 
-import test.util.{Browser, TestUser, Config}
+import test.util.user.EmailTestUser
+import test.util.{Browser, Config}
 import org.scalatest.selenium.Page
 
-class Signin(val testUser: TestUser) extends Page with Browser {
+class Signin(val testUser: EmailTestUser) extends Page with Browser {
   val url = s"${Config.baseUrl}/signin"
 
   def signUp() = {
@@ -17,12 +18,23 @@ class Signin(val testUser: TestUser) extends Page with Browser {
   }
 
   def signInWithFacebook() = {
-    assert(pageHasElement(signInWithFacebookButton))
-    click.on(signInWithFacebookButton)
+
+    if (Config.stage == "CODE") {
+      val selector = cssSelector("a[data-test-id='facebook-sign-in']")
+      pageHasElement(selector)
+      click.on(selector)
+    } else { // PROD
+      assert(pageHasElement(signInWithFacebookButton))
+      click.on(signInWithFacebookButton)
+    }
   }
 
   def pageHasLoaded(): Boolean = {
-    pageHasElement(signUpLink)
+
+    if (Config.stage == "CODE")
+      pageHasElement(cssSelector("a[data-test-id='register-link']"))
+    else // PROD
+      pageHasElement(signUpLink)
   }
 
   def fillInCredentials() = {
@@ -36,8 +48,8 @@ class Signin(val testUser: TestUser) extends Page with Browser {
     def fillIn() = {
       assert(pageHasElement(id("signin_field_password")))
 
-      emailAddress.value = s"${testUser.username}@gu.com"
-      password.value = testUser.username
+      emailAddress.value = s"${testUser.name}@gu.com"
+      password.value = testUser.name
     }
   }
 

--- a/functional-tests/src/test/scala/util/Config.scala
+++ b/functional-tests/src/test/scala/util/Config.scala
@@ -10,8 +10,8 @@ object Config {
   private val conf = ConfigFactory.load()
 
   private val baseUrlsByStage = Map(
-    "PROD" -> "https://profile.theguardian.com"
-  )
+    "PROD" -> "https://profile.theguardian.com")
+
   val stage = conf.getString("stage")
 
   val baseUrl = baseUrlsByStage(stage)
@@ -23,10 +23,9 @@ object Config {
     case Failure(e) => ""
   }
 
-  object FacebookCredentials {
-    val email = conf.getString("facebook.test.email")
-    val password = conf.getString("facebook.test.password")
-    val name = conf.getString("facebook.test.name")
+  object FacebookAppCredentials {
+    val id = conf.getString(s"facebook.app.id")
+    val secret = conf.getString(s"facebook.app.secret")
   }
 
   def debug() = conf.root().render()

--- a/functional-tests/src/test/scala/util/LoadablePage.scala
+++ b/functional-tests/src/test/scala/util/LoadablePage.scala
@@ -1,0 +1,18 @@
+package test.util
+
+import org.scalatest.selenium.Page
+
+trait LoadablePage extends Page {
+
+  /**
+    * Page has loaded if the business critical element is present on the page.
+    *
+    * Do not relay on the 'load' event to determine if the page has loaded.
+    * Instead provide context dependant implementation of determining if the page
+    * has loaded by checking for the presence of a business critical element.
+    *
+    * @return business critical element is present on the page
+    */
+  def hasLoaded(): Boolean
+
+}

--- a/functional-tests/src/test/scala/util/user/EmailTestUser.scala
+++ b/functional-tests/src/test/scala/util/user/EmailTestUser.scala
@@ -1,13 +1,16 @@
-package test.util
+package test.util.user
 
 import com.github.nscala_time.time.Imports._
 import com.gu.identity.testing.usernames.TestUsernames
+import test.util.Config
 
-class TestUser {
+class EmailTestUser extends TestUser{
   private val testUsers = TestUsernames(
     com.gu.identity.testing.usernames.Encoder.withSecret(Config.testUsersSecret),
     recency = 2.days.standardDuration
   )
 
-  val username = testUsers.generate()
+  val name = testUsers.generate()
+  val email = Some(s"${name}@gu.com")
+  val password = Some(name)
 }

--- a/functional-tests/src/test/scala/util/user/FacebookTestUser.scala
+++ b/functional-tests/src/test/scala/util/user/FacebookTestUser.scala
@@ -1,0 +1,126 @@
+package util.user
+
+import java.net.URL
+
+import com.squareup.okhttp.{OkHttpClient, Request, Response}
+import org.slf4j.LoggerFactory
+import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
+import play.api.libs.json._
+import test.util.Config.FacebookAppCredentials
+import test.util.user.TestUser
+
+case class FacebookTestUser(name: String = "John Doe",
+                            installed: String = "false",
+                            password: Option[String] = None,
+                            locale: String = "en_US",
+                            permissions: String = "read_stream",
+                            method: String = "post",
+                            id: Option[String] = None,
+                            email: Option[String] = None,
+                            loginUrl: Option[String] = None,
+                            created: Boolean = false
+                           )
+  extends TestUser
+
+case class FaceBookTestUserException(msg: String) extends Exception(msg)
+
+object FacebookTestUserService {
+
+  def logger = LoggerFactory.getLogger(this.getClass)
+
+  private val graphApiUrl = "https://graph.facebook.com"
+
+  private val client = new OkHttpClient()
+
+  private def GET(url: URL): Response = {
+    val client = new OkHttpClient()
+    val request = new Request.Builder().url(url).build()
+    client.newCall(request).execute()
+  }
+
+  private val accessToken = {
+
+    val authEndpoint = "https://graph.facebook.com/oauth/access_token"
+
+    val queryString = Map(
+      "client_id" -> FacebookAppCredentials.id,
+      "client_secret" -> FacebookAppCredentials.secret,
+      "grant_type" -> "client_credentials"
+    ).map { case (k, v) => s"$k=$v" }.mkString("&")
+
+    val response = GET(new URL(s"${authEndpoint}?${queryString}"))
+
+    response.body().string().split("=")(1)
+  }
+
+  def createUser(facebookTestUser: FacebookTestUser = new FacebookTestUser): FacebookTestUser = {
+
+    val queryString = Map(
+      "installed" -> facebookTestUser.installed,
+      "name" -> facebookTestUser.name,
+      "locale" -> facebookTestUser.locale,
+      "permissions" -> facebookTestUser.permissions,
+      "method" -> facebookTestUser.method,
+      "access_token"-> accessToken
+    ).map { case (k, v) => s"$k=$v" }.mkString("&")
+
+    val response =
+      GET(new URL(s"$graphApiUrl/${FacebookAppCredentials.id}/accounts/test-users?$queryString"))
+
+    if (!response.isSuccessful)
+      throw new FaceBookTestUserException(
+        s"Could not create Facebook Test User. Response = ${response.body().string()}")
+
+    val responseJson: JsValue = Json.parse(response.body().string())
+
+    case class FacebookUserResponse(id: String,
+                                    password: String,
+                                    email: String,
+                                    login_url: String)
+
+    implicit val facebookUserJsonReads: Reads[FacebookUserResponse] = (
+       (JsPath \ "id").read[String] and
+         (JsPath \ "password").read[String] and
+         (JsPath \ "email").read[String] and
+         (JsPath \ "login_url").read[String]
+       )(FacebookUserResponse.apply _)
+
+    val fbUserResponse = responseJson.as[FacebookUserResponse]
+
+    val mergedFacebookTestUser = FacebookTestUser(
+      facebookTestUser.name,
+      facebookTestUser.installed,
+      Some(fbUserResponse.password),
+      facebookTestUser.locale,
+      facebookTestUser.permissions,
+      facebookTestUser.method,
+      Some(fbUserResponse.id),
+      Some(fbUserResponse.email),
+      Some(fbUserResponse.login_url),
+      created = true
+    )
+
+    mergedFacebookTestUser
+  }
+
+  def deleteUser(fbTestUser: FacebookTestUser): Boolean = {
+
+    val queryString = Map(
+      "access_token"-> accessToken,
+      "method" -> "delete"
+    ).map { case (k, v) => s"$k=$v" }.mkString("&")
+
+    val fbTestUserid = fbTestUser.id.getOrElse( throw new IllegalStateException(
+          "FacebookTestUser is missing ID. Cannot delete FacebookTestUser."))
+
+    val response = GET(new URL(s"$graphApiUrl/${fbTestUserid}?$queryString"))
+
+    if (!response.isSuccessful)
+      throw new FaceBookTestUserException(
+        s"Could not delete Facebook Test User with ID ${fbTestUserid}. ${response.body().string()}")
+
+    response.body().string().toBoolean
+  }
+}
+

--- a/functional-tests/src/test/scala/util/user/TestUser.scala
+++ b/functional-tests/src/test/scala/util/user/TestUser.scala
@@ -1,0 +1,7 @@
+package test.util.user
+
+trait TestUser {
+  val name: String
+  val email: Option[String]
+  val password: Option[String]
+}


### PR DESCRIPTION
@jamespamplin @nlindblad 

[Example screencast](https://saucelabs.com/tests/33a8d46ffe0e4d059593017293d2706f)

Added 'Register with Facebook' test which uses [Facebook Test User API](https://developers.facebook.com/docs/apps/test-users) to generate Facebook users, as opposed to using a hard-coded user.

This test corresponds to the old [SN1 test](https://github.com/guardian/identity-functional-tests/blob/master/identity-tests/src/test/scala/com/gu/identity/integration/test/features/SocialNetworkTests.scala#L25)