### PR TITLE
Fix removal of http protocol from links

### DIFF
--- a/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
+++ b/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
@@ -3,7 +3,7 @@ package com.gu.identity.frontend.configuration
 import com.gu.identity.frontend.controllers._
 import com.gu.identity.frontend.csrf.CSRFConfig
 import com.gu.identity.frontend.errors.ErrorHandler
-import com.gu.identity.frontend.filters.{SecurityHeadersFilter, Filters}
+import com.gu.identity.frontend.filters.{HtmlCompressorFilter, SecurityHeadersFilter, Filters}
 import com.gu.identity.frontend.logging.MetricsLoggingActor
 import com.gu.identity.frontend.services.{GoogleRecaptchaServiceHandler, IdentityServiceRequestHandler, IdentityServiceImpl, IdentityService}
 import com.gu.identity.service.client.IdentityClient
@@ -15,7 +15,6 @@ import router.Routes
 import play.api.libs.ws.ning.NingWSComponents
 import play.api.{Mode, Logger, BuiltInComponentsFromContext, ApplicationLoader}
 import play.api.ApplicationLoader.Context
-import com.mohiva.play.htmlcompressor.DefaultHTMLCompressorFilter
 import play.api.libs.concurrent.Execution.defaultContext
 
 class FrontendApplicationLoader extends ApplicationLoader {
@@ -47,7 +46,7 @@ class ApplicationComponents(context: Context) extends BuiltInComponentsFromConte
   override lazy val httpFilters = new Filters(new SecurityHeadersFilter(
     frontendConfiguration),
     new GzipFilter(),
-    new DefaultHTMLCompressorFilter(configuration, environment)
+    HtmlCompressorFilter(configuration, environment)
   ).filters
 
   override lazy val httpErrorHandler = new ErrorHandler(frontendConfiguration, messagesApi, environment, sourceMapper, Some(router))

--- a/app/com/gu/identity/frontend/filters/HtmlCompressorFilter.scala
+++ b/app/com/gu/identity/frontend/filters/HtmlCompressorFilter.scala
@@ -1,0 +1,31 @@
+package com.gu.identity.frontend.filters
+
+import com.googlecode.htmlcompressor.compressor.HtmlCompressor
+import com.mohiva.play.htmlcompressor.{HTMLCompressorFilter => MohivaHTMLCompressorFilter}
+import play.api.{Mode, Environment, Configuration}
+
+/**
+ * Adapter for HtmlCompressorFilter which compresses output of HTML responses only.
+ *
+ * @see https://github.com/mohiva/play-html-compressor
+ */
+final case class HtmlCompressorFilter(configuration: Configuration, environment: Environment)
+  extends MohivaHTMLCompressorFilter {
+
+  val compressor: HtmlCompressor = {
+    val c = new HtmlCompressor()
+
+    if (environment.mode == Mode.Dev) {
+      c.setPreserveLineBreaks(true)
+    }
+
+    c.setRemoveComments(true)
+    c.setRemoveIntertagSpaces(false)
+
+    // Remove https from protocol defs only - assume running under https
+    c.setRemoveHttpProtocol(false)
+    c.setRemoveHttpsProtocol(true)
+
+    c
+  }
+}


### PR DESCRIPTION
By default, the Google HTML Compressor will remove http protocol from href and src attributes, this change takes the defaults and modifies it so that the http protocol is preserved in the response.

Fixes issue where a Return URL requiring http will incorrectly link to https on the register confirm page due to the compressor removing the protocol from the link, eg:
https://profile.code.dev-theguardian.com/register/confirm?returnUrl=http%3A%2F%2Fm.code.dev-theguardian.com