### PR TITLE
Fix missing fields when Registering

### DIFF
--- a/app/com/gu/identity/frontend/services/IdentityServiceRequestHandler.scala
+++ b/app/com/gu/identity/frontend/services/IdentityServiceRequestHandler.scala
@@ -24,6 +24,7 @@ class IdentityServiceRequestHandler (ws: WSClient) extends IdentityClientRequest
 
   implicit val registerRequestBodyPublicFieldsFormat = Json.format[RegisterRequestBodyPublicFields]
   implicit val registerRequestBodyPrivateFieldsFormat = Json.format[RegisterRequestBodyPrivateFields]
+  implicit val registerRequestBodyStatusFieldsFormat = Json.format[RegisterRequestBodyStatusFields]
   implicit val registerRequestBodyFormat = Json.format[RegisterRequestBody]
 
   implicit val registerResponseUserGroupsFormat = Json.format[RegisterResponseUserGroups]
@@ -72,7 +73,7 @@ class IdentityServiceRequestHandler (ws: WSClient) extends IdentityClientRequest
           logger.warn(s"Unexpected response from server: ${response.status} ${response.statusText} ${response.body}")
           Left(Seq(GatewayError("Unexpected response from server")))
         }
-      
+
     case r: RegisterApiRequest =>
       response.json.asOpt[RegisterResponse]
         .map(Right.apply)

--- a/app/com/gu/identity/service/client/ApiRequests.scala
+++ b/app/com/gu/identity/service/client/ApiRequests.scala
@@ -85,4 +85,4 @@ case class RegisterRequestBody(primaryEmailAddress: String, password: String, pu
 
 case class RegisterRequestBodyPublicFields(username: String)
 
-case class RegisterRequestBodyPrivateFields(firstName: String, lastName: String, receiveGnmMarketing: Boolean, receive3rdPartyMarketing: Boolean,  registrationIp: String)
+case class RegisterRequestBodyPrivateFields(firstName: String, secondName: String, receiveGnmMarketing: Boolean, receive3rdPartyMarketing: Boolean, registrationIp: String)

--- a/app/com/gu/identity/service/client/ApiRequests.scala
+++ b/app/com/gu/identity/service/client/ApiRequests.scala
@@ -68,11 +68,13 @@ object RegisterApiRequest {
         request.password,
         RegisterRequestBodyPublicFields(request.username),
         RegisterRequestBodyPrivateFields(
-          request.firstName,
-          request.lastName,
-          request.receiveGnmMarketing,
-          request.receive3rdPartyMarketing,
-          clientIp.ip
+          firstName = request.firstName,
+          secondName = request.lastName,
+          registrationIp = clientIp.ip
+        ),
+        RegisterRequestBodyStatusFields(
+          receiveGnmMarketing = request.receiveGnmMarketing,
+          receive3rdPartyMarketing = request.receive3rdPartyMarketing
         )
       )),
       extraHeaders = ApiRequest.apiKeyHeaders,
@@ -81,8 +83,22 @@ object RegisterApiRequest {
   }
 }
 
-case class RegisterRequestBody(primaryEmailAddress: String, password: String, publicFields: RegisterRequestBodyPublicFields, privateFields: RegisterRequestBodyPrivateFields) extends ApiRequestBody
+case class RegisterRequestBody(
+    primaryEmailAddress: String,
+    password: String,
+    publicFields: RegisterRequestBodyPublicFields,
+    privateFields: RegisterRequestBodyPrivateFields,
+    statusFields: RegisterRequestBodyStatusFields)
+  extends ApiRequestBody
 
-case class RegisterRequestBodyPublicFields(username: String)
+case class RegisterRequestBodyPublicFields(
+    username: String)
 
-case class RegisterRequestBodyPrivateFields(firstName: String, secondName: String, receiveGnmMarketing: Boolean, receive3rdPartyMarketing: Boolean, registrationIp: String)
+case class RegisterRequestBodyPrivateFields(
+    firstName: String,
+    secondName: String,
+    registrationIp: String)
+
+case class RegisterRequestBodyStatusFields(
+    receiveGnmMarketing: Boolean,
+    receive3rdPartyMarketing: Boolean)

--- a/test/com/gu/identity/frontend/services/IdentityServiceRequestHandlerSpec.scala
+++ b/test/com/gu/identity/frontend/services/IdentityServiceRequestHandlerSpec.scala
@@ -1,11 +1,12 @@
 package com.gu.identity.frontend.services
 
