### PR TITLE
Better Content-Security-Policy 1.0 support

### DIFF
--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -89,9 +89,9 @@ object LayoutViewModel {
       }.toMap)
     }
 
-    val inlinedJSConfig = InlinedJavascriptResource(config.toJavascript, isInHead = true)
+    val inlinedJSConfig = InlinedJSONResource("id_config", config.toJSONString)
     val inlinedJSRuntimeParams = runtime.map { r =>
-      InlinedJavascriptResource(r.toJavascript, isInHead = true)
+      InlinedJSONResource("id_runtime_params", r.toJSONString)
     }
 
     val resources: Seq[PageResource with Product] = BaseLayoutViewModel.resources ++ Seq(Some(inlinedJSConfig), inlinedJSRuntimeParams).flatten

--- a/app/com/gu/identity/frontend/views/models/PageResources.scala
+++ b/app/com/gu/identity/frontend/views/models/PageResources.scala
@@ -11,6 +11,9 @@ sealed trait InlinedResource
 
 sealed trait UnsafeResource
 
+// Resources without a Content-Security-Policy requirement
+sealed trait NoPolicyRequirement
+
 sealed trait InlinedSource {
   val source: String
   val sha256: String
@@ -82,6 +85,14 @@ object InlinedJavascriptResource {
   def apply(source: String, isInHead: Boolean): InlinedJavascriptResource =
     InlinedJavascriptResource(source, InlinedSource.sha256(source).getOrElse(""), isInHead)
 }
+
+
+case class InlinedJSONResource(
+    id: String,
+    source: String,
+    isInHead: Boolean = true,
+    isJSON: Boolean = true)
+  extends ScriptResource with NoPolicyRequirement
 
 
 case class LocalCSSResource private(

--- a/public/components/analytics/mvt-model.js
+++ b/public/components/analytics/mvt-model.js
@@ -1,4 +1,4 @@
-/*global window*/
+import { configuration } from '../configuration/configuration';
 
 const MAX_ID = 899999;
 
@@ -34,8 +34,8 @@ export class MultiVariantTest {
   }
 
   static initFromPageConfig() {
-    if (window._idConfig && Array.isArray(window._idConfig.mvtTests)) {
-      return window._idConfig.mvtTests.map(test => MultiVariantTest.fromObject(test));
+    if ( configuration && Array.isArray( configuration.mvtTests ) ) {
+      return configuration.mvtTests.map( test => MultiVariantTest.fromObject( test ) );
     }
 
     return [];

--- a/public/components/analytics/mvt.js
+++ b/public/components/analytics/mvt.js
@@ -2,7 +2,7 @@
  * Multi-variant testing.
  */
 
-/*global window*/
+import { runtimeParameters } from '../configuration/configuration';
 
 import cookies from 'cookie-cutter';
 import { MultiVariantTest } from './mvt-model';
@@ -64,8 +64,8 @@ function getActiveTestsAndResults() {
 }
 
 function getServerSideActiveTestResults() {
-  if (window._idRuntimeParams && typeof (window._idRuntimeParams.activeTests) === 'object') {
-    return window._idRuntimeParams.activeTests;
+  if ( runtimeParameters && typeof ( runtimeParameters.activeTests) === 'object') {
+    return runtimeParameters.activeTests;
   }
   return {};
 }

--- a/public/components/analytics/omniture.js
+++ b/public/components/analytics/omniture.js
@@ -2,6 +2,8 @@
 
 /*global window*/
 
+import { configuration } from '../configuration/configuration';
+
 /* SiteCatalyst code version: AM 1.4.1
  Copyright 1996-2014 Adobe, Inc. All Rights Reserved
  More info available at http://www.omniture.com */
@@ -13,7 +15,7 @@ const s = s_gi(s_account);
 export default s;
 
 function getOmnitureAccount() {
-  const account = window._idConfig && window._idConfig.omnitureAccount;
+  const account = configuration && configuration.omnitureAccount;
   if (!account) {
     throw new Error('Omniture account configuration not found');
   }

--- a/public/components/browser/dom-element.js
+++ b/public/components/browser/dom-element.js
@@ -12,7 +12,8 @@ export function domElement( elem ) {
     select: domElementFunctionProxy.bind( null, elem, 'select' ),
     on: domElementEventHandler.bind( null, elem ),
     value: domElementValueExtractor.bind( null, elem, 'value' ),
-    setValue: domElementValueSetter.bind( null, elem, 'value' )
+    setValue: domElementValueSetter.bind( null, elem, 'value' ),
+    innerHTML: domElementValueExtractor.bind( null, elem, 'innerHTML' )
   });
 }
 

--- a/public/components/configuration/configuration.js
+++ b/public/components/configuration/configuration.js
@@ -1,0 +1,63 @@
+/*global console*/
+
+import { getElementById } from '../browser/browser';
+
+class Configuration {
+  constructor( omnitureAccount, mvtTests ) {
+    this.omnitureAccount = omnitureAccount;
+    this.mvtTests = mvtTests;
+  }
+
+  static fromObject( { omnitureAccount, mvtTests } ) {
+    return new Configuration( omnitureAccount, mvtTests );
+  }
+
+  static fromDocument() {
+    const configElem = getElementById( 'id_config' );
+    if ( configElem !== undefined ) {
+      const html = configElem.innerHTML();
+      const parsed = parseJSON( html );
+
+      return Configuration.fromObject( parsed );
+    }
+  }
+}
+
+
+class RuntimeParameters {
+  constructor( activeTests ) {
+    this.activeTests = activeTests;
+  }
+
+  static fromObject( { activeTests } ) {
+    return new RuntimeParameters( activeTests );
+  }
+
+  static fromDocument() {
+    const configElem = getElementById( 'id_runtime_params' );
+    if ( configElem !== undefined ) {
+      const html = configElem.innerHTML();
+      const parsed = parseJSON( html );
+
+      return RuntimeParameters.fromObject( parsed );
+    }
+  }
+}
+
+
+function parseJSON( input ) {
+  try {
+    return JSON.parse( input );
+
+  } catch ( err ) {
+    if ( console ) {
+      console.warn( 'Could not parse Configuration JSON: ' + err );
+    }
+
+    return undefined;
+  }
+}
+
+
+export const configuration = Configuration.fromDocument();
+export const runtimeParameters = RuntimeParameters.fromDocument();

--- a/public/layout.hbs
+++ b/public/layout.hbs
@@ -26,6 +26,12 @@
       {{/isInHead}}
     {{/isJavascript}}
 
+    {{# isJSON }}
+      {{# isInHead }}
+        <script id="{{ id }}" type="application/json">{{{ source }}}</script>
+      {{/ isInHead }}
+    {{/ isJSON }}
+
   {{/each}}
 
 </head>


### PR DESCRIPTION
Found an issue related to CSP and Firefox version < 43, where only CSP 1.0 is properly supported. Hashes of inlined scripts are not supported in this browser resulting in client errors.

This PR changes the config from an inlined script to be statically injected into the response into a `<script type="application/json">` tag, then parsed via the Javascript when it initialises.