### PR TITLE
Live in the present

### DIFF
--- a/app/com/gu/identity/frontend/models/Text.scala
+++ b/app/com/gu/identity/frontend/models/Text.scala
@@ -43,18 +43,4 @@ object Text {
       )
     }
   }
-
-  object FooterText {
-    def toMap(implicit messages: Messages): Map[String, String] = {
-      Map(
-        "help" -> messages("footer.help"),
-        "terms" -> messages("footer.terms"),
-        "contact" -> messages("footer.contact"),
-        "privacy" -> messages("footer.privacy"),
-        "techFeedback" -> messages("footer.techfeedback"),
-        "cookies" -> messages("footer.cookies"),
-        "copyright" -> messages("footer.copyright")
-      )
-    }
-  }
 }

--- a/app/com/gu/identity/frontend/models/text/FooterText.scala
+++ b/app/com/gu/identity/frontend/models/text/FooterText.scala
@@ -1,0 +1,25 @@
+package com.gu.identity.frontend.models.text
+
+import play.api.i18n.Messages
+
+case class FooterText private(
+    help: String,
+    terms: String,
+    contact: String,
+    privacy: String,
+    techFeedback: String,
+    cookies: String,
+    copyright: String)
+
+object FooterText {
+  def apply()(implicit messages: Messages): FooterText =
+    FooterText(
+      help = messages("footer.help"),
+      terms = messages("footer.terms"),
+      contact = messages("footer.contact"),
+      privacy = messages("footer.privacy"),
+      techFeedback = messages("footer.techfeedback"),
+      cookies = messages("footer.cookies"),
+      copyright = messages("footer.copyright")
+    )
+}

--- a/app/com/gu/identity/frontend/models/text/FooterText.scala
+++ b/app/com/gu/identity/frontend/models/text/FooterText.scala
@@ -1,5 +1,6 @@
 package com.gu.identity.frontend.models.text
 
+import org.joda.time.DateTime
 import play.api.i18n.Messages
 
 case class FooterText private(
@@ -12,6 +13,8 @@ case class FooterText private(
     copyright: String)
 
 object FooterText {
+  lazy val currentYear: String = new DateTime().year().getAsText
+
   def apply()(implicit messages: Messages): FooterText =
     FooterText(
       help = messages("footer.help"),
@@ -20,6 +23,6 @@ object FooterText {
       privacy = messages("footer.privacy"),
       techFeedback = messages("footer.techfeedback"),
       cookies = messages("footer.cookies"),
-      copyright = messages("footer.copyright")
+      copyright = messages("footer.copyright", currentYear)
     )
 }

--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -2,7 +2,8 @@ package com.gu.identity.frontend.views.models
 
 import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.models.ClientID
-import com.gu.identity.frontend.models.Text.{FooterText, HeaderText, LayoutText}
+import com.gu.identity.frontend.models.Text.{HeaderText, LayoutText}
+import com.gu.identity.frontend.models.text.FooterText
 import com.gu.identity.frontend.mvt
 import com.gu.identity.frontend.mvt.{ActiveMultiVariantTests, MultiVariantTests, MultiVariantTest}
 import play.api.i18n.Messages
@@ -32,7 +33,7 @@ case object BaseLayoutViewModel extends ViewModel with ViewModelResources {
 case class LayoutViewModel(
     text: Map[String,String],
     headerText: Map[String, String],
-    footerText: Map[String, String],
+    footerText: FooterText,
     resources: Seq[PageResource with Product],
     indirectResources: Seq[PageResource with Product],
     favicons: Seq[Favicon] = Favicons(),
@@ -113,7 +114,7 @@ object LayoutViewModel {
     LayoutViewModel(
       text = LayoutText.toMap,
       headerText = HeaderText.toMap,
-      footerText = FooterText.toMap,
+      footerText = FooterText(),
       resources = resources,
       indirectResources = BaseLayoutViewModel.indirectResources,
       skin = skin)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -55,7 +55,7 @@ footer.contact=contact us
 footer.privacy=privacy policy
 footer.techfeedback=report technical issue
 footer.cookies=cookie policy
-footer.copyright=© 2015 Guardian News and Media Limited or its affiliated companies. All rights reserved.
+footer.copyright=© {0} Guardian News and Media Limited or its affiliated companies. All rights reserved.
 
 # com.gu.identity.frontend.models.text.RegisterConfirmationText
 registerConfirmation.pageTitle=Register


### PR DESCRIPTION
Dynamically update the year in the footer copyright.

Note: requires that the apps are restarted / deployed when the year changes.