-import com.gu.identity.service.client.{RegisterRequestBodyPrivateFields, RegisterRequestBodyPublicFields, RegisterRequestBody, AuthenticateCookiesRequestBody}
+import com.gu.identity.service.client._
 import org.scalatest.mock.MockitoSugar
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{OptionValues, Matchers, WordSpec}
+import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 
-class IdentityServiceRequestHandlerSpec extends WordSpec with Matchers with MockitoSugar {
+class IdentityServiceRequestHandlerSpec extends WordSpec with Matchers with MockitoSugar with OptionValues {
 
   val mockWSClient = mock[WSClient]
 
@@ -37,12 +38,20 @@ class IdentityServiceRequestHandlerSpec extends WordSpec with Matchers with Mock
         email,
         password,
         RegisterRequestBodyPublicFields(username),
-        RegisterRequestBodyPrivateFields(firstName, secondName, receiveGnmMarketing, receive3rdPartyMarketing, registrationIp)
+        RegisterRequestBodyPrivateFields(firstName, secondName, registrationIp),
+        RegisterRequestBodyStatusFields(receiveGnmMarketing, receive3rdPartyMarketing)
       )
-      val result = handler.handleRequestBody(requestBody)
-      val expectedResult = s"""{"primaryEmailAddress":"$email","password":"$password","publicFields":{"username":"$username"},"privateFields":{"firstName":"$firstName","secondName":"$secondName","receiveGnmMarketing":$receiveGnmMarketing,"receive3rdPartyMarketing":$receive3rdPartyMarketing,"registrationIp":"$registrationIp"}}"""
+      val result: String = handler.handleRequestBody(requestBody)
+      val jsonResult = Json.parse(result)
 
-      result should equal (expectedResult)
+      (jsonResult \ "primaryEmailAddress").validate[String].asOpt.value should equal(email)
+      (jsonResult \ "password").validate[String].asOpt.value should equal(password)
+      (jsonResult \ "publicFields" \ "username").validate[String].asOpt.value should equal(username)
+      (jsonResult \ "privateFields" \ "firstName").validate[String].asOpt.value should equal(firstName)
+      (jsonResult \ "privateFields" \ "secondName").validate[String].asOpt.value should equal(secondName)
+      (jsonResult \ "privateFields" \ "registrationIp").validate[String].asOpt.value should equal(registrationIp)
+      (jsonResult \ "statusFields" \ "receiveGnmMarketing").validate[Boolean].asOpt.value should equal(receiveGnmMarketing)
+      (jsonResult \ "statusFields" \ "receive3rdPartyMarketing").validate[Boolean].asOpt.value should equal(receive3rdPartyMarketing)
     }
   }
 }

--- a/test/com/gu/identity/frontend/services/IdentityServiceRequestHandlerSpec.scala
+++ b/test/com/gu/identity/frontend/services/IdentityServiceRequestHandlerSpec.scala
@@ -28,7 +28,7 @@ class IdentityServiceRequestHandlerSpec extends WordSpec with Matchers with Mock
       val password = "some%thing"
       val username = "myUsername"
       val firstName = "First"
-      val lastName = "Last"
+      val secondName = "Last"
       val receiveGnmMarketing = false
       val receive3rdPartyMarketing = false
       val registrationIp = "123.456.789.012"
@@ -37,10 +37,10 @@ class IdentityServiceRequestHandlerSpec extends WordSpec with Matchers with Mock
         email,
         password,
         RegisterRequestBodyPublicFields(username),
-        RegisterRequestBodyPrivateFields(firstName, lastName, receiveGnmMarketing, receive3rdPartyMarketing, registrationIp)
+        RegisterRequestBodyPrivateFields(firstName, secondName, receiveGnmMarketing, receive3rdPartyMarketing, registrationIp)
       )
       val result = handler.handleRequestBody(requestBody)
-      val expectedResult = s"""{"primaryEmailAddress":"$email","password":"$password","publicFields":{"username":"$username"},"privateFields":{"firstName":"$firstName","lastName":"$lastName","receiveGnmMarketing":$receiveGnmMarketing,"receive3rdPartyMarketing":$receive3rdPartyMarketing,"registrationIp":"$registrationIp"}}"""
+      val expectedResult = s"""{"primaryEmailAddress":"$email","password":"$password","publicFields":{"username":"$username"},"privateFields":{"firstName":"$firstName","secondName":"$secondName","receiveGnmMarketing":$receiveGnmMarketing,"receive3rdPartyMarketing":$receive3rdPartyMarketing,"registrationIp":"$registrationIp"}}"""
 
       result should equal (expectedResult)
     }


### PR DESCRIPTION
Fixes the following missing fields when registering new users:

- Surname should be `secondName` as required by the API
- `receiveGnmMarketing` should be in a `statusFields` object
- `receive3rdPartyMarketing` should be in a `statusFields` object