### PR TITLE
Add 'Existing users sign in with Google' test

### DIFF
--- a/functional-tests/src/test/resources/application.conf
+++ b/functional-tests/src/test/resources/application.conf
@@ -11,9 +11,19 @@ identity.test.users.secret = ${?IDENTITY_TEST_USER_SECRET}
 
 webDriverRemoteUrl = ${?WEBDRIVER_REMOTE_URL}
 
+socialTestUser = {
+  email = ${?SOCIAL_TEST_USER_EMAIL}
+  password = ${?SOCIAL_TEST_USER_PASSWORD}
+  name = ${?SOCIAL_TEST_USER_NAME}
+}
+
 facebook {
   app {
     id = ${?FACEBOOK_APP_ID}
     secret = ${?FACEBOOK_APP_SECRET}
   }
+
+  test.user = ${socialTestUser}
 }
+
+google.test.user = ${socialTestUser}

--- a/functional-tests/src/test/scala/SigninSpec.scala
+++ b/functional-tests/src/test/scala/SigninSpec.scala
@@ -1,8 +1,8 @@
 package test
 
-import test.util.user.{FacebookTestUserService, EmailTestUser}
+import test.util.{Browser, Driver, Config}
+import test.util.user.{GoogleTestUser, FacebookTestUser, FacebookTestUserService, EmailTestUser}
 import test.pages.{FacebookAuthDialog, FacebookLogin, RegisterConfirm}
-import test.util._
 import org.scalatest.selenium.WebBrowser
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfter, FeatureSpec, GivenWhenThen}
 import org.slf4j.LoggerFactory
@@ -22,142 +22,193 @@ class SigninSpec extends FeatureSpec with WebBrowser with Browser
   // After all tests execute, close all windows, and exit the driver
   override def afterAll() = Driver.quit()
 
