### PR TITLE
Remove node_modules on `sbt clean`

### DIFF
--- a/frontend.sbt
+++ b/frontend.sbt
@@ -17,3 +17,14 @@ managedSourceDirectories in Assets += (buildOutputDirectory in build in Assets).
 
 // Include handlebars views in resources for lookup on classpath
 unmanagedResourceDirectories in Compile += (resourceDirectory in Assets).value
+
+
+// Clean out node_modules directory as part of a `clean` task
+cleanFiles ++= (WebKeys.nodeModuleDirectories in Assets).value
+
+
+clean := {
+  val log = streams.value.log
+  log.info("Cleaned target and node_modules - next compile may take a while")
+  clean.value
+}


### PR DESCRIPTION
- Removes node_modules directory on `clean` task
- Logs to the user that the node_modules have been deleted, so the next
  compile may be slow
- Log before node modules are installed for the first time, so the user
  will know it will take some time