### PR TITLE
Fix intermittent Facebook OAuthException

### DIFF
--- a/functional-tests/src/test/scala/util/user/FacebookTestUser.scala
+++ b/functional-tests/src/test/scala/util/user/FacebookTestUser.scala
@@ -49,7 +49,6 @@ object FacebookTestUserService {
         case 200 => response
         case _ => {
           logger.warn(s"Repeating GET call. Attempt number ... ${count-1}")
-          Thread.sleep(2000)
           repeater(url, count - 1)
         }
       }


### PR DESCRIPTION
@jamespamplin 

Fixes the [following](http://build.capi.gutools.co.uk/viewLog.html?buildId=1053&tab=buildResultsDiv&buildTypeId=Identity_FunctionalTests_IdentityFrontend) error that sometimes occurs when hitting Facebook Graph API:

```
{"error":{"message":"An unknown error has occurred.","type":"OAuthException","code":1,"fbtrace_id":"ACcRWVUlPbe"}}
```

by retrying the call up to 5 times. 

Implemented using tail recursion.