### PR TITLE
CSRF validation

### DIFF
--- a/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
+++ b/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
@@ -6,6 +6,7 @@ import com.gu.identity.frontend.services.{IdentityServiceRequestHandler, Identit
 import com.gu.identity.service.client.IdentityClient
 import jp.co.bizreach.play2handlebars.HandlebarsPlugin
 import play.api.i18n.I18nComponents
+import play.filters.csrf.CSRFComponents
 import play.filters.gzip.GzipFilter
 import router.Routes
 import play.api.libs.ws.ning.NingWSComponents
@@ -21,18 +22,18 @@ class FrontendApplicationLoader extends ApplicationLoader {
   }
 }
 
-class ApplicationComponents(context: Context) extends BuiltInComponentsFromContext(context) with NingWSComponents with I18nComponents {
+class ApplicationComponents(context: Context) extends BuiltInComponentsFromContext(context) with NingWSComponents with I18nComponents with CSRFComponents {
   lazy val frontendConfiguration = new ApplicationConfiguration(configuration)
 
   lazy val identityServiceRequestHandler = new IdentityServiceRequestHandler(wsClient)
   lazy val identityClient: IdentityClient = new IdentityClient
   lazy val identityService: IdentityService = new IdentityServiceImpl(frontendConfiguration, identityServiceRequestHandler, identityClient)
 
-  lazy val applicationController = new Application(frontendConfiguration, messagesApi)
+  lazy val applicationController = new Application(frontendConfiguration, messagesApi, csrfConfig)
   lazy val healthcheckController = new HealthCheck()
   lazy val manifestController = new Manifest()
   lazy val signinController = new SigninAction(identityService, messagesApi)
-  lazy val registerController = new RegisterAction(identityService, messagesApi, frontendConfiguration)
+  lazy val registerController = new RegisterAction(identityService, messagesApi, frontendConfiguration, csrfConfig)
   lazy val assets = new controllers.Assets(httpErrorHandler)
 
   override lazy val httpFilters = new Filters(new SecurityHeadersFilter(

--- a/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
+++ b/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
@@ -32,7 +32,7 @@ class ApplicationComponents(context: Context) extends BuiltInComponentsFromConte
   lazy val applicationController = new Application(frontendConfiguration, messagesApi, csrfConfig)
   lazy val healthcheckController = new HealthCheck()
   lazy val manifestController = new Manifest()
-  lazy val signinController = new SigninAction(identityService, messagesApi)
+  lazy val signinController = new SigninAction(identityService, messagesApi, csrfConfig)
   lazy val registerController = new RegisterAction(identityService, messagesApi, frontendConfiguration, csrfConfig)
   lazy val assets = new controllers.Assets(httpErrorHandler)
 

--- a/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
+++ b/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
@@ -1,12 +1,12 @@
 package com.gu.identity.frontend.configuration
 
 import com.gu.identity.frontend.controllers.{Manifest, RegisterAction, SigninAction, HealthCheck, Application}
+import com.gu.identity.frontend.csrf.CSRFConfig
 import com.gu.identity.frontend.filters.{BetaUserGroupFilter, SecurityHeadersFilter, Filters}
 import com.gu.identity.frontend.services.{IdentityServiceRequestHandler, IdentityServiceImpl, IdentityService}
 import com.gu.identity.service.client.IdentityClient
 import jp.co.bizreach.play2handlebars.HandlebarsPlugin
 import play.api.i18n.I18nComponents
-import play.filters.csrf.CSRFComponents
 import play.filters.gzip.GzipFilter
 import router.Routes
 import play.api.libs.ws.ning.NingWSComponents
@@ -22,8 +22,9 @@ class FrontendApplicationLoader extends ApplicationLoader {
   }
 }
 
-class ApplicationComponents(context: Context) extends BuiltInComponentsFromContext(context) with NingWSComponents with I18nComponents with CSRFComponents {
+class ApplicationComponents(context: Context) extends BuiltInComponentsFromContext(context) with NingWSComponents with I18nComponents {
   lazy val frontendConfiguration = new ApplicationConfiguration(configuration)
+  lazy val csrfConfig = CSRFConfig(configuration)
 
   lazy val identityServiceRequestHandler = new IdentityServiceRequestHandler(wsClient)
   lazy val identityClient: IdentityClient = new IdentityClient

--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -16,10 +16,12 @@ class Application (configuration: Configuration, val messagesApi: MessagesApi, c
     Redirect(routes.Application.signIn())
   }
 
-  def signIn(error: Seq[String], returnUrl: Option[String], skipConfirmation: Option[Boolean]) = MultiVariantTestAction { req =>
+  def signIn(error: Seq[String], returnUrl: Option[String], skipConfirmation: Option[Boolean]) = (CSRFAddToken(csrfConfig) andThen MultiVariantTestAction) { req =>
     val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"))
 
-    renderSignIn(configuration, req.activeTests, error, returnUrlActual, skipConfirmation)
+    val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
+
+    renderSignIn(configuration, req.activeTests, csrfToken, error, returnUrlActual, skipConfirmation)
   }
 
   def register(error: Seq[String], returnUrl: Option[String], skipConfirmation: Option[Boolean], group: Option[String]) = (CSRFAddToken(csrfConfig) andThen MultiVariantTestAction) { req =>

--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -1,14 +1,16 @@
 package com.gu.identity.frontend.controllers
 
 import com.gu.identity.frontend.configuration.Configuration
+import com.gu.identity.frontend.csrf.{CSRFToken, CSRFAddToken}
 import com.gu.identity.frontend.logging.Logging
 import com.gu.identity.frontend.models.ReturnUrl
 import com.gu.identity.frontend.views.ViewRenderer.{renderSignIn, renderRegisterConfirmation, renderRegister}
 import play.api.i18n.{MessagesApi, I18nSupport}
 import play.api.mvc._
+import play.filters.csrf.CSRFConfig
 
 
-class Application (configuration: Configuration, val messagesApi: MessagesApi) extends Controller with Logging with I18nSupport {
+class Application (configuration: Configuration, val messagesApi: MessagesApi, csrfConfig: CSRFConfig) extends Controller with Logging with I18nSupport {
 
   def index = Action {
     Redirect(routes.Application.signIn())
@@ -20,10 +22,12 @@ class Application (configuration: Configuration, val messagesApi: MessagesApi) e
     renderSignIn(configuration, req.activeTests, error, returnUrlActual, skipConfirmation)
   }
 
-  def register(error: Seq[String], returnUrl: Option[String], skipConfirmation: Option[Boolean], group: Option[String]) = MultiVariantTestAction { req =>
+  def register(error: Seq[String], returnUrl: Option[String], skipConfirmation: Option[Boolean], group: Option[String]) = (CSRFAddToken(csrfConfig) andThen MultiVariantTestAction) { req =>
     val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"))
 
-    renderRegister(configuration, req.activeTests, error, returnUrlActual, skipConfirmation)
+    val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
+
+    renderRegister(configuration, req.activeTests, error, csrfToken, returnUrlActual, skipConfirmation)
   }
 
   def confirm(returnUrl: Option[String]) = Action {

--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -1,13 +1,12 @@
 package com.gu.identity.frontend.controllers
 
 import com.gu.identity.frontend.configuration.Configuration
-import com.gu.identity.frontend.csrf.{CSRFToken, CSRFAddToken}
+import com.gu.identity.frontend.csrf.{CSRFConfig, CSRFToken, CSRFAddToken}
 import com.gu.identity.frontend.logging.Logging
 import com.gu.identity.frontend.models.ReturnUrl
 import com.gu.identity.frontend.views.ViewRenderer.{renderSignIn, renderRegisterConfirmation, renderRegister}
 import play.api.i18n.{MessagesApi, I18nSupport}
 import play.api.mvc._
-import play.filters.csrf.CSRFConfig
 
 
 class Application (configuration: Configuration, val messagesApi: MessagesApi, csrfConfig: CSRFConfig) extends Controller with Logging with I18nSupport {

--- a/app/com/gu/identity/frontend/controllers/RegisterAction.scala
+++ b/app/com/gu/identity/frontend/controllers/RegisterAction.scala
@@ -2,7 +2,7 @@ package com.gu.identity.frontend.controllers
 
 
 import com.gu.identity.frontend.configuration.Configuration
-import com.gu.identity.frontend.csrf.CSRFCheck
+import com.gu.identity.frontend.csrf.{CSRFConfig, CSRFCheck}
 import com.gu.identity.frontend.logging.Logging
 import com.gu.identity.frontend.models.{UrlBuilder, ClientRegistrationIp, TrackingData, ReturnUrl}
 import com.gu.identity.frontend.services.{ServiceGatewayError, ServiceError, IdentityService}
@@ -11,7 +11,6 @@ import play.api.data.Forms._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Controller, Cookie => PlayCookie}
-import play.filters.csrf.CSRFConfig
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal

--- a/app/com/gu/identity/frontend/controllers/SigninAction.scala
+++ b/app/com/gu/identity/frontend/controllers/SigninAction.scala
@@ -1,6 +1,6 @@
 package com.gu.identity.frontend.controllers
 
-import com.gu.identity.frontend.csrf.CSRFCheck
+import com.gu.identity.frontend.csrf.{CSRFConfig, CSRFCheck}
 import com.gu.identity.frontend.logging.Logging
 import com.gu.identity.frontend.models.{ReturnUrl, TrackingData}
 import com.gu.identity.frontend.services.{IdentityService, ServiceError, ServiceGatewayError}
@@ -9,7 +9,6 @@ import play.api.data.Forms.{boolean, default, mapping, optional, text}
 import play.api.i18n.{MessagesApi, I18nSupport}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc.{Action, Controller}
-import play.filters.csrf.CSRFConfig
 
 import scala.util.control.NonFatal
 import play.api.i18n.Messages.Implicits._

--- a/app/com/gu/identity/frontend/controllers/SigninAction.scala
+++ b/app/com/gu/identity/frontend/controllers/SigninAction.scala
@@ -1,5 +1,6 @@
 package com.gu.identity.frontend.controllers
 
+import com.gu.identity.frontend.csrf.CSRFCheck
 import com.gu.identity.frontend.logging.Logging
 import com.gu.identity.frontend.models.{ReturnUrl, TrackingData}
 import com.gu.identity.frontend.services.{IdentityService, ServiceError, ServiceGatewayError}
@@ -8,6 +9,7 @@ import play.api.data.Forms.{boolean, default, mapping, optional, text}
 import play.api.i18n.{MessagesApi, I18nSupport}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc.{Action, Controller}
+import play.filters.csrf.CSRFConfig
 
 import scala.util.control.NonFatal
 import play.api.i18n.Messages.Implicits._
@@ -16,7 +18,7 @@ import play.api.i18n.Messages.Implicits._
 /**
  * Form actions controller
  */
-class SigninAction(identityService: IdentityService, val messagesApi: MessagesApi) extends Controller with Logging with I18nSupport {
+class SigninAction(identityService: IdentityService, val messagesApi: MessagesApi, csrfConfig: CSRFConfig) extends Controller with Logging with I18nSupport {
 
   case class SignInRequest(email: Option[String], password: Option[String], rememberMe: Boolean, returnUrl: Option[String], skipConfirmation: Option[Boolean])
 
@@ -30,24 +32,22 @@ class SigninAction(identityService: IdentityService, val messagesApi: MessagesAp
     )(SignInRequest.apply)(SignInRequest.unapply)
   )
 
-  def signIn = Action.async { implicit request =>
-    NoCache {
-      val formParams = signInFormBody.bindFromRequest()(request).get
-      val trackingData = TrackingData(request, formParams.returnUrl)
-      val returnUrl = ReturnUrl(formParams.returnUrl, request.headers.get("Referer"))
+  def signIn = CSRFCheck(csrfConfig).async { implicit request =>
+    val formParams = signInFormBody.bindFromRequest()(request).get
+    val trackingData = TrackingData(request, formParams.returnUrl)
+    val returnUrl = ReturnUrl(formParams.returnUrl, request.headers.get("Referer"))
 
-      identityService.authenticate(formParams.email, formParams.password, formParams.rememberMe, trackingData).map {
-        case Left(errors) => redirectToSigninPageWithErrorsAndEmail(errors, returnUrl, formParams.skipConfirmation)
-        case Right(cookies) => {
-          SeeOther(returnUrl.url)
-            .withCookies(cookies: _*)
-        }
+    identityService.authenticate(formParams.email, formParams.password, formParams.rememberMe, trackingData).map {
+      case Left(errors) => redirectToSigninPageWithErrorsAndEmail(errors, returnUrl, formParams.skipConfirmation)
+      case Right(cookies) => {
+        SeeOther(returnUrl.url)
+          .withCookies(cookies: _*)
+      }
 
-      }.recover {
-        case NonFatal(ex) => {
-          logger.warn(s"Unexpected error signing in: ${ex.getMessage}", ex)
-          redirectToSigninPageWithErrorsAndEmail(Seq(ServiceGatewayError(ex.getMessage)), returnUrl, formParams.skipConfirmation)
-        }
+    }.recover {
+      case NonFatal(ex) => {
+        logger.warn(s"Unexpected error signing in: ${ex.getMessage}", ex)
+        redirectToSigninPageWithErrorsAndEmail(Seq(ServiceGatewayError(ex.getMessage)), returnUrl, formParams.skipConfirmation)
       }
     }
   }

--- a/app/com/gu/identity/frontend/csrf/CSRFActions.scala
+++ b/app/com/gu/identity/frontend/csrf/CSRFActions.scala
@@ -3,7 +3,7 @@ package com.gu.identity.frontend.csrf
 import com.gu.identity.frontend.controllers.NoCache
 import play.api.mvc._
 import play.filters.csrf.CSRF.ErrorHandler
-import play.filters.csrf.{CSRFAddToken => PlayCSRFAddToken, CSRFCheck => PlayCSRFCheck, CSRF, CSRFConfig}
+import play.filters.csrf.{CSRFAddToken => PlayCSRFAddToken, CSRFCheck => PlayCSRFCheck, CSRF}
 
 import scala.concurrent.Future
 
@@ -15,7 +15,11 @@ case class CSRFAddToken(config: CSRFConfig) extends ActionBuilder[Request] with 
     NoCache(block(request))
 
   override def composeAction[A](action: Action[A]) =
-    PlayCSRFAddToken(action, config)
+    if (config.enabled)
+      PlayCSRFAddToken(action, config.underlying)
+
+    else
+      action
 
 }
 
@@ -24,5 +28,9 @@ case class CSRFCheck(config: CSRFConfig, errorHandler: ErrorHandler = CSRF.Defau
     NoCache(block(request))
 
   override def composeAction[A](action: Action[A]) =
-    PlayCSRFCheck(action, errorHandler, config)
+    if (config.enabled)
+      PlayCSRFCheck(action, errorHandler, config.underlying)
+
+    else
+      action
 }

--- a/app/com/gu/identity/frontend/csrf/CSRFActions.scala
+++ b/app/com/gu/identity/frontend/csrf/CSRFActions.scala
@@ -3,7 +3,7 @@ package com.gu.identity.frontend.csrf
 import com.gu.identity.frontend.controllers.NoCache
 import play.api.mvc._
 import play.filters.csrf.CSRF.ErrorHandler
-import play.filters.csrf.{CSRFAddToken => PlayCSRFAddToken, CSRFCheck => PlayCSRFCheck, CSRF}
+import play.filters.csrf.{CSRFAddToken => PlayCSRFAddToken, CSRFCheck => PlayCSRFCheck}
 
 import scala.concurrent.Future
 

--- a/app/com/gu/identity/frontend/csrf/CSRFActions.scala
+++ b/app/com/gu/identity/frontend/csrf/CSRFActions.scala
@@ -1,0 +1,27 @@
+package com.gu.identity.frontend.csrf
+
+import play.api.mvc._
+import play.filters.csrf.CSRF.ErrorHandler
+import play.filters.csrf.{CSRFAddToken => PlayCSRFAddToken, CSRFCheck => PlayCSRFCheck, CSRF, CSRFConfig}
+
+import scala.concurrent.Future
+
+
+sealed trait CSRFActions
+
+case class CSRFAddToken(config: CSRFConfig) extends ActionBuilder[Request] with CSRFActions {
+  def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] =
+    block(request)
+
+  override def composeAction[A](action: Action[A]) =
+    PlayCSRFAddToken(action, config)
+
+}
+
+case class CSRFCheck(config: CSRFConfig, errorHandler: ErrorHandler = CSRF.DefaultErrorHandler) extends ActionBuilder[Request] with CSRFActions {
+  def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] =
+    block(request)
+
+  override def composeAction[A](action: Action[A]) =
+    PlayCSRFCheck(action, errorHandler, config)
+}

--- a/app/com/gu/identity/frontend/csrf/CSRFActions.scala
+++ b/app/com/gu/identity/frontend/csrf/CSRFActions.scala
@@ -23,14 +23,18 @@ case class CSRFAddToken(config: CSRFConfig) extends ActionBuilder[Request] with 
 
 }
 
-case class CSRFCheck(config: CSRFConfig, errorHandler: ErrorHandler = CSRF.DefaultErrorHandler) extends ActionBuilder[Request] with CSRFActions {
+case class CSRFCheck(config: CSRFConfig, errorHandler: CSRFErrorHandler = defaultErrorHandler) extends ActionBuilder[Request] with CSRFActions {
   def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] =
     NoCache(block(request))
 
   override def composeAction[A](action: Action[A]) =
     if (config.enabled)
-      PlayCSRFCheck(action, errorHandler, config.underlying)
+      PlayCSRFCheck(action, playErrorHandler, config.underlying)
 
     else
       action
+
+  lazy val playErrorHandler = new ErrorHandler {
+    def handle(req: RequestHeader, msg: String): Future[Result] = errorHandler(req, msg)
+  }
 }

--- a/app/com/gu/identity/frontend/csrf/CSRFActions.scala
+++ b/app/com/gu/identity/frontend/csrf/CSRFActions.scala
@@ -1,5 +1,6 @@
 package com.gu.identity.frontend.csrf
 
+import com.gu.identity.frontend.controllers.NoCache
 import play.api.mvc._
 import play.filters.csrf.CSRF.ErrorHandler
 import play.filters.csrf.{CSRFAddToken => PlayCSRFAddToken, CSRFCheck => PlayCSRFCheck, CSRF, CSRFConfig}
@@ -11,7 +12,7 @@ sealed trait CSRFActions
 
 case class CSRFAddToken(config: CSRFConfig) extends ActionBuilder[Request] with CSRFActions {
   def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] =
-    block(request)
+    NoCache(block(request))
 
   override def composeAction[A](action: Action[A]) =
     PlayCSRFAddToken(action, config)
@@ -20,7 +21,7 @@ case class CSRFAddToken(config: CSRFConfig) extends ActionBuilder[Request] with 
 
 case class CSRFCheck(config: CSRFConfig, errorHandler: ErrorHandler = CSRF.DefaultErrorHandler) extends ActionBuilder[Request] with CSRFActions {
   def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] =
-    block(request)
+    NoCache(block(request))
 
   override def composeAction[A](action: Action[A]) =
     PlayCSRFCheck(action, errorHandler, config)

--- a/app/com/gu/identity/frontend/csrf/CSRFConfig.scala
+++ b/app/com/gu/identity/frontend/csrf/CSRFConfig.scala
@@ -1,0 +1,31 @@
+package com.gu.identity.frontend.csrf
+
+import play.api.Configuration
+import play.filters.csrf.{CSRFConfig => PlayCSRFConfig}
+
+
+case class CSRFConfig private(
+    underlying: PlayCSRFConfig,
+    enabled: Boolean = true) {
+  val tokenName = underlying.tokenName
+}
+
+object CSRFConfig {
+  /** Default config */
+  def apply(): CSRFConfig =
+    apply(enabled = true)
+
+  def apply(enabled: Boolean): CSRFConfig =
+    CSRFConfig(PlayCSRFConfig(), enabled)
+
+  /** Config from Play configuration */
+  def apply(configuration: Configuration): CSRFConfig =
+    apply(configuration, enabled = true)
+
+  def apply(configuration: Configuration, enabled: Boolean): CSRFConfig =
+    CSRFConfig(PlayCSRFConfig.fromConfiguration(configuration))
+
+  /** Disabled config for tests */
+  lazy val disabled =
+    apply(enabled = false)
+}

--- a/app/com/gu/identity/frontend/csrf/CSRFConfig.scala
+++ b/app/com/gu/identity/frontend/csrf/CSRFConfig.scala
@@ -4,7 +4,7 @@ import play.api.Configuration
 import play.filters.csrf.{CSRFConfig => PlayCSRFConfig}
 
 
-case class CSRFConfig private(
+case class CSRFConfig private[csrf](
     underlying: PlayCSRFConfig,
     enabled: Boolean = true) {
   val tokenName = underlying.tokenName

--- a/app/com/gu/identity/frontend/csrf/CSRFToken.scala
+++ b/app/com/gu/identity/frontend/csrf/CSRFToken.scala
@@ -1,0 +1,16 @@
+package com.gu.identity.frontend.csrf
+
+import play.api.mvc.RequestHeader
+import play.filters.csrf.{CSRF, CSRFConfig}
+
+case class CSRFToken(fieldName: String, value: String)
+
+object CSRFToken {
+  def apply(config: CSRFConfig, token: CSRF.Token): CSRFToken =
+    CSRFToken(config.tokenName, token.value)
+
+  def fromRequest(config: CSRFConfig, request: RequestHeader): Option[CSRFToken] =
+    CSRF.getToken(request, config)
+      .map(CSRFToken(config, _))
+
+}

--- a/app/com/gu/identity/frontend/csrf/CSRFToken.scala
+++ b/app/com/gu/identity/frontend/csrf/CSRFToken.scala
@@ -1,16 +1,16 @@
 package com.gu.identity.frontend.csrf
 
 import play.api.mvc.RequestHeader
-import play.filters.csrf.{CSRF, CSRFConfig}
+import play.filters.csrf.CSRF.{Token, getToken}
 
-case class CSRFToken(fieldName: String, value: String)
+case class CSRFToken private(fieldName: String, value: String)
 
 object CSRFToken {
-  def apply(config: CSRFConfig, token: CSRF.Token): CSRFToken =
+  def apply(config: CSRFConfig, token: Token): CSRFToken =
     CSRFToken(config.tokenName, token.value)
 
   def fromRequest(config: CSRFConfig, request: RequestHeader): Option[CSRFToken] =
-    CSRF.getToken(request, config)
+    getToken(request, config.underlying)
       .map(CSRFToken(config, _))
 
 }

--- a/app/com/gu/identity/frontend/csrf/package.scala
+++ b/app/com/gu/identity/frontend/csrf/package.scala
@@ -1,0 +1,13 @@
+package com.gu.identity.frontend
+
+import play.api.mvc.{RequestHeader, Result}
+import play.filters.csrf.CSRF
+
+import scala.concurrent.Future
+
+
+package object csrf {
+  type CSRFErrorHandler = (RequestHeader, String) => Future[Result]
+
+  lazy val defaultErrorHandler: CSRFErrorHandler = CSRF.DefaultErrorHandler.handle
+}

--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -15,8 +15,23 @@ object ViewRenderer {
   def render(view: String, attributes: Map[String, Any] = Map.empty) =
     HBS(view, attributes)
 
-  def renderSignIn(configuration: Configuration, activeTests: Map[MultiVariantTest, MultiVariantTestVariant], errorIds: Seq[String], returnUrl: ReturnUrl, skipConfirmation: Option[Boolean])(implicit messages: Messages) = {
-    val errors = errorIds.map(ErrorViewModel.apply)
+  def renderSignIn(
+      configuration: Configuration,
+      activeTests: Map[MultiVariantTest, MultiVariantTestVariant],
+      csrfToken: Option[CSRFToken],
+      errorIds: Seq[String],
+      returnUrl: ReturnUrl,
+      skipConfirmation: Option[Boolean])
+      (implicit messages: Messages) = {
+
+    val model = SignInViewModel(
+      configuration = configuration,
+      activeTests = activeTests,
+      csrfToken = csrfToken,
+      errors = errorIds.map(ErrorViewModel.apply),
+      returnUrl = returnUrl,
+      skipConfirmation = skipConfirmation
+    )
 
     val defaultView = "signin-page"
     val view = activeTests.get(SignInV2Test) match {
@@ -24,13 +39,7 @@ object ViewRenderer {
       case _ => defaultView
     }
 
-    renderViewModel(view, SignInViewModel(
-      configuration = configuration,
-      activeTests = activeTests,
-      errors = errors,
-      returnUrl = returnUrl,
-      skipConfirmation = skipConfirmation
-    ))
+    renderViewModel(view, model)
   }
 
   def renderRegister(

--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -1,6 +1,7 @@
 package com.gu.identity.frontend.views
 
 import com.gu.identity.frontend.configuration._
+import com.gu.identity.frontend.csrf.CSRFToken
 import com.gu.identity.frontend.models.ReturnUrl
 import com.gu.identity.frontend.views.models._
 import jp.co.bizreach.play2handlebars.HBS
@@ -36,6 +37,7 @@ object ViewRenderer {
       configuration: Configuration,
       activeTests: Map[MultiVariantTest, MultiVariantTestVariant],
       errorIds: Seq[String],
+      csrfToken: Option[CSRFToken],
       returnUrl: ReturnUrl,
       skipConfirmation: Option[Boolean])
       (implicit messages: Messages) = {
@@ -44,6 +46,7 @@ object ViewRenderer {
       configuration = configuration,
       activeTests = activeTests,
       errors = errorIds.map(ErrorViewModel.apply),
+      csrfToken = csrfToken,
       returnUrl = returnUrl,
       skipConfirmation = skipConfirmation)
 

--- a/app/com/gu/identity/frontend/views/models/ErrorViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/ErrorViewModel.scala
@@ -13,6 +13,7 @@ object ErrorViewModel {
   val errorMessages = Map(
     "signin-error-gateway" -> "There was a problem signing in; please try again.",
     "signin-error-bad-request" -> "Incorrect email or password; please try again.",
+    "signin-error-csrf" -> "Forgery token invalid; please try again.",
     "register-error-gateway" -> "There was a problem creating your account; please try again.",
     "register-error-bad-request" -> "One or more inputs was not valid; please try again.",
     "register-error-username-in-use" -> "The username you selected is already in use; please choose another one.",
@@ -22,7 +23,8 @@ object ErrorViewModel {
     "register-error-lastName" -> nonEmptyField("last name"),
     "register-error-email" -> "Invalid email address; please try again.",
     "register-error-username" -> "Invalid username; your username must be between 6 and 20 characters long and contain only letters and numbers.",
-    "register-error-password" -> "Invalid password; your password must be between 6 and 20 characters long."
+    "register-error-password" -> "Invalid password; your password must be between 6 and 20 characters long.",
+    "register-error-csrf" -> "Forgery token invalid; please try again."
   )
 
   private def nonEmptyField(fieldName: String) = s"${fieldName.capitalize} field must not be blank."

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -2,6 +2,7 @@ package com.gu.identity.frontend.views.models
 
 import com.gu.identity.frontend.configuration.{MultiVariantTestVariant, MultiVariantTest, Configuration}
 import com.gu.identity.frontend.controllers.routes
+import com.gu.identity.frontend.csrf.CSRFToken
 import com.gu.identity.frontend.models.{UrlBuilder, ReturnUrl}
 import com.gu.identity.frontend.models.text.RegisterText
 import play.api.i18n.Messages
@@ -17,6 +18,8 @@ case class RegisterViewModel(
 
     hasErrors: Boolean,
     errors: Seq[ErrorViewModel],
+
+    csrfToken: Option[CSRFToken],
     returnUrl: String,
     skipConfirmation: Boolean,
 
@@ -34,6 +37,7 @@ object RegisterViewModel {
       configuration: Configuration,
       activeTests: Iterable[(MultiVariantTest, MultiVariantTestVariant)],
       errors: Seq[ErrorViewModel],
+      csrfToken: Option[CSRFToken],
       returnUrl: ReturnUrl,
       skipConfirmation: Option[Boolean])
       (implicit messages: Messages): RegisterViewModel = {
@@ -50,6 +54,8 @@ object RegisterViewModel {
 
       hasErrors = errors.nonEmpty,
       errors = errors,
+
+      csrfToken = csrfToken,
       returnUrl = returnUrl.url,
       skipConfirmation = skipConfirmation.getOrElse(false),
 

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -2,6 +2,7 @@ package com.gu.identity.frontend.views.models
 
 import com.gu.identity.frontend.configuration.{MultiVariantTestVariant, MultiVariantTest, Configuration}
 import com.gu.identity.frontend.controllers.routes
+import com.gu.identity.frontend.csrf.CSRFToken
 import com.gu.identity.frontend.models.{UrlBuilder, ReturnUrl}
 import com.gu.identity.frontend.models.Text._
 import play.api.i18n.Messages
@@ -17,6 +18,8 @@ case class SignInViewModel private(
     showPrelude: Boolean = false,
     hasErrors: Boolean = false,
     errors: Seq[ErrorViewModel] = Seq.empty,
+
+    csrfToken: Option[CSRFToken],
     returnUrl: String = "",
     skipConfirmation: Boolean = false,
     registerUrl: String = "",
@@ -30,7 +33,7 @@ case class SignInViewModel private(
 
 
 object SignInViewModel {
-  def apply(configuration: Configuration, activeTests: Iterable[(MultiVariantTest, MultiVariantTestVariant)], errors: Seq[ErrorViewModel], returnUrl: ReturnUrl, skipConfirmation: Option[Boolean])(implicit messages: Messages): SignInViewModel = {
+  def apply(configuration: Configuration, activeTests: Iterable[(MultiVariantTest, MultiVariantTestVariant)], csrfToken: Option[CSRFToken], errors: Seq[ErrorViewModel], returnUrl: ReturnUrl, skipConfirmation: Option[Boolean])(implicit messages: Messages): SignInViewModel = {
     val layout = LayoutViewModel(configuration, activeTests)
 
     SignInViewModel(
@@ -43,6 +46,8 @@ object SignInViewModel {
 
       hasErrors = errors.nonEmpty,
       errors = errors,
+
+      csrfToken = csrfToken,
       returnUrl = returnUrl.url,
       skipConfirmation = skipConfirmation.getOrElse(false),
       registerUrl = UrlBuilder(routes.Application.register(), returnUrl, skipConfirmation),

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -9,6 +9,12 @@ play2handlebars.root = ""
 # Compile Time DI
 play.application.loader="com.gu.identity.frontend.configuration.FrontendApplicationLoader"
 
+# CSRF protection config
+play.filters.csrf.cookie.name = "GU_PROFILE_CSRF"
+play.filters.csrf.cookie.httpOnly = true
+play.filters.csrf.cookie.secure = true
+
+
 # Identity configuration
 identity {
   # Identity API configuration for the client library

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -13,6 +13,7 @@ play.application.loader="com.gu.identity.frontend.configuration.FrontendApplicat
 play.filters.csrf.cookie.name = "GU_PROFILE_CSRF"
 play.filters.csrf.cookie.httpOnly = true
 play.filters.csrf.cookie.secure = true
+play.filters.csrf.cookie.headerBypass = false
 
 
 # Identity configuration

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.6")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.3")
 

--- a/public/components/register-form/_register-form.hbs
+++ b/public/components/register-form/_register-form.hbs
@@ -1,4 +1,5 @@
 <form id="register_form" class="register-form" action="{{ actions.register }}" method="POST">
+  <input type="hidden" name="{{ csrfToken.fieldName }}" value="{{ csrfToken.value }}">
   <input type="hidden" name="returnUrl" value="{{ returnUrl }}"/>
   <input type="hidden" name="skipConfirmation" value="{{ skipConfirmation }}"/>
 

--- a/public/signin-page-b.hbs
+++ b/public/signin-page-b.hbs
@@ -15,6 +15,7 @@
   {{/ hasErrors }}
 
   <form id="signin_form" class="signin-form{{# hasErrors }}--with-errors{{/ hasErrors }}" action="{{ actions.signIn }}" method="POST">
+    <input type="hidden" name="{{ csrfToken.fieldName }}" value="{{ csrfToken.value }}">
     <input type="hidden" name="returnUrl" value="{{returnUrl}}">
     <input type="hidden" name="skipConfirmation" value="{{skipConfirmation}}">
     <p class="signin-form__prelude">{{signInPageText.divideText}}</p>

--- a/public/signin-page.hbs
+++ b/public/signin-page.hbs
@@ -14,6 +14,7 @@
   {{> components/oauth-cta/_oauth-cta }}
 
   <form id="signin_form" class="signin-form" action="{{ actions.signIn }}" method="POST">
+    <input type="hidden" name="{{ csrfToken.fieldName }}" value="{{ csrfToken.value }}">
     <input type="hidden" name="returnUrl" value="{{returnUrl}}">
     <input type="hidden" name="skipConfirmation" value="{{skipConfirmation}}">
     <p class="signin-form__prelude">{{signInPageText.divideText}}</p>

--- a/test/com/gu/identity/frontend/controllers/RegisterActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/RegisterActionSpec.scala
@@ -3,6 +3,7 @@ package com.gu.identity.frontend.controllers
 import java.net.{URLDecoder, URLEncoder}
 
 import com.gu.identity.frontend.configuration.Configuration
+import com.gu.identity.frontend.csrf.CSRFConfig
 import com.gu.identity.frontend.models.{ClientRegistrationIp, TrackingData}
 import com.gu.identity.frontend.services.{ServiceGatewayError, ServiceBadRequest, IdentityService}
 import com.gu.identity.frontend.utils.UrlDecoder
@@ -15,14 +16,13 @@ import play.api.{Configuration => PlayConfiguration}
 import play.api.mvc.Cookie
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import play.filters.csrf.CSRFConfig
 import play.utils.UriEncoding
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class RegisterActionSpec extends PlaySpec with MockitoSugar {
 
-  val fakeCsrfConfig = CSRFConfig()
+  val fakeCsrfConfig = CSRFConfig.disabled
 
   trait WithControllerMockedDependencies {
     val mockIdentityService = mock[IdentityService]
@@ -64,7 +64,6 @@ class RegisterActionSpec extends PlaySpec with MockitoSugar {
       "group" -> group.getOrElse(""))
 
     FakeRequest("POST", "/actions/register")
-      .withHeaders(fakeCsrfConfig.headerName -> "nocheck")
       .withFormUrlEncodedBody(bodyParams: _*)
   }
 

--- a/test/com/gu/identity/frontend/controllers/SigninActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/SigninActionSpec.scala
@@ -1,5 +1,6 @@
 package com.gu.identity.frontend.controllers
 
+import com.gu.identity.frontend.csrf.CSRFConfig
 import com.gu.identity.frontend.models.TrackingData
 import com.gu.identity.frontend.services._
 import org.mockito.Mockito._
@@ -11,13 +12,12 @@ import play.api.mvc.Cookie
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import org.scalatest.Matchers._
-import play.filters.csrf.CSRFConfig
 
 import scala.concurrent.{ExecutionContext, Future}
 
 
 class SigninActionSpec extends PlaySpec with MockitoSugar {
-  val fakeCsrfConfig = CSRFConfig()
+  val fakeCsrfConfig = CSRFConfig.disabled
 
   trait WithControllerMockedDependencies {
     val mockIdentityService = mock[IdentityService]
@@ -32,7 +32,6 @@ class SigninActionSpec extends PlaySpec with MockitoSugar {
       .map(p => p._1 -> p._2.get)
 
     FakeRequest("POST", "/actions/signin")
-      .withHeaders(fakeCsrfConfig.headerName -> "nocheck")
       .withFormUrlEncodedBody(bodyParams: _*)
   }
 

--- a/test/com/gu/identity/frontend/controllers/SigninActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/SigninActionSpec.scala
@@ -11,17 +11,19 @@ import play.api.mvc.Cookie
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import org.scalatest.Matchers._
+import play.filters.csrf.CSRFConfig
 
 import scala.concurrent.{ExecutionContext, Future}
 
 
 class SigninActionSpec extends PlaySpec with MockitoSugar {
+  val fakeCsrfConfig = CSRFConfig()
 
   trait WithControllerMockedDependencies {
     val mockIdentityService = mock[IdentityService]
     val messages = mock[MessagesApi]
 
-    val controller = new SigninAction(mockIdentityService, messages)
+    val controller = new SigninAction(mockIdentityService, messages, fakeCsrfConfig)
   }
 
   def fakeSigninRequest(email: Option[String], password: Option[String], rememberMe: Option[String], returnUrl: Option[String]) = {
@@ -30,6 +32,7 @@ class SigninActionSpec extends PlaySpec with MockitoSugar {
       .map(p => p._1 -> p._2.get)
 
     FakeRequest("POST", "/actions/signin")
+      .withHeaders(fakeCsrfConfig.headerName -> "nocheck")
       .withFormUrlEncodedBody(bodyParams: _*)
   }
 

--- a/test/com/gu/identity/frontend/csrf/CSRFActionsSpec.scala
+++ b/test/com/gu/identity/frontend/csrf/CSRFActionsSpec.scala
@@ -5,10 +5,15 @@ import org.scalatestplus.play.PlaySpec
 import play.api.mvc.Controller
 import play.api.test._
 import play.api.test.Helpers._
+import play.filters.csrf.{CSRFConfig => PlayCSRFConfig}
 
 class CSRFActionsSpec extends PlaySpec with SimpleAppPerSuite {
 
-  val csrfConfig = CSRFConfig()
+  val csrfCookieName = "GU_TEST_CSRF"
+  val underlyingCsrfConfig = PlayCSRFConfig(
+    cookieName = Some(csrfCookieName)
+  )
+  val csrfConfig = CSRFConfig(underlyingCsrfConfig)
 
   "Add token Action" must {
 
@@ -24,6 +29,15 @@ class CSRFActionsSpec extends PlaySpec with SimpleAppPerSuite {
       val cacheHeader = header("Cache-Control", resp)
 
       cacheHeader.value must include("no-cache")
+    }
+
+    "have token on response" in {
+      val resp = controller.testEndpoint(FakeRequest())
+
+      val respCookies = cookies(resp)
+      val csrfCookie = respCookies.get(csrfCookieName)
+
+      csrfCookie must not be empty
     }
 
   }

--- a/test/com/gu/identity/frontend/csrf/CSRFActionsSpec.scala
+++ b/test/com/gu/identity/frontend/csrf/CSRFActionsSpec.scala
@@ -15,16 +15,20 @@ class CSRFActionsSpec extends PlaySpec with SimpleAppPerSuite {
   )
   val csrfConfig = CSRFConfig(underlyingCsrfConfig)
 
-  "Add token Action" must {
-
-    val controller = new Controller {
-      def testEndpoint = CSRFAddToken(csrfConfig) {
-        Ok("test response")
-      }
+  val controller = new Controller {
+    def testCSRFAddToken = CSRFAddToken(csrfConfig) {
+      Ok("test add token response")
     }
 
+    def testCSRFCheck = CSRFCheck(csrfConfig) {
+      Ok("test check response")
+    }
+  }
+
+  "Add token Action" must {
+
     "have non-cacheable response" in {
-      val resp = controller.testEndpoint(FakeRequest())
+      val resp = controller.testCSRFAddToken(FakeRequest())
 
       val cacheHeader = header("Cache-Control", resp)
 
@@ -32,12 +36,25 @@ class CSRFActionsSpec extends PlaySpec with SimpleAppPerSuite {
     }
 
     "have token on response" in {
-      val resp = controller.testEndpoint(FakeRequest())
+      val resp = controller.testCSRFAddToken(FakeRequest())
 
       val respCookies = cookies(resp)
       val csrfCookie = respCookies.get(csrfCookieName)
 
       csrfCookie must not be empty
+    }
+
+  }
+
+
+  "Check token Action" must {
+
+    "have non-cacheable response" in {
+      val resp = controller.testCSRFCheck(FakeRequest())
+
+      val cacheHeader = header("Cache-Control", resp)
+
+      cacheHeader.value must include("no-cache")
     }
 
   }

--- a/test/com/gu/identity/frontend/csrf/CSRFActionsSpec.scala
+++ b/test/com/gu/identity/frontend/csrf/CSRFActionsSpec.scala
@@ -1,0 +1,30 @@
+package com.gu.identity.frontend.csrf
+
+import com.gu.identity.frontend.test.SimpleAppPerSuite
+import org.scalatestplus.play.PlaySpec
+import play.api.mvc.Controller
+import play.api.test._
+import play.api.test.Helpers._
+
+class CSRFActionsSpec extends PlaySpec with SimpleAppPerSuite {
+
+  val csrfConfig = CSRFConfig()
+
+  "Add token Action" must {
+
+    val controller = new Controller {
+      def testEndpoint = CSRFAddToken(csrfConfig) {
+        Ok("test response")
+      }
+    }
+
+    "have non-cacheable response" in {
+      val resp = controller.testEndpoint(FakeRequest())
+
+      val cacheHeader = header("Cache-Control", resp)
+
+      cacheHeader.value must include("no-cache")
+    }
+
+  }
+}

--- a/test/com/gu/identity/frontend/test/SimpleAppPerSuite.scala
+++ b/test/com/gu/identity/frontend/test/SimpleAppPerSuite.scala
@@ -1,0 +1,26 @@
+package com.gu.identity.frontend.test
+
+import org.scalatest._
+import play.api.{Application, Play}
+
+
+trait SimpleAppPerSuite extends SuiteMixin { this: Suite =>
+
+  lazy val app: Application = SimpleFakeApplication()
+
+  abstract override def run(testName: Option[String], args: Args): Status = {
+    Play.start(app)
+    try {
+      val newConfigMap = args.configMap + ("org.scalatestplus.play.app" -> app)
+      val newArgs = args.copy(configMap = newConfigMap)
+      val status = super.run(testName, newArgs)
+      status.whenCompleted { _ => Play.stop(app) }
+      status
+    }
+    catch { // In case the suite aborts, ensure the app is stopped
+      case ex: Throwable =>
+        Play.stop(app)
+        throw ex
+    }
+  }
+}

--- a/test/com/gu/identity/frontend/test/SimpleFakeApplication.scala
+++ b/test/com/gu/identity/frontend/test/SimpleFakeApplication.scala
@@ -1,0 +1,31 @@
+package com.gu.identity.frontend.test
+
+import play.api.ApplicationLoader.Context
+import play.api.routing.Router
+import play.api.{Application, ApplicationLoader, BuiltInComponentsFromContext, Environment}
+
+
+/**
+ * Loads a Simple FakeApplication for use with tests.
+ *
+ * Required as play.api.test.FakeApplication uses the Guice DI Injector
+ * which fails with our app as we use Compile time (manual) injection.
+ */
+object SimpleFakeApplication {
+  def apply(): Application = {
+    val env = Environment.simple()
+    val context = ApplicationLoader.createContext(env)
+
+    SimpleFakeApplicationLoader.load(context)
+  }
+}
+
+
+object SimpleFakeApplicationLoader extends ApplicationLoader {
+  override def load(context: Context): Application =
+    new ApplicationComponents(context).application
+
+  private class ApplicationComponents(context: Context) extends BuiltInComponentsFromContext(context) {
+    override lazy val router = Router.empty
+  }
+}


### PR DESCRIPTION
Uses adapters around play's CSRF filters / API to use request tokens to prevent CSRF attacks.

Added to both Sign in and Registration endpoints.