### PR TITLE
Remember form inputs on Register page

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "npm run build-css && npm run build-js",
     "prebuild-css": "npm run lint-css && mkdir -p ./target/web/build",
     "build-css": "postcss -c postcss.json",
-    "build-js": "webpack -p --bail",
+    "build-js": "webpack --bail",
     "lint-css": "stylelint 'public/**/*.css'"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "cookie-cutter": "^0.1.1",
-    "curl-amd": "^0.8.12"
+    "curl-amd": "^0.8.12",
+    "lodash": "^4.0.1"
   }
 }

--- a/public/components/browser/storage.js
+++ b/public/components/browser/storage.js
@@ -21,8 +21,27 @@ function storage( type ) {
       checkSupported() && storageActual.setItem( key, value );
     },
 
+    setJSON: function setJSONValue( key, value ) {
+      return this.set( key, JSON.stringify( value ) );
+    },
+
     get: function getValue( key ) {
-      return checkSupported() && storageActual.getItem( key );
+      return checkSupported() && storageActual.getItem( key ) || undefined;
+    },
+
+    getJSON: function getJSONValue( key ) {
+      try {
+        const value = this.get(key);
+
+        if ( typeof value === 'string' ) {
+          return JSON.parse( value );
+        }
+
+      } catch ( err ) {
+        if ( console && console.warn ) {
+          console.warn( `Error parsing JSON from storage for key "${key}": ${err}` );
+        }
+      }
     }
   });
 }

--- a/public/components/lib/lodash.js
+++ b/public/components/lib/lodash.js
@@ -1,0 +1,11 @@
+/**
+ * Adapter for lodash - JS utilities.
+ *
+ * Only used functions should be exported from the library.
+ *
+ * @see https://lodash.com/
+ */
+
+import mapValues from 'lodash/mapValues';
+
+export { mapValues };

--- a/public/components/register-form/register-form.js
+++ b/public/components/register-form/register-form.js
@@ -1,6 +1,8 @@
 
 import { getElementById, sessionStorage } from '../browser/browser';
 
+import { mapValues as _mapValues } from '../lib/lodash';
+
 const STORAGE_KEY = 'gu_id_register_state';
 
 
@@ -19,15 +21,12 @@ class RegisterFormFields {
     this.username.setValue( username );
   }
 
-  toJSON() {
-    // TODO use _.mapValues
+  mapValues( callback ) {
+    return _mapValues( this, callback );
+  }
 
-    return {
-      firstName: this.firstName.value(),
-      lastName: this.lastName.value(),
-      email: this.email.value(),
-      username: this.username.value()
-    };
+  toJSON() {
+    return this.mapValues( field => field.value() );
   }
 }
 
@@ -38,10 +37,10 @@ class RegisterFormModel {
 
     this.fields = new RegisterFormFields( firstNameField, lastNameField, emailField, usernameField );
 
-    this.addFormListeners();
+    this.addBindings();
   }
 
-  addFormListeners() {
+  addBindings() {
     this.formElement.on( 'submit', this.formSubmitted.bind( this ) );
   }
 

--- a/public/components/register-form/register-form.js
+++ b/public/components/register-form/register-form.js
@@ -1,0 +1,122 @@
+
+import { getElementById, sessionStorage } from '../browser/browser';
+
+const STORAGE_KEY = 'gu_id_register_state';
+
+
+class RegisterFormFields {
+  constructor(firstNameField, lastNameField, emailField, usernameField) {
+    this.firstName = firstNameField;
+    this.lastName = lastNameField;
+    this.email = emailField;
+    this.username = usernameField;
+  }
+
+  setValues( { firstName, lastName, email, username } = {} ) {
+    this.firstName.setValue( firstName );
+    this.lastName.setValue( lastName );
+    this.email.setValue( email );
+    this.username.setValue( username );
+  }
+
+  toJSON() {
+    // TODO use _.mapValues
+
+    return {
+      firstName: this.firstName.value(),
+      lastName: this.lastName.value(),
+      email: this.email.value(),
+      username: this.username.value()
+    };
+  }
+}
+
+
+class RegisterFormModel {
+  constructor( formElement, firstNameField, lastNameField, emailField, usernameField ) {
+    this.formElement = formElement;
+
+    this.fields = new RegisterFormFields( firstNameField, lastNameField, emailField, usernameField );
+
+    this.addFormListeners();
+  }
+
+  addFormListeners() {
+    this.formElement.on( 'submit', this.formSubmitted.bind( this ) );
+  }
+
+  loadState() {
+    this.state = RegisterFormState.fromStorage();
+    this.fields.setValues( this.state );
+  }
+
+  saveState() {
+    this.state = RegisterFormState.fromForm( this );
+    this.state.save();
+  }
+
+  formSubmitted() {
+    this.saveState();
+  }
+
+  static fromDocument() {
+    const form = getElementById( 'register_form' );
+    const firstNameField = getElementById( 'register_field_firstname' );
+    const lastNameField = getElementById( 'register_field_lastname' );
+    const emailField = getElementById( 'register_field_email' );
+    const usernameField = getElementById( 'register_field_username' );
+
+    if ( form && firstNameField && lastNameField && emailField && usernameField ) {
+      return new RegisterFormModel( form, firstNameField, lastNameField, emailField, usernameField );
+    }
+  }
+}
+
+
+class RegisterFormState {
+  constructor( firstName = "", lastName = "", email = "", username = "" ) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.email = email;
+    this.username = username;
+  }
+
+  save() {
+    sessionStorage.setJSON( STORAGE_KEY, this );
+  }
+
+  /**
+   * @return {RegisterFormState}
+   */
+  static fromObject( { firstName, lastName, email, username } = {} ) {
+    return new RegisterFormState( firstName, lastName, email, username );
+  }
+
+  /**
+   * @return {RegisterFormState}
+   */
+  static fromStorage() {
+    const existingState = sessionStorage.getJSON( STORAGE_KEY );
+
+    return RegisterFormState.fromObject( existingState )
+  }
+
+  /**
+   * @param {RegisterFormModel} form
+   * @return {RegisterFormState}
+   */
+  static fromForm( form ) {
+    return RegisterFormState.fromObject( form.fields.toJSON() );
+  }
+}
+
+
+export function init() {
+  const form = RegisterFormModel.fromDocument();
+
+  if ( form ) {
+    form.loadState();
+  }
+
+  return form;
+}

