### PR TITLE
Long life caching of Assets

### DIFF
--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -119,7 +119,7 @@ object Favicons {
 
   private val iconBaseDir = "components/favicons"
 
-  private val iconUrls = iconFiles.map(f => f -> routes.Assets.at(s"$iconBaseDir/$f").url)
+  private val iconUrls = iconFiles.map(f => f -> routes.Assets.versioned(s"$iconBaseDir/$f").url)
 
   def apply(): Seq[Favicon] = iconUrls.map {
     case (file, url) if file.endsWith(".png") => Favicon(file, "apple-touch-icon", url)

--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -2,7 +2,6 @@ package com.gu.identity.frontend.views.models
 
 import com.gu.identity.frontend.configuration.{MultiVariantTestVariant, MultiVariantTests, MultiVariantTest, Configuration}
 import com.gu.identity.frontend.models.Text.{FooterText, HeaderText, LayoutText}
-import controllers.routes
 import play.api.i18n.Messages
 import play.api.libs.json.Json
 
@@ -107,6 +106,8 @@ case class Favicon(filename: String, rel: String, url: String, sizes: Option[Str
 
 object Favicons {
 
+  import LocalResource.resolveAssetUrl
+
   private val iconFiles = Seq(
     "32x32.ico",
     "57x57.png",
@@ -119,7 +120,7 @@ object Favicons {
 
   private val iconBaseDir = "components/favicons"
 
-  private val iconUrls = iconFiles.map(f => f -> routes.Assets.versioned(s"$iconBaseDir/$f").url)
+  private val iconUrls = iconFiles.map(f => f -> resolveAssetUrl(s"$iconBaseDir/$f"))
 
   def apply(): Seq[Favicon] = iconUrls.map {
     case (file, url) if file.endsWith(".png") => Favicon(file, "apple-touch-icon", url)

--- a/app/com/gu/identity/frontend/views/models/PageResources.scala
+++ b/app/com/gu/identity/frontend/views/models/PageResources.scala
@@ -27,7 +27,7 @@ sealed trait LocalResource
 
 object LocalResource {
   def resolveAssetUrl(path: String) =
-    routes.Assets.at(path).url
+    routes.Assets.versioned(path).url
 }
 
 sealed trait LinkedResource {

--- a/conf/routes
+++ b/conf/routes
@@ -19,4 +19,4 @@ GET        /management/healthcheck        com.gu.identity.frontend.controllers.H
 
 GET        /management/manifest           com.gu.identity.frontend.controllers.Manifest.manifest
 
-GET        /static/*file                  controllers.Assets.at(path="/public", file)
+GET        /static/*file                  controllers.Assets.versioned(path="/public", file: Asset)

--- a/frontend.sbt
+++ b/frontend.sbt
@@ -8,6 +8,8 @@ buildCommands in build in Assets := Seq(
   BuildCommand("build-js", "npm run build-js -s", includeFilter = Some("*.js"))
 )
 
+pipelineStages := Seq(digest)
+
 // Ensure frontend build task is a source generator task
 sourceGenerators in Assets <+= build in Assets
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,5 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.5.0")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.0")


### PR DESCRIPTION
Use [`sbt-digest`](https://github.com/sbt/sbt-digest) to create hashes of assets on package compilation, which Play can use at runtime to cache the asset for a looonnnggg time.

Note: only works when app is running in production mode.