+  /* Sign in into existing Google Account with */
+  def googleFixture(): Unit = {
+
+    // When they visit 'Google Accounts' page
+    val googleAccounts = new pages.GoogleAccounts
+    go.to(googleAccounts)
+    assert(googleAccounts.hasLoaded())
+
+    // and sign in with their Google credentials
+    googleAccounts.signIn()
+
+    // then they should land on 'Google My Account' page
+    assert(pageHasUrl("https://myaccount.google.com"))
+  }
+
+  def withFacebookTestUserFixture(testFun: FacebookTestUser => Any) {
+
+    val fbTestUser = FacebookTestUserService.createUser() // create fixture
+    assert(fbTestUser.created)
+
+    try {
+      testFun(fbTestUser) // "loan" fixture to the test
+    }
+    finally {
+      val fbTestUserIsDeleted = FacebookTestUserService.deleteUser(fbTestUser) // clean up fixture
+      assert(fbTestUserIsDeleted)
+    }
+  }
+
+  def withEmailTestUserFixture(testFun: EmailTestUser => Any) {
+    val emailTestUser = new EmailTestUser
+    testFun(emailTestUser)
+  }
+
   feature("Sign in") {
     scenario("Users register with Email.") {
-      val testUser = new EmailTestUser
+      withEmailTestUserFixture { emailTestUser =>
 
-      Given("users have not registered with email before,")
+        Given("users have not registered with email before,")
 
-      When("they visit 'Sign in' page,")
-      val signin = new pages.Signin(testUser)
-      go.to(signin)
-      assert(signin.pageHasLoaded())
+        When("they visit 'Sign in' page,")
+        val signin = new pages.Signin(emailTestUser)
+        go.to(signin)
+        assert(signin.pageHasLoaded())
 
-      And("click on 'Sign up' link,")
-      signin.signUp()
+        And("click on 'Sign up' link,")
+        signin.signUp()
 
-      Then("they should land on 'Register' page.")
-      val register = new pages.Register(testUser)
-      assert(register.hasLoaded())
+        Then("they should land on 'Register' page.")
+        val register = new pages.Register(emailTestUser)
+        assert(register.hasLoaded())
 
-      When("Users fill in personal details,")
-      register.fillInPersonalDetails()
+        When("Users fill in personal details,")
+        register.fillInPersonalDetails()
 
-      And("click on 'Create account' button,")
-      register.submit()
+        And("click on 'Create account' button,")
+        register.createAccount()
 
-      Then("they should land on 'Registration Confirmation' page,")
-      val registerConfirm = new RegisterConfirm
-      assert(registerConfirm.hasLoaded())
+        Then("they should land on 'Registration Confirmation' page,")
+        val registerConfirm = new RegisterConfirm
+        assert(registerConfirm.hasLoaded())
 
-      And("they should have Identity cookies.")
-      Seq("GU_U", "SC_GU_U", "SC_GU_LA").foreach { idCookie =>
-        assert(Driver.cookiesSet.map(_.getName).contains(idCookie))
+        And("they should have Identity cookies.")
+        Seq("GU_U", "SC_GU_U", "SC_GU_LA").foreach { idCookie =>
+          assert(Driver.cookiesSet.map(_.getName).contains(idCookie))
+        }
+
+        When("Users click on 'Confirm Registration' button,")
+        registerConfirm.confirmRegistration()
+
+        Then("they should land on 'Guardian Homepage',")
+        val homepage = new pages.Homepage
+        assert(homepage.hasLoaded())
+
+        And("should be signed in.")
+        assert(elementHasText(className("js-profile-info"), emailTestUser.name))
       }
-
-      When("Users click on 'Confirm Registration' button,")
-      registerConfirm.confirmRegistration()
-
-      Then("they should land on 'Guardian Homepage',")
-      val homepage = new pages.Homepage
-      assert(homepage.hasLoaded())
-
-      And("should be signed in.")
-      assert(elementHasText(className("js-profile-info"), testUser.name))
     }
 
     scenario("Users register with Facebook.") {
-      val fbTestUser = FacebookTestUserService.createUser()
-      assert(fbTestUser.created)
+      withFacebookTestUserFixture { fbTestUser =>
 
-      Given("users have not registered with Facebook before,")
+        Given("users have not registered with Facebook before,")
 
-      When("they visit 'Sign in' page")
-      val signin = new pages.Signin(new EmailTestUser)
+        When("they visit 'Sign in' page")
+        val signin = new pages.Signin(new EmailTestUser)
+        go.to(signin)
+        assert(signin.pageHasLoaded())
+
+        And("click on 'Sign in with Facebook' button")
+        signin.signInWithFacebook()
+
+        Then("they should land on 'Facebook Login' page.")
+        val facebookLogin = new FacebookLogin()
+        assert(facebookLogin.hasLoaded())
+
+        When("users fill in Facebook credentials")
+        facebookLogin.fillInCredentials(fbTestUser)
+
+        And("click on 'Log In' button")
+        facebookLogin.logIn()
+
+        Then("Facebook auth dialog should open.")
+        val facebookAuthDialog = new FacebookAuthDialog
+        assert(facebookAuthDialog.hasLoaded())
+
+        When("users clicks on 'Okay' button")
+        facebookAuthDialog.confirm()
+
+        Then("they should land on 'Guardian Homepage'")
+        val homepage = new pages.Homepage
+        assert(homepage.hasLoaded())
+
+        And("should be signed in.")
+        assert(elementHasText(className("js-profile-info"), fbTestUser.name))
+      }
+    }
+
+    scenario("Users attempt to register with Facebook without granting email permissions.") {
+      withFacebookTestUserFixture { fbTestUser =>
+
+        Given("users have not registered with Facebook before,")
+
+        When("they visit 'Sign in' page,")
+        val signin = new pages.Signin(new EmailTestUser)
+        go.to(signin)
+        assert(signin.pageHasLoaded())
+
+        And("click on 'Sign in with Facebook' button")
+        signin.signInWithFacebook()
+
+        Then("they should land on 'Facebook Login' page.")
+        val facebookLogin = new FacebookLogin()
+        assert(facebookLogin.hasLoaded())
+
+        When("users fill in Facebook credentials,")
+        facebookLogin.fillInCredentials(fbTestUser)
+
+        And("click on 'Log In' button,")
+        facebookLogin.logIn()
+
+        Then("'Facebook Auth Dialog' should open.")
+        val facebookAuthDialog = new FacebookAuthDialog
+        assert(facebookAuthDialog.hasLoaded())
+
+        When("users click on 'Edit the info you provide' link,")
+        facebookAuthDialog.editProvidedInfo()
+
+        Then("'Edit Provided Info' dialog should open.")
+        val facebookProvidedInfoDialog = new pages.FacebookProvidedInfoDialog
+        assert(facebookProvidedInfoDialog.hasLoaded())
+
+        When("users un-check granting email permissions to Guardian,")
+        facebookProvidedInfoDialog.uncheckEmailPermission()
+
+        And("click on 'Okay' button,")
+        facebookAuthDialog.confirm()
+
+        Then("they should be rejected back to 'Guardian Register' page,")
+        val register = new pages.Register(new EmailTestUser)
+        assert(register.hasLoaded())
+
+        And("should see Facebook error message.")
+        pageHasUrl("error=fbEmail")
+      }
+    }
+
+    scenario("Existing users sign in with Google.") {
+      googleFixture()
+
+      Given("users have already registered with Guardian via Google " +
+        "and are signed in their Google account,")
+
+      When("they visit 'Sign in' page,")
+      val signin = new pages.Signin
       go.to(signin)
       assert(signin.pageHasLoaded())
 
-      And("click on 'Sign in with Facebook' button")
-      signin.signInWithFacebook()
-
-      Then("they should land on 'Facebook Login' page.")
-      val facebookLogin = new FacebookLogin()
-      assert(facebookLogin.hasLoaded())
-
-      When("users fill in Facebook credentials")
-      facebookLogin.fillInCredentials(fbTestUser)
-
-      And("click on 'Log In' button")
-      facebookLogin.logIn()
-
-      Then("Facebook auth dialog should open.")
-      val facebookAuthDialog = new FacebookAuthDialog
-      assert(facebookAuthDialog.hasLoaded())
-
-      When("users clicks on 'Okay' button")
-      facebookAuthDialog.confirm()
+      And("click on 'Sign in with Google' button,")
+      signin.signInWithGoogle()
 
       Then("they should land on 'Guardian Homepage'")
       val homepage = new pages.Homepage
       assert(homepage.hasLoaded())
 
       And("should be signed in.")
-      assert(elementHasText(className("js-profile-info"), fbTestUser.name))
-
-      val fbTestUserIsDeleted = FacebookTestUserService.deleteUser(fbTestUser)
-      assert(fbTestUserIsDeleted)
-    }
-
-    scenario("Users attempt to register with Facebook without granting email permissions.") {
-      val fbTestUser = FacebookTestUserService.createUser()
-      assert(fbTestUser.created)
-
-      Given("users have not registered with Facebook before,")
-
-      When("they visit 'Sign in' page,")
-      val signin = new pages.Signin(new EmailTestUser)
-      go.to(signin)
-      assert(signin.pageHasLoaded())
-
-      And("click on 'Sign in with Facebook' button")
-      signin.signInWithFacebook()
-
-      Then("they should land on 'Facebook Login' page.")
-      val facebookLogin = new FacebookLogin()
-      assert(facebookLogin.hasLoaded())
-
-      When("users fill in Facebook credentials,")
-      facebookLogin.fillInCredentials(fbTestUser)
-
-      And("click on 'Log In' button,")
-      facebookLogin.logIn()
-
-      Then("'Facebook Auth Dialog' should open.")
-      val facebookAuthDialog = new FacebookAuthDialog
-      assert(facebookAuthDialog.hasLoaded())
-
-      When("users click on 'Edit the info you provide' link,")
-      facebookAuthDialog.editProvidedInfo()
-
-      Then("'Edit Provided Info' dialog should open.")
-      val facebookProvidedInfoDialog = new pages.FacebookProvidedInfoDialog
-      assert(facebookProvidedInfoDialog.hasLoaded())
-
-      When("users un-check granting email permissions to Guardian,")
-      facebookProvidedInfoDialog.uncheckEmailPermission()
-
-      And("click on 'Okay' button,")
-      facebookAuthDialog.confirm()
-
-      Then("they should be rejected back to 'Guardian Register' page,")
-      val register = new pages.Register(new EmailTestUser)
-      assert(register.hasLoaded())
-
-      And("should see Facebook error message.")
-      pageHasUrl("error=fbEmail")
-
-      val fbTestUserIsDeleted = FacebookTestUserService.deleteUser(fbTestUser)
-      assert(fbTestUserIsDeleted)
+      assert(elementHasText(className("js-profile-info"), GoogleTestUser.name))
     }
   }
 }