--- a/public/components/signin/signin.js
+++ b/public/components/signin/signin.js
@@ -10,23 +10,22 @@ class SignInFormModel {
     this.formElement = formElement;
     this.emailFieldElement = emailField;
 
-    this.state = SignInFormState.fromStorage();
-    this.addFormListeners();
+    this.addBindings();
   }
 
-  addFormListeners() {
+  addBindings() {
     this.formElement.on( 'submit', this.formSubmitted.bind( this ) );
   }
 
   loadState() {
-    if ( !this.emailFieldElement.value() && this.state.email ) {
-      this.emailFieldElement.setValue( this.state.email );
-    }
+    this.state = SignInFormState.fromStorage();
+    this.emailFieldElement.setValue( this.state.email );
   }
 
   saveState() {
     const email = this.emailFieldElement.value();
 
+    this.state = new SignInFormState( email );
     this.state.save( email );
   }
 
@@ -46,22 +45,25 @@ class SignInFormModel {
 
 
 class SignInFormState {
-  constructor( email ) {
+  constructor( email = "" ) {
     this.email = email;
   }
 
-  save( email ) {
-    if ( typeof email === 'string' && email.length > 0 ) {
-      sessionStorage.setJSON( STORAGE_KEY, { email } );
-    }
+  save() {
+    sessionStorage.setJSON( STORAGE_KEY, this );
+  }
+
+  /**
+   * @return {SignInFormState}
+   */
+  static fromObject( { email } = {} ) {
+    return new SignInFormState( email );
   }
 
   static fromStorage() {
     const existingState = sessionStorage.getJSON( STORAGE_KEY );
 
-    const email = typeof existingState === 'object' && existingState.email || undefined;
-
-    return new SignInFormState( email );
+    return SignInFormState.fromObject( existingState )
   }
 }
 

--- a/public/main.js
+++ b/public/main.js
@@ -5,6 +5,8 @@ import { logPageView } from './components/analytics/analytics';
 import { init as initSigninBindings } from './components/signin/signin';
 import { init as initSigninTestB } from './components/signin-b/signin-b';
 
+import { init as initRegisterBindings } from './components/register-form/register-form';
+
 
 if ( isBrowserSupported ) {
 
@@ -13,5 +15,7 @@ if ( isBrowserSupported ) {
   initSigninBindings();
 
   initSigninTestB();
+
+  initRegisterBindings();
 
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,23 +1,31 @@
-var webpack = require('webpack');
-var path = require('path');
+/*eslint-env node*/
+
+var webpack = require( 'webpack' );
+var path = require( 'path' );
 
 module.exports = {
   entry: {
     main: './public/main'
   },
   output: {
-    path: path.resolve(__dirname, 'target/web/build/'),
-    publicPath: "/static/",
-    filename: "[name].bundle.js"
+    path: path.resolve( __dirname, 'target/web/build/' ),
+    publicPath: '/static/',
+    filename: '[name].bundle.js'
   },
-  devtool: "#source-map",
+  devtool: '#source-map',
   module: {
     loaders: [
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loaders: ['babel?presets[]=es2015']
+        loaders: [ 'babel?presets[]=es2015' ]
       }
     ]
-  }
+  },
+  plugins: [
+    new webpack.optimize.OccurrenceOrderPlugin(),
+    new webpack.optimize.UglifyJsPlugin( {
+      mangle: false
+    } )
+  ]
 };


### PR DESCRIPTION
Remember form inputs on Register page using session storage in the browser as persistence.

- Uses classes to model the Register form, fields, and state
- Updated logic for sign in field persistence to match Register's
- Added lodash as a dependency, only using `mapValues` for now
- Changed webpack config to not mangle JS variables with Uglify, aids with debugging