### PR TITLE
Capture legacy routes and redirect

### DIFF
--- a/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
+++ b/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
@@ -42,6 +42,7 @@ class ApplicationComponents(context: Context) extends BuiltInComponentsFromConte
   lazy val signinController = new SigninAction(identityService, messagesApi, csrfConfig, googleRecaptchaCheck, frontendConfiguration)
   lazy val registerController = new RegisterAction(identityService, messagesApi, frontendConfiguration, csrfConfig)
   lazy val assets = new controllers.Assets(httpErrorHandler)
+  lazy val redirects = new Redirects
 
   override lazy val httpFilters = new Filters(new SecurityHeadersFilter(
     frontendConfiguration),
@@ -58,5 +59,5 @@ class ApplicationComponents(context: Context) extends BuiltInComponentsFromConte
 
   applicationLifecycle.addStopHook(() => terminateActor()(defaultContext))
 
-  override lazy val router: Router = new Routes(httpErrorHandler, applicationController, signinController, registerController, cspReporterController, healthcheckController, manifestController, assets)
+  override lazy val router: Router = new Routes(httpErrorHandler, applicationController, signinController, registerController, cspReporterController, healthcheckController, manifestController, assets, redirects)
 }

--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -12,10 +12,6 @@ import play.api.mvc._
 
 class Application (configuration: Configuration, val messagesApi: MessagesApi, csrfConfig: CSRFConfig) extends Controller with Logging with I18nSupport {
 
-  def index = Action {
-    Redirect(routes.Application.signIn())
-  }
-
   def signIn(error: Seq[String], returnUrl: Option[String], skipConfirmation: Option[Boolean], clientId: Option[String]) = (CSRFAddToken(csrfConfig) andThen MultiVariantTestAction) { req =>
     val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"), configuration)
     val clientIdActual = ClientID(clientId)

--- a/app/com/gu/identity/frontend/controllers/Redirects.scala
+++ b/app/com/gu/identity/frontend/controllers/Redirects.scala
@@ -1,0 +1,38 @@
+package com.gu.identity.frontend.controllers
+
+import com.gu.identity.frontend.logging.Logging
+import play.api.mvc.{Call, Action, Controller}
+
+
+final class Redirects extends Controller with Logging {
+
+  lazy val signInRoute: Call = routes.Application.signIn()
+  lazy val registerRoute: Call = routes.Application.register()
+
+
+  def indexRedirect =
+    redirectToRoute(signInRoute)
+
+
+  def signInPageTrailingSlash =
+    redirectToRoute(signInRoute, isLegacy = true)
+
+
+  def registerPageTrailingSlash =
+    redirectToRoute(registerRoute, isLegacy = true)
+
+
+  private def redirectToRoute(call: Call, isLegacy: Boolean = false) = Action { request =>
+    if (isLegacy) {
+      val referrer = request.headers.get(REFERER).getOrElse("_unknown_")
+
+      logger.info(s"Legacy route called: ${request.uri} from $referrer")
+
+      MovedPermanently(call.url)
+
+    } else {
+      SeeOther(call.url)
+    }
+  }
+
+}

--- a/conf/routes
+++ b/conf/routes
@@ -3,8 +3,6 @@
 # ~~~~
 
 # Home page
-GET        /                              com.gu.identity.frontend.controllers.Application.index
-
 GET        /signin                        com.gu.identity.frontend.controllers.Application.signIn(error: Seq[String] ?= Seq.empty, returnUrl: Option[String] ?= None, skipConfirmation: Option[Boolean] ?= None, clientId: Option[String] ?= None)
 
 GET        /register                      com.gu.identity.frontend.controllers.Application.register(error: Seq[String] ?= Seq.empty, returnUrl: Option[String] ?= None, skipConfirmation: Option[Boolean] ?= None, group: Option[String] ?= None, clientId: Option[String] ?= None)
@@ -22,3 +20,9 @@ GET        /management/healthcheck        com.gu.identity.frontend.controllers.H
 GET        /management/manifest           com.gu.identity.frontend.controllers.Manifest.manifest
 
 GET        /static/*file                  controllers.Assets.versioned(path="/public", file: Asset)
+
+
+# Redirects
+GET        /                              com.gu.identity.frontend.controllers.Redirects.indexRedirect
+GET        /signin/                       com.gu.identity.frontend.controllers.Redirects.signInPageTrailingSlash
+GET        /register/                     com.gu.identity.frontend.controllers.Redirects.registerPageTrailingSlash


### PR DESCRIPTION
- New Redirects controller for all redirects
- Legacy routes log request uri and referrer, redirect with permanent
  redirect code

Legacy routes for `/signin/` and `/register/` are being reported in the logs as 404. This should fix these.