### PR TITLE
Return url tech debt

### DIFF
--- a/app/com/gu/identity/frontend/configuration/Configuration.scala
+++ b/app/com/gu/identity/frontend/configuration/Configuration.scala
@@ -11,6 +11,8 @@ case class Configuration(
 
   identityProfileBaseUrl: String,
 
+  identityDefaultReturnUrl: String,
+
   identityFederationApiHost: String,
 
   omnitureAccount: String,
@@ -42,6 +44,8 @@ object Configuration {
 
       identityProfileBaseUrl = getString("identity.frontend.baseUrl"),
 
+      identityDefaultReturnUrl = getString("identity.frontend.defaultReturnUrl"),
+
       omnitureAccount = getString("omniture.account"),
 
       googleRecaptchaSiteKey = getString("google.recaptcha.site"),
@@ -64,6 +68,8 @@ object Configuration {
     identityFederationApiHost = "https://oauth.code.dev-theguardian.com",
 
     identityProfileBaseUrl = "https://profile.code.dev-theguardian.com",
+
+    identityDefaultReturnUrl = "http://www.theguardian.com",
 
     omnitureAccount = "--test-omniture-account--",
 

--- a/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
+++ b/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
@@ -38,7 +38,7 @@ class ApplicationComponents(context: Context) extends BuiltInComponentsFromConte
   lazy val cspReporterController = new CSPViolationReporter()
   lazy val googleRecaptchaServiceHandler = new GoogleRecaptchaServiceHandler(wsClient, frontendConfiguration)
   lazy val googleRecaptchaCheck = new GoogleRecaptchaCheck(googleRecaptchaServiceHandler)
-  lazy val signinController = new SigninAction(identityService, messagesApi, csrfConfig, googleRecaptchaCheck)
+  lazy val signinController = new SigninAction(identityService, messagesApi, csrfConfig, googleRecaptchaCheck, frontendConfiguration)
   lazy val registerController = new RegisterAction(identityService, messagesApi, frontendConfiguration, csrfConfig)
   lazy val assets = new controllers.Assets(httpErrorHandler)
 

--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -16,7 +16,7 @@ class Application (configuration: Configuration, val messagesApi: MessagesApi, c
   }
 
   def signIn(error: Seq[String], returnUrl: Option[String], skipConfirmation: Option[Boolean]) = (CSRFAddToken(csrfConfig) andThen MultiVariantTestAction) { req =>
-    val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"))
+    val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"), configuration)
 
     val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
 
@@ -24,7 +24,7 @@ class Application (configuration: Configuration, val messagesApi: MessagesApi, c
   }
 
   def register(error: Seq[String], returnUrl: Option[String], skipConfirmation: Option[Boolean], group: Option[String]) = (CSRFAddToken(csrfConfig) andThen MultiVariantTestAction) { req =>
-    val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"))
+    val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"), configuration)
 
     val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
 

--- a/app/com/gu/identity/frontend/controllers/RegisterAction.scala
+++ b/app/com/gu/identity/frontend/controllers/RegisterAction.scala
@@ -64,7 +64,7 @@ class RegisterAction(identityService: IdentityService, val messagesApi: Messages
         Future.successful(SeeOther(routes.Application.register(errors).url))},
       successForm => {
         val trackingData = TrackingData(request, successForm.returnUrl)
-        val returnUrl = ReturnUrl(successForm.returnUrl, request.headers.get("Referer"))
+        val returnUrl = ReturnUrl(successForm.returnUrl, request.headers.get("Referer"), config)
         identityService.registerThenSignIn(successForm, clientIp, trackingData).map {
           case Left(errors) =>
             redirectToRegisterPageWithErrors(errors, returnUrl, successForm.skipConfirmation, successForm.group)

--- a/app/com/gu/identity/frontend/controllers/SigninAction.scala
+++ b/app/com/gu/identity/frontend/controllers/SigninAction.scala
@@ -37,7 +37,7 @@ class SigninAction(identityService: IdentityService, val messagesApi: MessagesAp
   def signIn = CSRFCheck(csrfConfig, handleCSRFError).async { implicit request =>
     val formParams = signInFormBody.bindFromRequest()(request).get
     val trackingData = TrackingData(request, formParams.returnUrl)
-    val returnUrl = ReturnUrl(formParams.returnUrl, request.headers.get("Referer"))
+    val returnUrl = ReturnUrl(formParams.returnUrl, request.headers.get("Referer"), config)
 
     def googleRecaptchaError = Future.successful(
       redirectToSigninPageWithErrorsAndEmail(Seq(ServiceBadRequest("error-captcha")), returnUrl, formParams.skipConfirmation)

--- a/app/com/gu/identity/frontend/controllers/SigninAction.scala
+++ b/app/com/gu/identity/frontend/controllers/SigninAction.scala
@@ -1,5 +1,6 @@
 package com.gu.identity.frontend.controllers
 
+import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.csrf.{CSRFConfig, CSRFCheck}
 import com.gu.identity.frontend.logging.Logging
 import com.gu.identity.frontend.models.{ReturnUrl, TrackingData}
@@ -18,7 +19,7 @@ import play.api.i18n.Messages.Implicits._
 /**
  * Form actions controller
  */
-class SigninAction(identityService: IdentityService, val messagesApi: MessagesApi, csrfConfig: CSRFConfig, googleRecaptchaCheck: GoogleRecaptchaCheck) extends Controller with Logging with I18nSupport {
+class SigninAction(identityService: IdentityService, val messagesApi: MessagesApi, csrfConfig: CSRFConfig, googleRecaptchaCheck: GoogleRecaptchaCheck, config: Configuration) extends Controller with Logging with I18nSupport {
 
   case class SignInRequest(email: Option[String], password: Option[String], rememberMe: Boolean, returnUrl: Option[String], skipConfirmation: Option[Boolean], googleRecaptchaResponse: Option[String])
 

--- a/app/com/gu/identity/frontend/models/ReturnUrl.scala
+++ b/app/com/gu/identity/frontend/models/ReturnUrl.scala
@@ -1,17 +1,21 @@
 package com.gu.identity.frontend.models
 
 import java.net.URI
+import com.gu.identity.frontend.configuration.Configuration
+
 import scala.util.Try
 
 case class ReturnUrl(url: String)
 
 object ReturnUrl {
 
-  val default = ReturnUrl("http://www.theguardian.com")
   val domains = List(".theguardian.com", ".code.dev-theguardian.com", ".thegulocal.com")
   val invalidUrlPaths = List("/signin", "/register", "/register/confirm")
 
-  def apply(returnUrl: Option[String], referer: Option[String]): ReturnUrl = {
+  def apply(returnUrl: Option[String], referer: Option[String], configuration: Configuration): ReturnUrl = {
+
+    val default = ReturnUrl(configuration.identityDefaultReturnUrl)
+
     returnUrl.map(ReturnUrl(_))
       .orElse(referer.map(ReturnUrl(_)))
       .filter(validDomain(_))

--- a/app/com/gu/identity/frontend/models/ReturnUrl.scala
+++ b/app/com/gu/identity/frontend/models/ReturnUrl.scala
@@ -9,11 +9,13 @@ object ReturnUrl {
 
   val default = ReturnUrl("http://www.theguardian.com")
   val domains = List(".theguardian.com", ".code.dev-theguardian.com", ".thegulocal.com")
+  val invalidUrlPaths = List("/signin", "/register", "/register/confirm")
 
   def apply(returnUrl: Option[String], referer: Option[String]): ReturnUrl = {
     returnUrl.map(ReturnUrl(_))
       .orElse(referer.map(ReturnUrl(_)))
       .filter(validDomain(_))
+      .filter(validUrlPath(_))
       .getOrElse(default)
   }
 
@@ -22,6 +24,12 @@ object ReturnUrl {
     domains.exists(s".$hostname".endsWith(_))
   }
 
+  def validUrlPath(returnUrl: ReturnUrl): Boolean = {
+    val urlPath = path(returnUrl)
+    !invalidUrlPaths.contains(urlPath)
+  }
+
   def host(returnUrl: ReturnUrl): String = Try(new URI(returnUrl.url)).map(_.getHost).getOrElse("")
 
+  def path(returnUrl: ReturnUrl): String = Try(new URI(returnUrl.url)).map(_.getPath).getOrElse("")
 }

--- a/app/com/gu/identity/frontend/models/ReturnUrl.scala
+++ b/app/com/gu/identity/frontend/models/ReturnUrl.scala
@@ -3,9 +3,9 @@ package com.gu.identity.frontend.models
 import java.net.URI
 import com.gu.identity.frontend.configuration.Configuration
 
-import scala.util.Try
-
-case class ReturnUrl(url: String)
+case class ReturnUrl(uri: URI) {
+  lazy val url: String = uri.toString
+}
 
 object ReturnUrl {
 
@@ -14,10 +14,10 @@ object ReturnUrl {
 
   def apply(returnUrl: Option[String], referer: Option[String], configuration: Configuration): ReturnUrl = {
 
-    val default = ReturnUrl(configuration.identityDefaultReturnUrl)
+    val default = ReturnUrl(new URI(configuration.identityDefaultReturnUrl))
 
-    returnUrl.map(ReturnUrl(_))
-      .orElse(referer.map(ReturnUrl(_)))
+    returnUrl.map(url => ReturnUrl(new URI(url)))
+      .orElse(referer.map(url => ReturnUrl(new URI(url))))
       .filter(validDomain(_))
       .filter(validUrlPath(_))
       .getOrElse(default)
@@ -33,7 +33,7 @@ object ReturnUrl {
     !invalidUrlPaths.contains(urlPath)
   }
 
-  def host(returnUrl: ReturnUrl): String = Try(new URI(returnUrl.url)).map(_.getHost).getOrElse("")
+  def host(returnUrl: ReturnUrl): String = returnUrl.uri.getHost
 
-  def path(returnUrl: ReturnUrl): String = Try(new URI(returnUrl.url)).map(_.getPath).getOrElse("")
+  def path(returnUrl: ReturnUrl): String = returnUrl.uri.getPath
 }

--- a/app/com/gu/identity/frontend/models/UrlBuilder.scala
+++ b/app/com/gu/identity/frontend/models/UrlBuilder.scala
@@ -27,11 +27,16 @@ object UrlBuilder {
 
 
   def apply(baseUrl: String, returnUrl: ReturnUrl, skipConfirmation: Option[Boolean]): String = {
-    val params = Seq(
-      Some("returnUrl" -> returnUrl.url),
-      skipConfirmation.map("skipConfirmation" -> _.toString)
-    ).flatten
+    val params = Seq(skipConfirmation.map("skipConfirmation" -> _.toString)).flatten
 
-    apply(baseUrl, params)
+    if (isDefaultReturnUrl(returnUrl)) {
+      apply(baseUrl, params)
+    } else {
+      apply(baseUrl, params ++ Seq("returnUrl" -> returnUrl.url))
+    }
+  }
+
+  private def isDefaultReturnUrl(returnUrl: ReturnUrl): Boolean = {
+    returnUrl.url == "http://www.theguardian.com"
   }
 }

--- a/conf/CODE.conf
+++ b/conf/CODE.conf
@@ -6,6 +6,8 @@ identity.frontend.cookieDomain=code.dev-theguardian.com
 
 identity.frontend.baseUrl="https://profile.code.dev-theguardian.com"
 
+identity.frontend.defaultReturnUrl="http://m.code.dev-theguardian.com"
+
 identity.federation.api.host="https://oauth.code.dev-theguardian.com"
 
 omniture.account="guardiangudev-code"

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -6,6 +6,8 @@ identity.frontend.cookieDomain=thegulocal.com
 
 identity.frontend.baseUrl="https://profile.thegulocal.com"
 
+identity.frontend.defaultReturnUrl="http://www.theguardian.com"
+
 identity.federation.api.host="https://oauth.code.dev-theguardian.com"
 
 omniture.account="guardiangudev-code"

--- a/conf/PROD.conf
+++ b/conf/PROD.conf
@@ -6,6 +6,8 @@ identity.frontend.cookieDomain=theguardian.com
 
 identity.frontend.baseUrl="https://profile.theguardian.com"
 
+identity.frontend.defaultReturnUrl="http://www.theguardian.com"
+
 identity.federation.api.host="https://oauth.theguardian.com"
 
 omniture.account="guardiangu-network"

--- a/test/com/gu/identity/frontend/controllers/SigninActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/SigninActionSpec.scala
@@ -1,5 +1,6 @@
 package com.gu.identity.frontend.controllers
 
+import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.csrf.CSRFConfig
 import com.gu.identity.frontend.models.TrackingData
 import com.gu.identity.frontend.services._
@@ -23,7 +24,8 @@ class SigninActionSpec extends PlaySpec with MockitoSugar {
     val mockIdentityService = mock[IdentityService]
     val messages = mock[MessagesApi]
     val mockGoogleRecaptchaCheck = new MockRecaptchaCheck()
-    lazy val controller = new SigninAction(mockIdentityService, messages, fakeCsrfConfig, mockGoogleRecaptchaCheck)
+    val config = Configuration.testConfiguration
+    lazy val controller = new SigninAction(mockIdentityService, messages, fakeCsrfConfig, mockGoogleRecaptchaCheck, config)
   }
 
   trait WithFailedRecaptchaCheck extends WithControllerMockedDependencies{

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -32,4 +32,12 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
     ReturnUrl(None, Some("http://profile-origin2.thegulocal.com")) should be(ReturnUrl("http://profile-origin2.thegulocal.com"))
   }
 
+  it should "Determine valid url path" in {
+    validUrlPath(ReturnUrl("http://theguardian.com/signin")) should be(false)
+    validUrlPath(ReturnUrl("http://theguardian.com/register")) should be(false)
+    validUrlPath(ReturnUrl("http://theguardian.com/register/confirm")) should be(false)
+    validUrlPath(ReturnUrl("http://theguardian.com")) should be(true)
+    validUrlPath(ReturnUrl("http://theguardian.com/politics")) should be(true)
+  }
+
 }

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -1,5 +1,7 @@
 package com.gu.identity.frontend.models
 
+import java.net.URI
+
 import com.gu.identity.frontend.configuration.Configuration
 import org.scalatest.{Matchers, FlatSpec}
 
@@ -11,43 +13,43 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
 
   it should "determine valid domain" in {
 
-    validDomain(ReturnUrl("http://www.theguardian.com")) should be(true)
-    validDomain(ReturnUrl("http://jobs.theguardian.com")) should be(true)
-    validDomain(ReturnUrl("http://code.dev-theguardian.com")) should be(true)
-    validDomain(ReturnUrl("http://thegulocal.com")) should be(true)
-    validDomain(ReturnUrl("http://baddomain.com")) should be(false)
+    validDomain(ReturnUrl(new URI("http://www.theguardian.com"))) should be(true)
+    validDomain(ReturnUrl(new URI("http://jobs.theguardian.com"))) should be(true)
+    validDomain(ReturnUrl(new URI("http://code.dev-theguardian.com"))) should be(true)
+    validDomain(ReturnUrl(new URI("http://thegulocal.com"))) should be(true)
+    validDomain(ReturnUrl(new URI("http://baddomain.com"))) should be(false)
   }
 
   it should "construct return url" in {
 
-    ReturnUrl(Some("http://www.theguardian.com/uk"), None, config) should be(ReturnUrl("http://www.theguardian.com/uk"))
-    ReturnUrl(None, Some("http://www.theguardian.com/uk"), config) should be(ReturnUrl("http://www.theguardian.com/uk"))
+    ReturnUrl(Some("http://www.theguardian.com/uk"), None, config) should be(ReturnUrl(new URI("http://www.theguardian.com/uk")))
+    ReturnUrl(None, Some("http://www.theguardian.com/uk"), config) should be(ReturnUrl(new URI("http://www.theguardian.com/uk")))
 
-    ReturnUrl(Some("http://jobs.theguardian.com/apply"), None, config) should be(ReturnUrl("http://jobs.theguardian.com/apply"))
-    ReturnUrl(None, Some("http://jobs.theguardian.com/apply"), config) should be(ReturnUrl("http://jobs.theguardian.com/apply"))
+    ReturnUrl(Some("http://jobs.theguardian.com/apply"), None, config) should be(ReturnUrl(new URI("http://jobs.theguardian.com/apply")))
+    ReturnUrl(None, Some("http://jobs.theguardian.com/apply"), config) should be(ReturnUrl(new URI("http://jobs.theguardian.com/apply")))
 
-    ReturnUrl(None, Some("http://www.thegulocal.com/"), config) should be(ReturnUrl("http://www.thegulocal.com/"))
-    ReturnUrl(None, None, config) should be(ReturnUrl("http://www.theguardian.com"))
+    ReturnUrl(None, Some("http://www.thegulocal.com/"), config) should be(ReturnUrl(new URI("http://www.thegulocal.com/")))
+    ReturnUrl(None, None, config) should be(ReturnUrl(new URI("http://www.theguardian.com")))
 
-    ReturnUrl(Some("http://baddomain.com"), None, config) should be(ReturnUrl("http://www.theguardian.com"))
-    ReturnUrl(None, Some("http://baddomain.com"), config) should be(ReturnUrl("http://www.theguardian.com"))
+    ReturnUrl(Some("http://baddomain.com"), None, config) should be(ReturnUrl(new URI("http://www.theguardian.com")))
+    ReturnUrl(None, Some("http://baddomain.com"), config) should be(ReturnUrl(new URI("http://www.theguardian.com")))
 
-    ReturnUrl(None, Some("http://profile-origin2.thegulocal.com"), config) should be(ReturnUrl("http://profile-origin2.thegulocal.com"))
+    ReturnUrl(None, Some("http://profile-origin2.thegulocal.com"), config) should be(ReturnUrl(new URI("http://profile-origin2.thegulocal.com")))
   }
 
   it should "Determine valid url path" in {
-    validUrlPath(ReturnUrl("http://theguardian.com/signin")) should be(false)
-    validUrlPath(ReturnUrl("http://theguardian.com/register")) should be(false)
-    validUrlPath(ReturnUrl("http://theguardian.com/register/confirm")) should be(false)
-    validUrlPath(ReturnUrl("http://theguardian.com")) should be(true)
-    validUrlPath(ReturnUrl("http://theguardian.com/politics")) should be(true)
+    validUrlPath(ReturnUrl(new URI("http://theguardian.com/signin"))) should be(false)
+    validUrlPath(ReturnUrl(new URI("http://theguardian.com/register"))) should be(false)
+    validUrlPath(ReturnUrl(new URI("http://theguardian.com/register/confirm"))) should be(false)
+    validUrlPath(ReturnUrl(new URI("http://theguardian.com"))) should be(true)
+    validUrlPath(ReturnUrl(new URI("http://theguardian.com/politics"))) should be(true)
   }
-  
+
   it should "Use the default return url" in {
     val codeConfig = config.copy(identityDefaultReturnUrl = "http://m.code.dev-theguardian.com")
 
-    ReturnUrl(None, None, codeConfig) should be(ReturnUrl("http://m.code.dev-theguardian.com"))
+    ReturnUrl(None, None, codeConfig) should be(ReturnUrl(new URI("http://m.code.dev-theguardian.com")))
 
-    ReturnUrl(None, None, config) should be(ReturnUrl("http://www.theguardian.com"))
+    ReturnUrl(None, None, config) should be(ReturnUrl(new URI("http://www.theguardian.com")))
   }
 }

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -1,10 +1,13 @@
 package com.gu.identity.frontend.models
 
+import com.gu.identity.frontend.configuration.Configuration
 import org.scalatest.{Matchers, FlatSpec}
 
 class ReturnUrlSpec extends FlatSpec with Matchers {
 
   import ReturnUrl._
+
+  val config = Configuration.testConfiguration
 
   it should "determine valid domain" in {
 
@@ -17,19 +20,19 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
 
   it should "construct return url" in {
 
-    ReturnUrl(Some("http://www.theguardian.com/uk"), None) should be(ReturnUrl("http://www.theguardian.com/uk"))
-    ReturnUrl(None, Some("http://www.theguardian.com/uk")) should be(ReturnUrl("http://www.theguardian.com/uk"))
+    ReturnUrl(Some("http://www.theguardian.com/uk"), None, config) should be(ReturnUrl("http://www.theguardian.com/uk"))
+    ReturnUrl(None, Some("http://www.theguardian.com/uk"), config) should be(ReturnUrl("http://www.theguardian.com/uk"))
 
-    ReturnUrl(Some("http://jobs.theguardian.com/apply"), None) should be(ReturnUrl("http://jobs.theguardian.com/apply"))
-    ReturnUrl(None, Some("http://jobs.theguardian.com/apply")) should be(ReturnUrl("http://jobs.theguardian.com/apply"))
+    ReturnUrl(Some("http://jobs.theguardian.com/apply"), None, config) should be(ReturnUrl("http://jobs.theguardian.com/apply"))
+    ReturnUrl(None, Some("http://jobs.theguardian.com/apply"), config) should be(ReturnUrl("http://jobs.theguardian.com/apply"))
 
-    ReturnUrl(None, Some("http://www.thegulocal.com/")) should be(ReturnUrl("http://www.thegulocal.com/"))
-    ReturnUrl(None, None) should be(ReturnUrl("http://www.theguardian.com"))
+    ReturnUrl(None, Some("http://www.thegulocal.com/"), config) should be(ReturnUrl("http://www.thegulocal.com/"))
+    ReturnUrl(None, None, config) should be(ReturnUrl("http://www.theguardian.com"))
 
-    ReturnUrl(Some("http://baddomain.com"), None) should be(ReturnUrl("http://www.theguardian.com"))
-    ReturnUrl(None, Some("http://baddomain.com")) should be(ReturnUrl("http://www.theguardian.com"))
+    ReturnUrl(Some("http://baddomain.com"), None, config) should be(ReturnUrl("http://www.theguardian.com"))
+    ReturnUrl(None, Some("http://baddomain.com"), config) should be(ReturnUrl("http://www.theguardian.com"))
 
-    ReturnUrl(None, Some("http://profile-origin2.thegulocal.com")) should be(ReturnUrl("http://profile-origin2.thegulocal.com"))
+    ReturnUrl(None, Some("http://profile-origin2.thegulocal.com"), config) should be(ReturnUrl("http://profile-origin2.thegulocal.com"))
   }
 
   it should "Determine valid url path" in {
@@ -39,5 +42,12 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
     validUrlPath(ReturnUrl("http://theguardian.com")) should be(true)
     validUrlPath(ReturnUrl("http://theguardian.com/politics")) should be(true)
   }
+  
+  it should "Use the default return url" in {
+    val codeConfig = config.copy(identityDefaultReturnUrl = "http://m.code.dev-theguardian.com")
 
+    ReturnUrl(None, None, codeConfig) should be(ReturnUrl("http://m.code.dev-theguardian.com"))
+
+    ReturnUrl(None, None, config) should be(ReturnUrl("http://www.theguardian.com"))
+  }
 }


### PR DESCRIPTION
Addresses 3 tech debt issues with return url:

- If the return url is the default return url (i.e. http://www.theguardian.com) it is not included as a query param in the url to make the url cleaner

- Ignore return url and referrer header if they are the url for the sign in page, register page or register confirmation page.

- The default return url should be environment specific
