### PR TITLE
Fix: P7282.F05 User-controlled client-side redirect

### DIFF
--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -32,8 +32,9 @@ class Application (configuration: Configuration, val messagesApi: MessagesApi, c
     renderRegister(configuration, req.activeTests, error, csrfToken, returnUrlActual, skipConfirmation)
   }
 
-  def confirm(returnUrl: Option[String]) = Action {
-    renderRegisterConfirmation(configuration, returnUrl)
+  def confirm(returnUrl: Option[String]) = Action { req =>
+    val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"), configuration)
+    renderRegisterConfirmation(configuration, returnUrlActual)
   }
 }
 

--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -65,7 +65,7 @@ object ViewRenderer {
     renderViewModel("register-page", model)
   }
 
-  def renderRegisterConfirmation(configuration: Configuration, returnUrl: Option[String])(implicit messages: Messages) = {
+  def renderRegisterConfirmation(configuration: Configuration, returnUrl: ReturnUrl)(implicit messages: Messages) = {
     renderViewModel(
       "register-confirmation-page",
       RegisterConfirmationViewModel(configuration, returnUrl))

--- a/app/com/gu/identity/frontend/views/models/RegisterConfirmationViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterConfirmationViewModel.scala
@@ -1,7 +1,7 @@
 package com.gu.identity.frontend.views.models
 
 import com.gu.identity.frontend.configuration.Configuration
-import com.gu.identity.frontend.models.UrlBuilder
+import com.gu.identity.frontend.models.{ReturnUrl, UrlBuilder}
 import com.gu.identity.frontend.models.text.RegisterConfirmationText
 import play.api.i18n.Messages
 
@@ -19,13 +19,13 @@ case class RegisterConfirmationViewModel private(
   with ViewModelResources
 
 object RegisterConfirmationViewModel {
-  def apply(configuration: Configuration, returnUrl: Option[String])(implicit messages: Messages): RegisterConfirmationViewModel = {
+  def apply(configuration: Configuration, returnUrl: ReturnUrl)(implicit messages: Messages): RegisterConfirmationViewModel = {
     val layout = LayoutViewModel(configuration)
-    val urlParams = Seq(("returnUrl" -> returnUrl.getOrElse("http://www.theguardian.com")))
+    val urlParams = Seq(("returnUrl" -> returnUrl.url))
 
     RegisterConfirmationViewModel(
       layout = layout,
-      returnUrl = returnUrl.getOrElse("http://www.theguardian.com"),
+      returnUrl = returnUrl.url,
       registerConfirmationPageText = RegisterConfirmationText(),
       resetPasswordUrl = UrlBuilder("https://profile.theguardian.com/reset",urlParams),
       signOutUrl = UrlBuilder("https://profile.theguardian.com/signout",urlParams),


### PR DESCRIPTION
From the PEN test report:

A URL variable passed between the client and server was subsequently used to create a hyperlink and embed it in the page: https://profile.theguardian.com/register/confirm?returnUrl=http%3A%2F%2Fwww.corsaire.com By sending crafted links to users of the system, it would be possible to include third party content in the context of the application, and engage in phishing attacks, for example.