### PR TITLE
Move CSP report endpoint

### DIFF
--- a/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
+++ b/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
@@ -55,5 +55,5 @@ class ApplicationComponents(context: Context) extends BuiltInComponentsFromConte
     Logger.configure(environment)
   }
 
-  override lazy val router: Router = new Routes(httpErrorHandler, applicationController, signinController, registerController, healthcheckController, manifestController, assets, cspReporterController)
+  override lazy val router: Router = new Routes(httpErrorHandler, applicationController, signinController, registerController, cspReporterController, healthcheckController, manifestController, assets)
 }

--- a/conf/routes
+++ b/conf/routes
@@ -15,10 +15,10 @@ POST       /actions/signin                com.gu.identity.frontend.controllers.S
 
 POST       /actions/register              com.gu.identity.frontend.controllers.RegisterAction.register
 
+POST       /actions/csp/report            com.gu.identity.frontend.controllers.CSPViolationReporter.cspReport
+
 GET        /management/healthcheck        com.gu.identity.frontend.controllers.HealthCheck.healthCheck
 
 GET        /management/manifest           com.gu.identity.frontend.controllers.Manifest.manifest
 
 GET        /static/*file                  controllers.Assets.versioned(path="/public", file: Asset)
-
-POST       /csp/report                    com.gu.identity.frontend.controllers.CSPViolationReporter.cspReport


### PR DESCRIPTION
Moved Content Security Policy endpoint under /actions to avoid having to have another route whitelisted in the fastly routing config.