--- a/functional-tests/src/test/scala/pages/FacebookAuthDialog.scala
+++ b/functional-tests/src/test/scala/pages/FacebookAuthDialog.scala
@@ -7,15 +7,9 @@ class FacebookAuthDialog extends LoadablePage with Browser {
 
   def hasLoaded(): Boolean = pageHasElement(confirmButton)
 
-  def confirm(): Unit = {
-    assert(pageHasElement(confirmButton))
-    click.on(confirmButton)
-  }
+  def confirm(): Unit = clickOn(confirmButton)
 
-  def editProvidedInfo(): Unit = {
-    assert(pageHasElement(editInfoLink))
-    click.on(editInfoLink)
-  }
+  def editProvidedInfo(): Unit = clickOn(editInfoLink)
 
   private lazy val confirmButton = name("__CONFIRM__")
 

--- a/functional-tests/src/test/scala/pages/FacebookLogin.scala
+++ b/functional-tests/src/test/scala/pages/FacebookLogin.scala
@@ -8,13 +8,9 @@ class FacebookLogin extends LoadablePage with Browser {
 
   def hasLoaded(): Boolean = pageHasElement(logInButton)
 
-  def fillInCredentials(fbTestUser: FacebookTestUser): Unit = {
+  def fillInCredentials(fbTestUser: FacebookTestUser): Unit =
+    CredentialsFields.fillIn(fbTestUser.email, fbTestUser.password)
 
-  (fbTestUser.email, fbTestUser.password) match {
-      case (Some(email), Some(password)) => CredentialsFields.fillIn(email, password)
-      case _ => throw new IllegalStateException("FacebookTestUser missing password.")
-    }
-  }
 
   def logIn(): Unit = click.on(logInButton)
 

--- a/functional-tests/src/test/scala/pages/GoogleAccounts.scala
+++ b/functional-tests/src/test/scala/pages/GoogleAccounts.scala
@@ -1,0 +1,22 @@
+package test.pages
+
+import test.util.{Browser, LoadablePage}
+import test.util.user.GoogleTestUser
+
+class GoogleAccounts extends LoadablePage with Browser {
+  val url = "https://accounts.google.com/ServiceLogin"
+
+  def hasLoaded(): Boolean = pageHasElement(id("Email"))
+
+  def signIn(): Unit = {
+    setValue(emailInput, GoogleTestUser.email)
+    clickOn(nextButton)
+    setValue(passwordInput, GoogleTestUser.password)
+    clickOn(signinButton)
+  }
+
+  private lazy val emailInput = id("Email")
+  private lazy val nextButton = id("next")
+  private lazy val passwordInput = id("Passwd")
+  private lazy val signinButton = id("signIn")
+}

--- a/functional-tests/src/test/scala/pages/Register.scala
+++ b/functional-tests/src/test/scala/pages/Register.scala
@@ -6,39 +6,27 @@ import test.util.{LoadablePage, Browser, Config}
 class Register(val testUser: EmailTestUser) extends LoadablePage with Browser {
   val url = s"${Config.baseUrl}/register"
 
+  def hasLoaded(): Boolean = pageHasElement(createAccountButton)
+
   def fillInPersonalDetails(): Unit = RegisterFields.fillIn()
 
-  def submit(): Unit = {
-    val selector = className("submit-input")
-    assert(pageHasElement(selector))
-    click on selector
-  }
-
-  def hasLoaded(): Boolean = pageHasElement(className("submit-input"))
-
-  def registerWithFacebook(): Unit = {
-    assert(pageHasElement(registerWithFacebookButton))
-    click.on(registerWithFacebookButton)
-  }
+  def createAccount(): Unit = clickOn(createAccountButton)
 
   private object RegisterFields {
-    val firstName = textField(id("user_firstName"))
-    val lastName = textField(id("user_secondName"))
-    val email = emailField(id("user_primaryEmailAddress"))
-    val username = textField(id("user_publicFields_username"))
-    val password = pwdField(id("user_password"))
+    val firstName = id("user_firstName")
+    val lastName = id("user_secondName")
+    val email = id("user_primaryEmailAddress")
+    val username = id("user_publicFields_username")
+    val password = id("user_password")
 
     def fillIn() = {
-      assert(pageHasElement(id("user_password")))
-
-      firstName.value = testUser.name
-      lastName.value = testUser.name
-      email.value = s"${testUser.name}@gu.com"
-      username.value = testUser.name
-      password.value = testUser.name
+      setValue(firstName, testUser.name)
+      setValue(lastName, testUser.name)
+      setValue(email, s"${testUser.name}@gu.com")
+      setValue(username, testUser.name)
+      setValue(password, testUser.name)
     }
   }
 
-  private lazy val registerWithFacebookButton =
-    cssSelector("a[data-test-id='facebook-sign-in']")
+  private lazy val createAccountButton = className("submit-input")
 }

--- a/functional-tests/src/test/scala/pages/RegisterConfirm.scala
+++ b/functional-tests/src/test/scala/pages/RegisterConfirm.scala
@@ -5,14 +5,9 @@ import test.util.{LoadablePage, Browser, Config}
 class RegisterConfirm extends LoadablePage with Browser {
   val url = s"""${Config.baseUrl}/register/confirm?returnUrl=${Config.baseUrl}/register"""
 
-  def confirmRegistration() = {
-    assert(pageHasElement(confirmRegistrationButton))
-    click.on(confirmRegistrationButton)
-  }
+  def hasLoaded(): Boolean = pageHasElement(confirmRegistrationButton)
 
-  def hasLoaded(): Boolean = {
-    pageHasElement(confirmRegistrationButton)
-  }
+  def confirmRegistration() = clickOn(confirmRegistrationButton)
 
   private lazy val confirmRegistrationButton = className(s"submit-input")
 }

--- a/functional-tests/src/test/scala/pages/Signin.scala
+++ b/functional-tests/src/test/scala/pages/Signin.scala
@@ -4,44 +4,33 @@ import test.util.user.EmailTestUser
 import test.util.{Browser, Config}
 import org.scalatest.selenium.Page
 
-class Signin(val testUser: EmailTestUser) extends Page with Browser {
+class Signin(val testUser: EmailTestUser = new EmailTestUser) extends Page with Browser {
   val url = s"${Config.baseUrl}/signin"
 
-  def signUp() = {
-    assert(pageHasElement(signUpLink))
-    click.on(signUpLink)
-  }
+  def signUp() = clickOn(signUpLink)
 
-  def signIn() = {
-    assert(pageHasElement(signInButton))
-    click.on(signInButton)
-  }
+  def signIn() = clickOn(signInButton)
 
-  def signInWithFacebook() = {
-    assert(pageHasElement(signInWithFacebookButton))
-    click.on(signInWithFacebookButton)
-  }
+  def signInWithFacebook() = clickOn(signInWithFacebookButton)
+
+  def signInWithGoogle() = clickOn(signInWithGoogleButton)
 
   def pageHasLoaded(): Boolean = pageHasElement(signUpLink)
 
-  def fillInCredentials() = {
-    SigninFields.fillIn()
-  }
+  def fillInCredentials() = SigninFields.fillIn()
 
   private object SigninFields {
-    val emailAddress = emailField(id("signin_field_email"))
-    val password = pwdField(id("signin_field_password"))
+    val emailAddress = id("signin_field_email")
+    val password = id("signin_field_password")
 
     def fillIn() = {
-      assert(pageHasElement(id("signin_field_password")))
-      emailAddress.value = s"${testUser.name}@gu.com"
-      password.value = testUser.name
+      setValue(emailAddress, s"${testUser.name}@gu.com")
+      setValue(password, testUser.name)
     }
   }
 
   private lazy val signUpLink = id("register_cta")
-
   private lazy val signInButton = id("signin_submit")
-
   private lazy val signInWithFacebookButton = id("social_signin_cta_facebook")
+  private lazy val signInWithGoogleButton = id("social_signin_cta_google")
 }

--- a/functional-tests/src/test/scala/util/Browser.scala
+++ b/functional-tests/src/test/scala/util/Browser.scala
@@ -11,6 +11,9 @@ trait Browser extends WebBrowser {
 
   private val timeOutSec = 30
 
+  case class MissingPageElementException(q: Query)
+    extends Exception(s"Could not find WebElement with locator: ${q.queryString}")
+
   def pageHasText(text: String): Boolean = {
     waitUntil(ExpectedConditions.textToBePresentInElementLocated(By.tagName("body"), text))
   }
@@ -29,5 +32,19 @@ trait Browser extends WebBrowser {
 
   def waitUntil[T](pred: ExpectedCondition[T]) = {
     Try(new WebDriverWait(driver, timeOutSec).until(pred)).isSuccess
+  }
+
+  def clickOn(q: Query): Unit = {
+    if (pageHasElement(q))
+      click.on(q)
+    else
+      throw new MissingPageElementException(q)
+  }
+
+  def setValue(q: Query, value: String): Unit = {
+    if (pageHasElement(q))
+      q.webElement.sendKeys(value)
+    else
+      throw new MissingPageElementException(q)
   }
 }

--- a/functional-tests/src/test/scala/util/Config.scala
+++ b/functional-tests/src/test/scala/util/Config.scala
@@ -24,8 +24,14 @@ object Config {
   }
 
   object FacebookAppCredentials {
-    val id = conf.getString(s"facebook.app.id")
-    val secret = conf.getString(s"facebook.app.secret")
+    val id = conf.getString("facebook.app.id")
+    val secret = conf.getString("facebook.app.secret")
+  }
+
+  object GoogleTestUserCredentials {
+    val email = conf.getString("google.test.user.email")
+    val password = conf.getString("google.test.user.password")
+    val name = conf.getString("google.test.user.name")
   }
 
   def debug() = conf.root().render()

--- a/functional-tests/src/test/scala/util/user/EmailTestUser.scala
+++ b/functional-tests/src/test/scala/util/user/EmailTestUser.scala
@@ -11,6 +11,6 @@ class EmailTestUser extends TestUser{
   )
 
   val name = testUsers.generate()
-  val email = Some(s"${name}@gu.com")
-  val password = Some(name)
+  val email = s"${name}@gu.com"
+  val password = name
 }

--- a/functional-tests/src/test/scala/util/user/GoogleTestUser.scala
+++ b/functional-tests/src/test/scala/util/user/GoogleTestUser.scala
@@ -1,0 +1,9 @@
+package test.util.user
+
+import test.util.Config
+
+object GoogleTestUser extends TestUser {
+  val name = Config.GoogleTestUserCredentials.name
+  val email = Config.GoogleTestUserCredentials.email
+  val password = Config.GoogleTestUserCredentials.password
+}

--- a/functional-tests/src/test/scala/util/user/TestUser.scala
+++ b/functional-tests/src/test/scala/util/user/TestUser.scala
@@ -2,6 +2,6 @@ package test.util.user
 
 trait TestUser {
   val name: String
-  val email: Option[String]
-  val password: Option[String]
+  val email: String
+  val password: String
 }


### PR DESCRIPTION
@jamespamplin 

[Example screencast](https://saucelabs.com/beta/tests/2e229beff72f4a26984967868ef3ca6b/commands)

Added test scenario:

  `Existing users sign in with Google.`

Since Google does not provide a similar Test User API to [Facebook](https://developers.facebook.com/docs/graph-api/reference/v2.5/test-user) we are using a hardcoded Google user "Bob Test". Thus we can test just the sign in functionality, and not the full registration via Google.

The relevant lines of code are [SigninSpec.scala#192-211](https://github.com/guardian/identity-frontend/compare/fun-tests-google-signin?expand=1#diff-8fa20870fda6f35709c81a4110121941R192). The rest is some refactoring of utilities and factoring out [test fixtures](http://www.scalatest.org/user_guide/sharing_fixtures).