### PR TITLE
Retry on synchronous call timeout

### DIFF
--- a/functional-tests/src/test/scala/util/user/FacebookTestUser.scala
+++ b/functional-tests/src/test/scala/util/user/FacebookTestUser.scala
@@ -47,7 +47,7 @@ object FacebookTestUserService {
       if (count == 0)
         throw new FaceBookTestUserException("Could not query Facebook Graph API.")
       else response.toOption.filter(_.status == OK).getOrElse {
-        logger.warn(s"Repeating GET call. Remaning attempts ... ${count-1}")
+        logger.warn(s"Repeating GET call. Remaining attempts ... ${count-1}")
         repeater(url, count - 1)
       }
     }


### PR DESCRIPTION
@jamespamplin 

Solves [Future timeout](http://build.capi.gutools.co.uk/viewLog.html?buildId=1089&tab=buildResultsDiv&buildTypeId=Identity_FunctionalTests_IdentityFrontend) issue when calling Facebook API:

```
java.util.concurrent.TimeoutException: Futures timed out after [5 seconds]
```