### PR TITLE
Fix issue where asset build triggers twice

### DIFF
--- a/frontend.sbt
+++ b/frontend.sbt
@@ -4,8 +4,8 @@
 
 // Configure npm commands to build frontend assets
 buildCommands in build in Assets := Seq(
-  BuildCommand("build-css", "npm run build-css -s", excludeFilter = Some("*.js" | "*.hbs")),
-  BuildCommand("build-js", "npm run build-js -s", includeFilter = Some("*.js"))
+  BuildCommand("build-css", "npm run build-css -s", excludeFilter = Some("*.js" | "*.js.map" | "*.hbs")),
+  BuildCommand("build-js", "npm run build-js -s", includeFilter = Some("*.js" | "*.js.map"))
 )
 
 pipelineStages := Seq(digest)

--- a/project/FrontendBuildPlugin.scala
+++ b/project/FrontendBuildPlugin.scala
@@ -91,6 +91,10 @@ object FrontendBuildPlugin extends AutoPlugin {
       val filesRead = (sourceDir ** fileFilter).get
       val filesWritten = (targetDir ** fileFilter).get
 
+      // Note:  Use the sbt command `last` to see debug logs
+      log.debug(s"[${op.id}] Success. Read files: ${filesRead.mkString(", ")}")
+      log.debug(s"[${op.id}] Success. Wrote files: ${filesWritten.mkString(", ")}")
+
       OpSuccess(filesRead.toSet, filesWritten.toSet)
     }
 


### PR DESCRIPTION
- Fixes issue where both build-css and build-js commands run whenever a
  css file or a js file are modified. Caused by the CSS task incorrectly
  including the built JS source map as its task output, causing its
  incremental cache to invalidate.
- Also added debug logs for easier debugging of task outputs. Use `last`
  in sbt to see debug logs.