### PR TITLE
Ensure test results recorded for 100% tests

### DIFF
--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -4,6 +4,7 @@ import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.csrf.{CSRFConfig, CSRFToken, CSRFAddToken}
 import com.gu.identity.frontend.logging.Logging
 import com.gu.identity.frontend.models.ReturnUrl
+import com.gu.identity.frontend.mvt.MultiVariantTestAction
 import com.gu.identity.frontend.views.ViewRenderer.{renderSignIn, renderRegisterConfirmation, renderRegister}
 import play.api.i18n.{MessagesApi, I18nSupport}
 import play.api.mvc._

--- a/app/com/gu/identity/frontend/mvt/MultiVariantTestAction.scala
+++ b/app/com/gu/identity/frontend/mvt/MultiVariantTestAction.scala
@@ -16,7 +16,7 @@ object MultiVariantTestRequest {
 
   def apply[A](request: Request[A]): MultiVariantTestRequest[A] = {
     val mvtCookie = MultiVariantTestID.fromRequest(request)
-    val activeTests = mvtCookie.map(id => TestResults.activeTests(id)).getOrElse(Nil).toMap
+    val activeTests = TestResults.activeTests(mvtCookie)
 
     MultiVariantTestRequest[A](mvtCookie, activeTests ++ getTestOverrides(request.queryString), request)
   }

--- a/app/com/gu/identity/frontend/mvt/MultiVariantTestAction.scala
+++ b/app/com/gu/identity/frontend/mvt/MultiVariantTestAction.scala
@@ -13,7 +13,7 @@ object MultiVariantTestRequest {
 
   def apply[A](request: Request[A]): MultiVariantTestRequest[A] = {
     val mvtCookie = getMvtCookie(request)
-    val activeTests = mvtCookie.map(id => MultiVariantTests.activeTests(id)).getOrElse(Nil).toMap
+    val activeTests = mvtCookie.map(id => TestResults.activeTests(id)).getOrElse(Nil).toMap
 
     MultiVariantTestRequest[A](mvtCookie, activeTests ++ getTestOverrides(request.queryString), request)
   }

--- a/app/com/gu/identity/frontend/mvt/MultiVariantTestAction.scala
+++ b/app/com/gu/identity/frontend/mvt/MultiVariantTestAction.scala
@@ -1,7 +1,7 @@
-package com.gu.identity.frontend.controllers
+package com.gu.identity.frontend.mvt
 
-import com.gu.identity.frontend.configuration.{MultiVariantTests, MultiVariantTestVariant, MultiVariantTest}
-import play.api.mvc.{Result, ActionBuilder, WrappedRequest, Request}
+import com.gu.identity.frontend.controllers.NoCache
+import play.api.mvc.{ActionBuilder, Request, Result, WrappedRequest}
 
 import scala.concurrent.Future
 import scala.util.Try

--- a/app/com/gu/identity/frontend/mvt/MultiVariantTestAction.scala
+++ b/app/com/gu/identity/frontend/mvt/MultiVariantTestAction.scala
@@ -7,7 +7,7 @@ import scala.concurrent.Future
 
 case class MultiVariantTestRequest[A](
     mvtCookie: Option[MultiVariantTestID],
-    activeTests: Map[MultiVariantTest, MultiVariantTestVariant],
+    activeTests: ActiveMultiVariantTests,
     request: Request[A])
   extends WrappedRequest[A](request)
 

--- a/app/com/gu/identity/frontend/mvt/MultiVariantTestID.scala
+++ b/app/com/gu/identity/frontend/mvt/MultiVariantTestID.scala
@@ -1,0 +1,20 @@
+package com.gu.identity.frontend.mvt
+
+import play.api.mvc.RequestHeader
+
+import scala.util.Try
+
+case class MultiVariantTestID(
+    id: Int,
+    maxId: Int = MultiVariantTestID.MAX_ID)
+
+
+object MultiVariantTestID {
+  val MVT_COOKIE_NAME = "GU_mvt_id"
+  val MAX_ID = 899999
+
+  def fromRequest(request: RequestHeader): Option[MultiVariantTestID] =
+    request.cookies.get(MVT_COOKIE_NAME).flatMap { mvtId =>
+      Try(Integer.parseInt(mvtId.value)).toOption
+    }.map(MultiVariantTestID(_))
+}

--- a/app/com/gu/identity/frontend/mvt/MultiVariantTests.scala
+++ b/app/com/gu/identity/frontend/mvt/MultiVariantTests.scala
@@ -114,26 +114,6 @@ case class RuntimeMultiVariantTestVariant(id: String) extends MultiVariantTestVa
 
 object MultiVariantTests {
 
-  object Implicits {
-    import play.api.libs.json._
-
-    implicit val mvtVariantJsonWrites: Writes[MultiVariantTestVariant] = new Writes[MultiVariantTestVariant] {
-      override def writes(o: MultiVariantTestVariant): JsValue = Json.obj(
-        "id" -> o.id
-      )
-    }
-
-    implicit val mvtJsonWrites: Writes[MultiVariantTest] = new Writes[MultiVariantTest] {
-      override def writes(o: MultiVariantTest): JsValue = Json.obj(
-        "name" -> o.name,
-        "audience" -> o.audience,
-        "audienceOffset" -> o.audienceOffset,
-        "isServerSide" -> o.isServerSide,
-        "variants" -> o.variants
-      )
-    }
-  }
-
   val MVT_COOKIE_NAME = "GU_mvt_id"
   val MAX_ID = 899999
 
@@ -143,25 +123,4 @@ object MultiVariantTests {
 
   def allServerSide = allActive.filter(_.isServerSide)
 
-  def isInTest(test: MultiVariantTest, mvtId: Int, maxId: Int = MAX_ID): Boolean = {
-    val minBound = maxId * test.audienceOffset
-    val maxBound = minBound + maxId * test.audience
-
-    minBound < mvtId && mvtId <= maxBound
-  }
-
-  def activeVariantForTest(test: MultiVariantTest, mvtId: Int, maxId: Int = MAX_ID): Option[MultiVariantTestVariant] = {
-    if (isInTest(test, mvtId, maxId))
-      Some(test.variants(mvtId % test.variants.size))
-
-    else None
-  }
-
-  /**
-   * Retrieve active server-side tests and the selected variant for an mvtId.
-   */
-  def activeTests(mvtId: Int, maxId: Int = MAX_ID): Set[(MultiVariantTest, MultiVariantTestVariant)] =
-    allServerSide.flatMap { test =>
-      activeVariantForTest(test, mvtId, maxId).map(test -> _)
-    }
 }

--- a/app/com/gu/identity/frontend/mvt/MultiVariantTests.scala
+++ b/app/com/gu/identity/frontend/mvt/MultiVariantTests.scala
@@ -98,17 +98,12 @@ case object RegisterTestVariantA extends MultiVariantTestVariant { val id = "A" 
 /**
  * Define a MVT at runtime - should only be used for tests.
  */
-case class RuntimeMultiVariantTest(
-  name: String,
-  audience: Double,
-  audienceOffset: Double,
-  isServerSide: Boolean = true,
-  variants: Seq[MultiVariantTestVariant]) extends MultiVariantTest
+private[mvt] trait RuntimeMultiVariantTest extends MultiVariantTest
 
 /**
  * Define a MVT variant at runtime - should only be used for tests.
  */
-case class RuntimeMultiVariantTestVariant(id: String) extends MultiVariantTestVariant
+private[mvt] trait RuntimeMultiVariantTestVariant extends MultiVariantTestVariant
 
 
 

--- a/app/com/gu/identity/frontend/mvt/MultiVariantTests.scala
+++ b/app/com/gu/identity/frontend/mvt/MultiVariantTests.scala
@@ -114,9 +114,6 @@ case class RuntimeMultiVariantTestVariant(id: String) extends MultiVariantTestVa
 
 object MultiVariantTests {
 
-  val MVT_COOKIE_NAME = "GU_mvt_id"
-  val MAX_ID = 899999
-
   def all: Set[MultiVariantTest] = Set(SignInV2Test, RegisterV2Test)
 
   def allActive = all.filter(_.active)

--- a/app/com/gu/identity/frontend/mvt/MultiVariantTests.scala
+++ b/app/com/gu/identity/frontend/mvt/MultiVariantTests.scala
@@ -63,6 +63,12 @@ sealed trait MultiVariantTest {
    * Variants available to the test which will be exposed to user's in the test.
    */
   val variants: Seq[MultiVariantTestVariant]
+
+  /**
+   * Defines a default variant to use when a MVT ID cannot be determined.
+   * Should only be used in 100% tests.
+   */
+  val defaultVariant: Option[MultiVariantTestVariant] = None
 }
 
 
@@ -78,6 +84,7 @@ case object SignInV2Test extends MultiVariantTest {
   val audienceOffset = 0.0
   val isServerSide = true
   val variants = Seq(SignInV2TestVariantA, SignInV2TestVariantB)
+  override val defaultVariant = Some(SignInV2TestVariantA)
 }
 
 case object SignInV2TestVariantA extends MultiVariantTestVariant { val id = "A" }
@@ -90,6 +97,7 @@ case object RegisterV2Test extends MultiVariantTest {
   val audienceOffset = 0.0
   val isServerSide = true
   val variants = Seq(RegisterTestVariantA)
+  override val defaultVariant = Some(RegisterTestVariantA)
 }
 
 case object RegisterTestVariantA extends MultiVariantTestVariant { val id = "A" }

--- a/app/com/gu/identity/frontend/mvt/MultiVariantTests.scala
+++ b/app/com/gu/identity/frontend/mvt/MultiVariantTests.scala
@@ -1,4 +1,4 @@
-package com.gu.identity.frontend.configuration
+package com.gu.identity.frontend.mvt
 
 /**
  * Define a Multi Variant Test for testing different logic on Users to

--- a/app/com/gu/identity/frontend/mvt/TestResults.scala
+++ b/app/com/gu/identity/frontend/mvt/TestResults.scala
@@ -4,16 +4,16 @@ package com.gu.identity.frontend.mvt
 object TestResults {
   import MultiVariantTests._
 
-  def isInTest(test: MultiVariantTest, mvtId: Int, maxId: Int = MAX_ID): Boolean = {
-    val minBound = maxId * test.audienceOffset
-    val maxBound = minBound + maxId * test.audience
+  def isInTest(test: MultiVariantTest, mvtId: MultiVariantTestID): Boolean = {
+    val minBound = mvtId.maxId * test.audienceOffset
+    val maxBound = minBound + mvtId.maxId * test.audience
 
-    minBound < mvtId && mvtId <= maxBound
+    minBound < mvtId.id && mvtId.id <= maxBound
   }
 
-  def activeVariantForTest(test: MultiVariantTest, mvtId: Int, maxId: Int = MAX_ID): Option[MultiVariantTestVariant] = {
-    if (isInTest(test, mvtId, maxId))
-      Some(test.variants(mvtId % test.variants.size))
+  def activeVariantForTest(test: MultiVariantTest, mvtId: MultiVariantTestID): Option[MultiVariantTestVariant] = {
+    if (isInTest(test, mvtId))
+      Some(test.variants(mvtId.id % test.variants.size))
 
     else None
   }
@@ -21,8 +21,8 @@ object TestResults {
   /**
    * Retrieve active server-side tests and the selected variant for an mvtId.
    */
-  def activeTests(mvtId: Int, maxId: Int = MAX_ID): Set[(MultiVariantTest, MultiVariantTestVariant)] =
+  def activeTests(mvtId: MultiVariantTestID): Set[(MultiVariantTest, MultiVariantTestVariant)] =
     allServerSide.flatMap { test =>
-      activeVariantForTest(test, mvtId, maxId).map(test -> _)
+      activeVariantForTest(test, mvtId).map(test -> _)
     }
 }

--- a/app/com/gu/identity/frontend/mvt/TestResults.scala
+++ b/app/com/gu/identity/frontend/mvt/TestResults.scala
@@ -21,8 +21,22 @@ object TestResults {
   /**
    * Retrieve active server-side tests and the selected variant for an mvtId.
    */
-  def activeTests(mvtId: MultiVariantTestID): ActiveMultiVariantTests =
-    allServerSide.flatMap { test =>
-      activeVariantForTest(test, mvtId).map(test -> _)
-    }.toMap
+  def activeTests(mvtId: MultiVariantTestID): ActiveMultiVariantTests = (
+    for {
+      test <- allServerSide
+      variant <- activeVariantForTest(test, mvtId)
+    } yield test -> variant
+  ).toMap
+
+
+  def activeTests(mvtId: Option[MultiVariantTestID]): ActiveMultiVariantTests =
+    mvtId.fold(ifEmpty = activeTestsDefaultVariants)(activeTests)
+
+
+  def activeTestsDefaultVariants: ActiveMultiVariantTests = (
+    for {
+      test <- allServerSide
+      variant <- test.defaultVariant
+    } yield test -> variant
+  ).toMap
 }

--- a/app/com/gu/identity/frontend/mvt/TestResults.scala
+++ b/app/com/gu/identity/frontend/mvt/TestResults.scala
@@ -1,0 +1,28 @@
+package com.gu.identity.frontend.mvt
+
+
+object TestResults {
+  import MultiVariantTests._
+
+  def isInTest(test: MultiVariantTest, mvtId: Int, maxId: Int = MAX_ID): Boolean = {
+    val minBound = maxId * test.audienceOffset
+    val maxBound = minBound + maxId * test.audience
+
+    minBound < mvtId && mvtId <= maxBound
+  }
+
+  def activeVariantForTest(test: MultiVariantTest, mvtId: Int, maxId: Int = MAX_ID): Option[MultiVariantTestVariant] = {
+    if (isInTest(test, mvtId, maxId))
+      Some(test.variants(mvtId % test.variants.size))
+
+    else None
+  }
+
+  /**
+   * Retrieve active server-side tests and the selected variant for an mvtId.
+   */
+  def activeTests(mvtId: Int, maxId: Int = MAX_ID): Set[(MultiVariantTest, MultiVariantTestVariant)] =
+    allServerSide.flatMap { test =>
+      activeVariantForTest(test, mvtId, maxId).map(test -> _)
+    }
+}

--- a/app/com/gu/identity/frontend/mvt/TestResults.scala
+++ b/app/com/gu/identity/frontend/mvt/TestResults.scala
@@ -21,8 +21,8 @@ object TestResults {
   /**
    * Retrieve active server-side tests and the selected variant for an mvtId.
    */
-  def activeTests(mvtId: MultiVariantTestID): Set[(MultiVariantTest, MultiVariantTestVariant)] =
+  def activeTests(mvtId: MultiVariantTestID): ActiveMultiVariantTests =
     allServerSide.flatMap { test =>
       activeVariantForTest(test, mvtId).map(test -> _)
-    }
+    }.toMap
 }

--- a/app/com/gu/identity/frontend/mvt/package.scala
+++ b/app/com/gu/identity/frontend/mvt/package.scala
@@ -3,6 +3,8 @@ package com.gu.identity.frontend
 
 package object mvt {
 
+  type ActiveMultiVariantTests = Map[MultiVariantTest, MultiVariantTestVariant]
+
   object Implicits {
     import play.api.libs.json._
 

--- a/app/com/gu/identity/frontend/mvt/package.scala
+++ b/app/com/gu/identity/frontend/mvt/package.scala
@@ -1,0 +1,26 @@
+package com.gu.identity.frontend
+
+
+package object mvt {
+
+  object Implicits {
+    import play.api.libs.json._
+
+    implicit val mvtVariantJsonWrites: Writes[MultiVariantTestVariant] = new Writes[MultiVariantTestVariant] {
+      override def writes(o: MultiVariantTestVariant): JsValue = Json.obj(
+        "id" -> o.id
+      )
+    }
+
+    implicit val mvtJsonWrites: Writes[MultiVariantTest] = new Writes[MultiVariantTest] {
+      override def writes(o: MultiVariantTest): JsValue = Json.obj(
+        "name" -> o.name,
+        "audience" -> o.audience,
+        "audienceOffset" -> o.audienceOffset,
+        "isServerSide" -> o.isServerSide,
+        "variants" -> o.variants
+      )
+    }
+  }
+
+}

--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -4,6 +4,7 @@ import com.gu.identity.frontend.configuration._
 import com.gu.identity.frontend.csrf.CSRFToken
 import com.gu.identity.frontend.errors.HttpError
 import com.gu.identity.frontend.models.ReturnUrl
+import com.gu.identity.frontend.mvt.{SignInV2TestVariantB, SignInV2Test, MultiVariantTestVariant, MultiVariantTest}
 import com.gu.identity.frontend.views.models._
 import jp.co.bizreach.play2handlebars.HBS
 import play.api.i18n.Messages

--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -1,7 +1,8 @@
 package com.gu.identity.frontend.views.models
 
-import com.gu.identity.frontend.configuration.{MultiVariantTestVariant, MultiVariantTests, MultiVariantTest, Configuration}
+import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.models.Text.{FooterText, HeaderText, LayoutText}
+import com.gu.identity.frontend.mvt.{MultiVariantTests, MultiVariantTestVariant, MultiVariantTest}
 import play.api.i18n.Messages
 import play.api.libs.json.Json
 

--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -2,6 +2,7 @@ package com.gu.identity.frontend.views.models
 
 import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.models.Text.{FooterText, HeaderText, LayoutText}
+import com.gu.identity.frontend.mvt
 import com.gu.identity.frontend.mvt.{MultiVariantTests, MultiVariantTestVariant, MultiVariantTest}
 import play.api.i18n.Messages
 import play.api.libs.json.Json
@@ -44,7 +45,7 @@ case class LayoutViewModel(
 case class JavascriptConfig(omnitureAccount: String, mvtTests: Seq[MultiVariantTest]) {
   self =>
 
-  import MultiVariantTests.Implicits._
+  import mvt.Implicits._
   implicit val jsonWrites = Json.writes[JavascriptConfig]
 
   def toJSON =

--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -3,7 +3,7 @@ package com.gu.identity.frontend.views.models
 import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.models.Text.{FooterText, HeaderText, LayoutText}
 import com.gu.identity.frontend.mvt
-import com.gu.identity.frontend.mvt.{MultiVariantTests, MultiVariantTestVariant, MultiVariantTest}
+import com.gu.identity.frontend.mvt.{ActiveMultiVariantTests, MultiVariantTests, MultiVariantTest}
 import play.api.i18n.Messages
 import play.api.libs.json.Json
 
@@ -78,7 +78,7 @@ object LayoutViewModel {
   def apply(configuration: Configuration)(implicit messages: Messages): LayoutViewModel =
     apply(configuration, Map.empty)
 
-  def apply(configuration: Configuration, activeTests: Iterable[(MultiVariantTest, MultiVariantTestVariant)])(implicit messages: Messages): LayoutViewModel = {
+  def apply(configuration: Configuration, activeTests: ActiveMultiVariantTests)(implicit messages: Messages): LayoutViewModel = {
 
     val config = JavascriptConfig(
       omnitureAccount = configuration.omnitureAccount,
@@ -88,7 +88,7 @@ object LayoutViewModel {
     val runtime = activeTests.headOption.map { _ =>
       JavascriptRuntimeParams(activeTests.map {
         case (key, value) => key.name -> value.id
-      }.toMap)
+      })
     }
 
     val inlinedJSConfig = InlinedJSONResource("id_config", config.toJSONString)

--- a/app/com/gu/identity/frontend/views/models/RegisterConfirmationViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterConfirmationViewModel.scala
@@ -20,7 +20,7 @@ case class RegisterConfirmationViewModel private(
 
 object RegisterConfirmationViewModel {
   def apply(configuration: Configuration, returnUrl: Option[String])(implicit messages: Messages): RegisterConfirmationViewModel = {
-    val layout = LayoutViewModel(configuration, None)
+    val layout = LayoutViewModel(configuration)
     val urlParams = Seq(("returnUrl" -> returnUrl.getOrElse("http://www.theguardian.com")))
 
     RegisterConfirmationViewModel(

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -1,10 +1,11 @@
 package com.gu.identity.frontend.views.models
 
-import com.gu.identity.frontend.configuration.{MultiVariantTestVariant, MultiVariantTest, Configuration}
+import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.controllers.routes
 import com.gu.identity.frontend.csrf.CSRFToken
 import com.gu.identity.frontend.models.{UrlBuilder, ReturnUrl}
 import com.gu.identity.frontend.models.text.RegisterText
+import com.gu.identity.frontend.mvt.{MultiVariantTestVariant, MultiVariantTest}
 import play.api.i18n.Messages
 
 

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -5,7 +5,7 @@ import com.gu.identity.frontend.controllers.routes
 import com.gu.identity.frontend.csrf.CSRFToken
 import com.gu.identity.frontend.models.{UrlBuilder, ReturnUrl}
 import com.gu.identity.frontend.models.text.RegisterText
-import com.gu.identity.frontend.mvt.{MultiVariantTestVariant, MultiVariantTest}
+import com.gu.identity.frontend.mvt._
 import play.api.i18n.Messages
 
 
@@ -36,7 +36,7 @@ object RegisterViewModel {
 
   def apply(
       configuration: Configuration,
-      activeTests: Iterable[(MultiVariantTest, MultiVariantTestVariant)],
+      activeTests: ActiveMultiVariantTests,
       errors: Seq[ErrorViewModel],
       csrfToken: Option[CSRFToken],
       returnUrl: ReturnUrl,

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -1,10 +1,11 @@
 package com.gu.identity.frontend.views.models
 
-import com.gu.identity.frontend.configuration.{MultiVariantTestVariant, MultiVariantTest, Configuration}
+import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.controllers.routes
 import com.gu.identity.frontend.csrf.CSRFToken
 import com.gu.identity.frontend.models.{UrlBuilder, ReturnUrl}
 import com.gu.identity.frontend.models.Text._
+import com.gu.identity.frontend.mvt.{MultiVariantTestVariant, MultiVariantTest}
 import play.api.i18n.Messages
 
 case class SignInViewModel private(

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -5,7 +5,7 @@ import com.gu.identity.frontend.controllers.routes
 import com.gu.identity.frontend.csrf.CSRFToken
 import com.gu.identity.frontend.models.{UrlBuilder, ReturnUrl}
 import com.gu.identity.frontend.models.Text._
-import com.gu.identity.frontend.mvt.{MultiVariantTestVariant, MultiVariantTest}
+import com.gu.identity.frontend.mvt.ActiveMultiVariantTests
 import play.api.i18n.Messages
 
 case class SignInViewModel private(
@@ -36,7 +36,7 @@ case class SignInViewModel private(
 
 
 object SignInViewModel {
-  def apply(configuration: Configuration, activeTests: Iterable[(MultiVariantTest, MultiVariantTestVariant)], csrfToken: Option[CSRFToken], errors: Seq[ErrorViewModel], returnUrl: ReturnUrl, skipConfirmation: Option[Boolean])(implicit messages: Messages): SignInViewModel = {
+  def apply(configuration: Configuration, activeTests: ActiveMultiVariantTests, csrfToken: Option[CSRFToken], errors: Seq[ErrorViewModel], returnUrl: ReturnUrl, skipConfirmation: Option[Boolean])(implicit messages: Messages): SignInViewModel = {
 
     val layout = LayoutViewModel(configuration, activeTests)
     val recaptchaModel : Option[GoogleRecaptchaViewModel] =
@@ -75,7 +75,7 @@ object SignInViewModel {
       None
     }
   }
-  
+
   private def getResources(layout: LayoutViewModel, recaptchaViewModel: Option[GoogleRecaptchaViewModel]): Seq[PageResource with Product] ={
     recaptchaViewModel match {
       case Some(model) =>  layout.resources ++ model.resources

--- a/test/com/gu/identity/frontend/mvt/MultiVariantTestsSpec.scala
+++ b/test/com/gu/identity/frontend/mvt/MultiVariantTestsSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.identity.frontend.mvt
 
-import com.gu.identity.frontend.mvt.MultiVariantTests.{activeVariantForTest, isInTest}
+import com.gu.identity.frontend.mvt.TestResults._
 import org.scalatest.{Matchers, WordSpec}
 
 

--- a/test/com/gu/identity/frontend/mvt/MultiVariantTestsSpec.scala
+++ b/test/com/gu/identity/frontend/mvt/MultiVariantTestsSpec.scala
@@ -6,6 +6,8 @@ import org.scalatest.{Matchers, WordSpec}
 
 class MultiVariantTestsSpec extends WordSpec with Matchers {
 
+  def testMvtID = MultiVariantTestID(_: Int, maxId = 100)
+
   "A Multi Variant Test" when {
 
     "determining whether user is in test" should {
@@ -18,21 +20,21 @@ class MultiVariantTestsSpec extends WordSpec with Matchers {
       )
 
       "yield true when in test" in {
-        isInTest(test, 51, 100) shouldBe true
-        isInTest(test, 60, 100) shouldBe true
+        isInTest(test, testMvtID(51)) shouldBe true
+        isInTest(test, testMvtID(60)) shouldBe true
       }
 
       "yield false when below audience offset" in {
-        isInTest(test, 1, 100) shouldBe false
-        isInTest(test, 50, 100) shouldBe false
+        isInTest(test, testMvtID(1)) shouldBe false
+        isInTest(test, testMvtID(50)) shouldBe false
       }
 
       "yield false when outside of audience participation" in {
-        isInTest(test, 61, 100) shouldBe false
+        isInTest(test, testMvtID(61)) shouldBe false
       }
 
       "yield false when mvt id > max" in {
-        isInTest(test, 101, 100) shouldBe false
+        isInTest(test, testMvtID(101)) shouldBe false
       }
     }
 
@@ -47,11 +49,11 @@ class MultiVariantTestsSpec extends WordSpec with Matchers {
       )
 
       "yield variant when in test" in {
-        activeVariantForTest(test, 51, 100) shouldEqual Some(variant)
+        activeVariantForTest(test, testMvtID(51)) shouldEqual Some(variant)
       }
 
       "yield None when not in test" in {
-        activeVariantForTest(test, 1, 100) shouldEqual None
+        activeVariantForTest(test, testMvtID(1)) shouldEqual None
       }
     }
 
@@ -68,10 +70,10 @@ class MultiVariantTestsSpec extends WordSpec with Matchers {
           variants = Seq(variantA, variantB)
         )
 
-        activeVariantForTest(test, 51, 100) shouldEqual Some(variantB)
-        activeVariantForTest(test, 52, 100) shouldEqual Some(variantA)
-        activeVariantForTest(test, 53, 100) shouldEqual Some(variantB)
-        activeVariantForTest(test, 54, 100) shouldEqual Some(variantA)
+        activeVariantForTest(test, testMvtID(51)) shouldEqual Some(variantB)
+        activeVariantForTest(test, testMvtID(52)) shouldEqual Some(variantA)
+        activeVariantForTest(test, testMvtID(53)) shouldEqual Some(variantB)
+        activeVariantForTest(test, testMvtID(54)) shouldEqual Some(variantA)
       }
 
       "yield correct variant when three variants available" in {
@@ -82,12 +84,12 @@ class MultiVariantTestsSpec extends WordSpec with Matchers {
           variants = Seq(variantA, variantB, variantC)
         )
 
-        activeVariantForTest(test, 51, 100) shouldEqual Some(variantA)
-        activeVariantForTest(test, 52, 100) shouldEqual Some(variantB)
-        activeVariantForTest(test, 53, 100) shouldEqual Some(variantC)
-        activeVariantForTest(test, 54, 100) shouldEqual Some(variantA)
-        activeVariantForTest(test, 55, 100) shouldEqual Some(variantB)
-        activeVariantForTest(test, 56, 100) shouldEqual Some(variantC)
+        activeVariantForTest(test, testMvtID(51)) shouldEqual Some(variantA)
+        activeVariantForTest(test, testMvtID(52)) shouldEqual Some(variantB)
+        activeVariantForTest(test, testMvtID(53)) shouldEqual Some(variantC)
+        activeVariantForTest(test, testMvtID(54)) shouldEqual Some(variantA)
+        activeVariantForTest(test, testMvtID(55)) shouldEqual Some(variantB)
+        activeVariantForTest(test, testMvtID(56)) shouldEqual Some(variantC)
       }
     }
   }

--- a/test/com/gu/identity/frontend/mvt/MultiVariantTestsSpec.scala
+++ b/test/com/gu/identity/frontend/mvt/MultiVariantTestsSpec.scala
@@ -8,11 +8,22 @@ class MultiVariantTestsSpec extends WordSpec with Matchers {
 
   def testMvtID = MultiVariantTestID(_: Int, maxId = 100)
 
+  case class MockedMVT(
+      name: String,
+      audience: Double,
+      audienceOffset: Double,
+      variants: Seq[MultiVariantTestVariant],
+      isServerSide: Boolean = true)
+    extends RuntimeMultiVariantTest
+
+  case class MockedMVTVariant(id: String) extends RuntimeMultiVariantTestVariant
+
+
   "A Multi Variant Test" when {
 
     "determining whether user is in test" should {
 
-      val test = RuntimeMultiVariantTest(
+      val test = MockedMVT(
         name = "test",
         audience = 0.1,
         audienceOffset = 0.5,
@@ -39,9 +50,9 @@ class MultiVariantTestsSpec extends WordSpec with Matchers {
     }
 
     "it has only a single variant" should {
-      val variant = RuntimeMultiVariantTestVariant("A")
+      val variant = MockedMVTVariant("A")
 
-      val test = RuntimeMultiVariantTest(
+      val test = MockedMVT(
         name = "test",
         audience = 0.1,
         audienceOffset = 0.5,
@@ -58,12 +69,12 @@ class MultiVariantTestsSpec extends WordSpec with Matchers {
     }
 
     "it has multiple variants" should {
-      val variantA = RuntimeMultiVariantTestVariant("A")
-      val variantB = RuntimeMultiVariantTestVariant("B")
-      val variantC = RuntimeMultiVariantTestVariant("C")
+      val variantA = MockedMVTVariant("A")
+      val variantB = MockedMVTVariant("B")
+      val variantC = MockedMVTVariant("C")
 
       "yield correct variant when two variants available" in {
-        val test = RuntimeMultiVariantTest(
+        val test = MockedMVT(
           name = "test",
           audience = 0.1,
           audienceOffset = 0.5,
@@ -77,7 +88,7 @@ class MultiVariantTestsSpec extends WordSpec with Matchers {
       }
 
       "yield correct variant when three variants available" in {
-        val test = RuntimeMultiVariantTest(
+        val test = MockedMVT(
           name = "test",
           audience = 0.1,
           audienceOffset = 0.5,

--- a/test/com/gu/identity/frontend/mvt/MultiVariantTestsSpec.scala
+++ b/test/com/gu/identity/frontend/mvt/MultiVariantTestsSpec.scala
@@ -1,7 +1,7 @@
-package com.gu.identity.frontend.configuration
+package com.gu.identity.frontend.mvt
 
+import com.gu.identity.frontend.mvt.MultiVariantTests.{activeVariantForTest, isInTest}
 import org.scalatest.{Matchers, WordSpec}
-import MultiVariantTests.{activeVariantForTest, isInTest}
 
 
 class MultiVariantTestsSpec extends WordSpec with Matchers {


### PR DESCRIPTION
Fixes an issue on PROD where test results may be omitted when a `GU_mvt_id` cookie is not present by defining default variants on tests with 100% participation.

Also addresses some tech debt raised in #53:
- Moved all MVT stuff to `mvt` package
- Moved a lot of code out of `MultiVariantTests.scala` so that now it only contains Test definitions
- Created `ActiveMultiVariantTests` type definition for active test results instead of `Iterable[(MultiVariantTest, MultiVariantTestVariant)]` for better readability