### PR TITLE
Make back button go back (and members logo link go to membership)

### DIFF
--- a/app/com/gu/identity/frontend/configuration/Configuration.scala
+++ b/app/com/gu/identity/frontend/configuration/Configuration.scala
@@ -16,8 +16,6 @@ case class Configuration(
 
   identityProfileBaseUrl: String,
 
-  identityDefaultReturnUrl: String,
-
   dotcomBaseUrl: String,
   membershipBaseUrl: String,
 
@@ -52,8 +50,6 @@ object Configuration {
 
       identityProfileBaseUrl = getString("identity.frontend.baseUrl"),
 
-      identityDefaultReturnUrl = getString("identity.frontend.defaultReturnUrl"),
-
       dotcomBaseUrl = getString("identity.frontend.dotcomBaseUrl"),
 
       membershipBaseUrl = getString("identity.frontend.membershipBaseUrl"),
@@ -80,8 +76,6 @@ object Configuration {
     identityFederationApiHost = "https://oauth.code.dev-theguardian.com",
 
     identityProfileBaseUrl = "https://profile.code.dev-theguardian.com",
-
-    identityDefaultReturnUrl = "http://www.theguardian.com",
 
     dotcomBaseUrl = "http://www.theguardian.com",
     membershipBaseUrl = "https://members.theguardian.com",

--- a/app/com/gu/identity/frontend/configuration/Configuration.scala
+++ b/app/com/gu/identity/frontend/configuration/Configuration.scala
@@ -18,6 +18,9 @@ case class Configuration(
 
   identityDefaultReturnUrl: String,
 
+  dotcomBaseUrl: String,
+  membershipBaseUrl: String,
+
   identityFederationApiHost: String,
 
   omnitureAccount: String,
@@ -51,6 +54,10 @@ object Configuration {
 
       identityDefaultReturnUrl = getString("identity.frontend.defaultReturnUrl"),
 
+      dotcomBaseUrl = getString("identity.frontend.dotcomBaseUrl"),
+
+      membershipBaseUrl = getString("identity.frontend.membershipBaseUrl"),
+
       omnitureAccount = getString("omniture.account"),
 
       googleRecaptchaSiteKey = getString("google.recaptcha.site"),
@@ -75,6 +82,9 @@ object Configuration {
     identityProfileBaseUrl = "https://profile.code.dev-theguardian.com",
 
     identityDefaultReturnUrl = "http://www.theguardian.com",
+
+    dotcomBaseUrl = "http://www.theguardian.com",
+    membershipBaseUrl = "https://members.theguardian.com",
 
     omnitureAccount = "--test-omniture-account--",
 

--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -13,26 +13,26 @@ import play.api.mvc._
 class Application (configuration: Configuration, val messagesApi: MessagesApi, csrfConfig: CSRFConfig) extends Controller with Logging with I18nSupport {
 
   def signIn(error: Seq[String], returnUrl: Option[String], skipConfirmation: Option[Boolean], clientId: Option[String]) = (CSRFAddToken(csrfConfig) andThen MultiVariantTestAction) { req =>
-    val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"), configuration)
-    val clientIdActual = ClientID(clientId)
+    val clientIdOpt = ClientID(clientId)
+    val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"), configuration, clientIdOpt)
 
     val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
 
-    renderSignIn(configuration, req.activeTests, csrfToken, error, returnUrlActual, skipConfirmation, clientIdActual)
+    renderSignIn(configuration, req.activeTests, csrfToken, error, returnUrlActual, skipConfirmation, clientIdOpt)
   }
 
   def register(error: Seq[String], returnUrl: Option[String], skipConfirmation: Option[Boolean], group: Option[String], clientId: Option[String]) = (CSRFAddToken(csrfConfig) andThen MultiVariantTestAction) { req =>
-    val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"), configuration)
-    val clientIdActual = ClientID(clientId)
+    val clientIdOpt = ClientID(clientId)
+    val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"), configuration, clientIdOpt)
 
     val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
 
-    renderRegister(configuration, req.activeTests, error, csrfToken, returnUrlActual, skipConfirmation, clientIdActual)
+    renderRegister(configuration, req.activeTests, error, csrfToken, returnUrlActual, skipConfirmation, clientIdOpt)
   }
 
   def confirm(returnUrl: Option[String], clientId: Option[String]) = Action {
     val clientIdOpt = ClientID(clientId)
-    val returnUrlActual = ReturnUrl(returnUrl, referer = None, configuration)
+    val returnUrlActual = ReturnUrl(returnUrl, refererHeader = None, configuration, clientIdOpt)
 
     renderRegisterConfirmation(configuration, returnUrlActual, clientIdOpt)
   }

--- a/app/com/gu/identity/frontend/controllers/RegisterAction.scala
+++ b/app/com/gu/identity/frontend/controllers/RegisterAction.scala
@@ -67,7 +67,7 @@ class RegisterAction(identityService: IdentityService, val messagesApi: Messages
         Future.successful(SeeOther(routes.Application.register(errors).url))},
       successForm => {
         val trackingData = TrackingData(request, successForm.returnUrl)
-        val returnUrl = ReturnUrl(successForm.returnUrl, request.headers.get("Referer"), config)
+        val returnUrl = ReturnUrl(successForm.returnUrl, request.headers.get("Referer"), config, successForm.clientID)
         identityService.registerThenSignIn(successForm, clientIp, trackingData).map {
           case Left(errors) =>
             redirectToRegisterPageWithErrors(errors, returnUrl, successForm.skipConfirmation, successForm.group, successForm.clientID)

--- a/app/com/gu/identity/frontend/controllers/SigninAction.scala
+++ b/app/com/gu/identity/frontend/controllers/SigninAction.scala
@@ -46,7 +46,7 @@ class SigninAction(identityService: IdentityService, val messagesApi: MessagesAp
   def signIn = CSRFCheck(csrfConfig, handleCSRFError).async { implicit request =>
     val formParams = signInFormBody.bindFromRequest()(request).get
     val trackingData = TrackingData(request, formParams.returnUrl)
-    val returnUrl = ReturnUrl(formParams.returnUrl, request.headers.get("Referer"), config)
+    val returnUrl = ReturnUrl(formParams.returnUrl, request.headers.get("Referer"), config, formParams.clientID)
 
     def googleRecaptchaError = Future.successful(
       redirectToSigninPageWithErrorsAndEmail(Seq(ServiceBadRequest("error-captcha")), returnUrl, formParams.skipConfirmation, formParams.clientID)

--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -1,7 +1,7 @@
 package com.gu.identity.frontend.views.models
 
 import com.gu.identity.frontend.configuration.Configuration
-import com.gu.identity.frontend.models.{ReturnUrl, ClientID}
+import com.gu.identity.frontend.models.{GuardianMembersClientID, ReturnUrl, ClientID}
 import com.gu.identity.frontend.models.Text.{HeaderText, LayoutText}
 import com.gu.identity.frontend.models.text.FooterText
 import com.gu.identity.frontend.mvt
@@ -129,10 +129,11 @@ case class LayoutLinks private(
 
 object LayoutLinks {
   def apply(configuration: Configuration, clientId: Option[ClientID], returnUrl: Option[ReturnUrl]): LayoutLinks = {
-    val baseUrl = "http://www.theguardian.com"
+    val baseUrl = configuration.dotcomBaseUrl
+
     LayoutLinks(
       headerBack = returnUrl.map(_.url).getOrElse(baseUrl),
-      headerLogo = baseUrl,
+      headerLogo = logoUrl(configuration, clientId),
       footerHelp = s"$baseUrl/help/identity-faq",
       footerTerms = s"$baseUrl/help/terms-of-service",
       footerContact = s"$baseUrl/help/contact-us",
@@ -141,6 +142,13 @@ object LayoutLinks {
       footerCookies = s"$baseUrl/info/cookies"
     )
   }
+
+  private def logoUrl(configuration: Configuration, clientId: Option[ClientID]) =
+    clientId match {
+      case Some(GuardianMembersClientID) => configuration.membershipBaseUrl
+      case _ => configuration.dotcomBaseUrl
+    }
+
 }
 
 case class Favicon(filename: String, rel: String, url: String, sizes: Option[String] = None)

--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -1,7 +1,7 @@
 package com.gu.identity.frontend.views.models
 
 import com.gu.identity.frontend.configuration.Configuration
-import com.gu.identity.frontend.models.ClientID
+import com.gu.identity.frontend.models.{ReturnUrl, ClientID}
 import com.gu.identity.frontend.models.Text.{HeaderText, LayoutText}
 import com.gu.identity.frontend.models.text.FooterText
 import com.gu.identity.frontend.mvt
@@ -30,10 +30,11 @@ case object BaseLayoutViewModel extends ViewModel with ViewModelResources {
 }
 
 
-case class LayoutViewModel(
+case class LayoutViewModel private(
     text: Map[String,String],
     headerText: Map[String, String],
     footerText: FooterText,
+    links: LayoutLinks,
     resources: Seq[PageResource with Product],
     indirectResources: Seq[PageResource with Product],
     favicons: Seq[Favicon] = Favicons(),
@@ -115,9 +116,36 @@ object LayoutViewModel {
       text = LayoutText.toMap,
       headerText = HeaderText.toMap,
       footerText = FooterText(),
+      links = LayoutLinks(configuration, clientId, None),
       resources = resources,
       indirectResources = BaseLayoutViewModel.indirectResources,
       skin = skin)
+  }
+}
+
+case class LayoutLinks private(
+    headerBack: String,
+    headerLogo: String,
+    footerHelp: String,
+    footerTerms: String,
+    footerContact: String,
+    footerPrivacy: String,
+    footerFeedback: String,
+    footerCookies: String)
+
+object LayoutLinks {
+  def apply(configuration: Configuration, clientId: Option[ClientID], returnUrl: Option[ReturnUrl]): LayoutLinks = {
+    val baseUrl = "http://www.theguardian.com"
+    LayoutLinks(
+      headerBack = baseUrl,
+      headerLogo = baseUrl,
+      footerHelp = s"$baseUrl/help/identity-faq",
+      footerTerms = s"$baseUrl/help/terms-of-service",
+      footerContact = s"$baseUrl/help/contact-us",
+      footerPrivacy = s"$baseUrl/info/privacy",
+      footerFeedback = s"$baseUrl/info/tech-feedback",
+      footerCookies = s"$baseUrl/info/cookies"
+    )
   }
 }
 

--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -82,6 +82,9 @@ object LayoutViewModel {
   def apply(configuration: Configuration)(implicit messages: Messages): LayoutViewModel =
     apply(configuration, Map.empty, clientId = None, returnUrl = None)
 
+  def apply(configuration: Configuration, clientId: Option[ClientID], returnUrl: Option[ReturnUrl])(implicit messages: Messages): LayoutViewModel =
+    apply(configuration, activeTests = Map.empty, clientId, returnUrl)
+
   def apply(configuration: Configuration, activeTests: ActiveMultiVariantTests, clientId: Option[ClientID], returnUrl: Option[ReturnUrl])(implicit messages: Messages): LayoutViewModel = {
 
     val skin = clientId

--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -80,15 +80,9 @@ case class JavascriptRuntimeParams(activeTests: Map[String, String]) {
 object LayoutViewModel {
 
   def apply(configuration: Configuration)(implicit messages: Messages): LayoutViewModel =
-    apply(configuration, Map.empty, None)
+    apply(configuration, Map.empty, clientId = None, returnUrl = None)
 
-  def apply(configuration: Configuration, clientId: Option[ClientID])(implicit messages: Messages): LayoutViewModel =
-    apply(configuration, Map.empty, clientId)
-
-  def apply(configuration: Configuration, activeTests: ActiveMultiVariantTests)(implicit messages: Messages): LayoutViewModel =
-    apply(configuration, activeTests, None)
-
-  def apply(configuration: Configuration, activeTests: ActiveMultiVariantTests, clientId: Option[ClientID])(implicit messages: Messages): LayoutViewModel = {
+  def apply(configuration: Configuration, activeTests: ActiveMultiVariantTests, clientId: Option[ClientID], returnUrl: Option[ReturnUrl])(implicit messages: Messages): LayoutViewModel = {
 
     val skin = clientId
       .filter(_.hasSkin)
@@ -116,7 +110,7 @@ object LayoutViewModel {
       text = LayoutText.toMap,
       headerText = HeaderText.toMap,
       footerText = FooterText(),
-      links = LayoutLinks(configuration, clientId, None),
+      links = LayoutLinks(configuration, clientId, returnUrl),
       resources = resources,
       indirectResources = BaseLayoutViewModel.indirectResources,
       skin = skin)
@@ -137,7 +131,7 @@ object LayoutLinks {
   def apply(configuration: Configuration, clientId: Option[ClientID], returnUrl: Option[ReturnUrl]): LayoutLinks = {
     val baseUrl = "http://www.theguardian.com"
     LayoutLinks(
-      headerBack = baseUrl,
+      headerBack = returnUrl.map(_.url).getOrElse(baseUrl),
       headerLogo = baseUrl,
       footerHelp = s"$baseUrl/help/identity-faq",
       footerTerms = s"$baseUrl/help/terms-of-service",

--- a/app/com/gu/identity/frontend/views/models/RegisterConfirmationViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterConfirmationViewModel.scala
@@ -21,7 +21,7 @@ case class RegisterConfirmationViewModel private(
 
 object RegisterConfirmationViewModel {
   def apply(configuration: Configuration, returnUrl: ReturnUrl, clientId: Option[ClientID])(implicit messages: Messages): RegisterConfirmationViewModel = {
-    val layout = LayoutViewModel(configuration, clientId)
+    val layout = LayoutViewModel(configuration, activeTests = Map.empty, clientId, returnUrl = Some(returnUrl))
 
     RegisterConfirmationViewModel(
       layout = layout,

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -47,7 +47,7 @@ object RegisterViewModel {
       clientId: Option[ClientID])
       (implicit messages: Messages): RegisterViewModel = {
 
-    val layout = LayoutViewModel(configuration, activeTests, clientId)
+    val layout = LayoutViewModel(configuration, activeTests, clientId, Some(returnUrl))
 
     RegisterViewModel(
       layout = layout,

--- a/app/com/gu/identity/frontend/views/models/ResetPasswordEmailSentViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/ResetPasswordEmailSentViewModel.scala
@@ -17,7 +17,7 @@ case class ResetPasswordEmailSentViewModel private(
 object ResetPasswordEmailSentViewModel {
 
   def apply(configuration: Configuration, clientId: Option[ClientID])(implicit messages: Messages): ResetPasswordEmailSentViewModel = {
-    val layout = LayoutViewModel(configuration, clientId = clientId)
+    val layout = LayoutViewModel(configuration, clientId, returnUrl = None)
 
     ResetPasswordEmailSentViewModel(
       layout = layout,

--- a/app/com/gu/identity/frontend/views/models/ResetPasswordViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/ResetPasswordViewModel.scala
@@ -31,7 +31,7 @@ object ResetPasswordViewModel {
     csrfToken: Option[CSRFToken],
     clientId: Option[ClientID])
     (implicit messages: Messages): ResetPasswordViewModel = {
-    val layout = LayoutViewModel(configuration, clientId = clientId)
+    val layout = LayoutViewModel(configuration, clientId = clientId, returnUrl = None)
 
     ResetPasswordViewModel(
       layout = layout,

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -40,7 +40,7 @@ case class SignInViewModel private(
 object SignInViewModel {
   def apply(configuration: Configuration, activeTests: ActiveMultiVariantTests, csrfToken: Option[CSRFToken], errors: Seq[ErrorViewModel], returnUrl: ReturnUrl, skipConfirmation: Option[Boolean], clientId: Option[ClientID])(implicit messages: Messages): SignInViewModel = {
 
-    val layout = LayoutViewModel(configuration, activeTests, clientId)
+    val layout = LayoutViewModel(configuration, activeTests, clientId, Some(returnUrl))
     val recaptchaModel : Option[GoogleRecaptchaViewModel] =
       getRecaptchaModel(configuration, isError = !errors.isEmpty, recaptchaEnabled = configuration.recaptchaEnabled)
 

--- a/conf/CODE.conf
+++ b/conf/CODE.conf
@@ -6,7 +6,7 @@ identity.frontend.cookieDomain=code.dev-theguardian.com
 
 identity.frontend.baseUrl="https://profile.code.dev-theguardian.com"
 
-identity.frontend.defaultReturnUrl="http://m.code.dev-theguardian.com"
+identity.frontend.dotcomBaseUrl="http://m.code.dev-theguardian.com"
 
 identity.federation.api.host="https://oauth.code.dev-theguardian.com"
 

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -6,8 +6,6 @@ identity.frontend.cookieDomain=thegulocal.com
 
 identity.frontend.baseUrl="https://profile.thegulocal.com"
 
-identity.frontend.defaultReturnUrl="http://www.theguardian.com"
-
 identity.federation.api.host="https://oauth.code.dev-theguardian.com"
 
 omniture.account="guardiangudev-code"

--- a/conf/PROD.conf
+++ b/conf/PROD.conf
@@ -6,8 +6,6 @@ identity.frontend.cookieDomain=theguardian.com
 
 identity.frontend.baseUrl="https://profile.theguardian.com"
 
-identity.frontend.defaultReturnUrl="http://www.theguardian.com"
-
 identity.federation.api.host="https://oauth.theguardian.com"
 
 omniture.account="guardiangu-network"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -27,6 +27,10 @@ identity {
   # Frontend app specific configuration
   frontend {
     cookieDomain = "theguardian.com"
+
+    dotcomBaseUrl = "http://www.theguardian.com"
+
+    membershipBaseUrl = "https://membership.theguardian.com"
   }
 
   federation {

--- a/public/components/footer/_footer.hbs
+++ b/public/components/footer/_footer.hbs
@@ -1,23 +1,25 @@
 <footer class="footer">
   <div class="footer__inner">
     <ul class="colophon__list">
-        <li class="colophon__item"><a data-link-name="help" href="http://www.theguardian.com/help/identity-faq">
-          {{layout.footerText.help}}</a></li>
-        <li class="colophon__item"><a data-link-name="terms" href="http://www.theguardian.com/help/terms-of-service">
-          {{layout.footerText.terms}}</a></li>
-        <li class="colophon__item"><a data-link-name="uk : footer : contact us" href="http://www.theguardian.com/help/contact-us">
-          {{layout.footerText.contact}}</a>
-        </li>
-        <li class="colophon__item"><a data-link-name="privacy" href="https://www.theguardian.com/info/privacy">
-          {{layout.footerText.privacy}}</a></li>
-        <li class="colophon__item">
-            <a data-link-name="tech feedback" class="js-tech-feedback-report" href="https://www.theguardian.com/info/tech-feedback">
-              {{layout.footerText.techFeedback}}
-            </a>
-        </li>
-        <li class="colophon__item"><a data-link-name="cookie" href="https://www.theguardian.com/info/cookies">{{layout.footerText.cookies}}</a></li>
+      <li class="colophon__item">
+        <a data-link-name="help" href="{{ layout.links.footerHelp }}">{{ layout.footerText.help }}</a>
+      </li>
+      <li class="colophon__item">
+        <a data-link-name="terms" href="{{ layout.links.footerTerms }}">{{ layout.footerText.terms }}</a>
+      </li>
+      <li class="colophon__item">
+        <a data-link-name="uk : footer : contact us" href="{{ layout.links.footerContact }}">{{ layout.footerText.contact }}</a>
+      </li>
+      <li class="colophon__item">
+        <a data-link-name="privacy" href="{{ layout.links.footerPrivacy }}">{{ layout.footerText.privacy }}</a>
+      </li>
+      <li class="colophon__item">
+        <a data-link-name="tech feedback" class="js-tech-feedback-report" href="{{ layout.links.footerFeedback }}">{{ layout.footerText.techFeedback }}</a>
+      </li>
+      <li class="colophon__item">
+        <a data-link-name="cookie" href="{{ layout.links.footerCookies }}">{{ layout.footerText.cookies }}</a>
+      </li>
     </ul>
-    <p class="footer__copyright">{{layout.footerText.copyright}}</p>
+    <p class="footer__copyright">{{ layout.footerText.copyright }}</p>
   </div>
-
 </footer>

--- a/public/components/header/_header.hbs
+++ b/public/components/header/_header.hbs
@@ -1,10 +1,10 @@
 <header class="header">
   <div class="header__inner">
-    <a class="header__back-link" href="http://www.theguardian.com">
-      <span class="header__back-link-text"> {{layout.headerText.back}} </span>
+    <a class="header__back-link" href="{{ layout.links.headerBack }}">
+      <span class="header__back-link-text">{{ layout.headerText.back }}</span>
     </a>
-    <a class="header__logo-link" href="http://www.theguardian.com">
-      <span class="header__logo-link-text"> {{layout.headerText.logo}} </span>
+    <a class="header__logo-link" href="{{ layout.links.headerLogo }}">
+      <span class="header__logo-link-text">{{ layout.headerText.logo }}</span>
     </a>
   </div>
 </header>

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -22,15 +22,15 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
 
   it should "construct return url" in {
 
-    ReturnUrl(Some("http://www.theguardian.com/uk"), None, config) should be(ReturnUrl(new URI("http://www.theguardian.com/uk")))
-    ReturnUrl(None, Some("http://www.theguardian.com/uk"), config) should be(ReturnUrl(new URI("http://www.theguardian.com/uk")))
+    ReturnUrl(Some("http://www.theguardian.com/uk"), None, config, None) should be(ReturnUrl(new URI("http://www.theguardian.com/uk")))
+    ReturnUrl(None, Some("http://www.theguardian.com/uk"), config, None) should be(ReturnUrl(new URI("http://www.theguardian.com/uk")))
 
-    ReturnUrl(Some("http://jobs.theguardian.com/apply"), None, config) should be(ReturnUrl(new URI("http://jobs.theguardian.com/apply")))
-    ReturnUrl(None, Some("http://jobs.theguardian.com/apply"), config) should be(ReturnUrl(new URI("http://jobs.theguardian.com/apply")))
+    ReturnUrl(Some("http://jobs.theguardian.com/apply"), None, config, None) should be(ReturnUrl(new URI("http://jobs.theguardian.com/apply")))
+    ReturnUrl(None, Some("http://jobs.theguardian.com/apply"), config, None) should be(ReturnUrl(new URI("http://jobs.theguardian.com/apply")))
 
-    ReturnUrl(None, Some("http://www.thegulocal.com/"), config) should be(ReturnUrl(new URI("http://www.thegulocal.com/")))
+    ReturnUrl(None, Some("http://www.thegulocal.com/"), config, None) should be(ReturnUrl(new URI("http://www.thegulocal.com/")))
 
-    ReturnUrl(None, Some("http://profile-origin2.thegulocal.com"), config) should be(ReturnUrl(new URI("http://profile-origin2.thegulocal.com")))
+    ReturnUrl(None, Some("http://profile-origin2.thegulocal.com"), config, None) should be(ReturnUrl(new URI("http://profile-origin2.thegulocal.com")))
   }
 
 
@@ -45,23 +45,30 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
 
   it should "Retrieve default Return URL" in {
     def assertDefaultFallbackFor(in: ReturnUrl) = {
-      in.url should be(config.identityDefaultReturnUrl)
+      in.url should be(config.dotcomBaseUrl)
       in shouldBe 'default
     }
 
-    assertDefaultFallbackFor(ReturnUrl(None, None, config))
-    assertDefaultFallbackFor(ReturnUrl(Some("http://baddomain.com"), None, config))
-    assertDefaultFallbackFor(ReturnUrl(None, Some("http://badreferrer.com"), config))
-    assertDefaultFallbackFor(ReturnUrl(Some("^!this-is\\a-bad-uri"), None, config))
-    assertDefaultFallbackFor(ReturnUrl(None, Some("^!this-is\\a-bad-referer!"), config))
+    assertDefaultFallbackFor(ReturnUrl(None, None, config, None))
+    assertDefaultFallbackFor(ReturnUrl(Some("http://baddomain.com"), None, config, None))
+    assertDefaultFallbackFor(ReturnUrl(None, Some("http://badreferrer.com"), config, None))
+    assertDefaultFallbackFor(ReturnUrl(Some("^!this-is\\a-bad-uri"), None, config, None))
+    assertDefaultFallbackFor(ReturnUrl(None, Some("^!this-is\\a-bad-referer!"), config, None))
   }
 
 
   it should "Use the default return url for CODE env" in {
-    val codeConfig = config.copy(identityDefaultReturnUrl = "http://m.code.dev-theguardian.com")
+    val codeConfig = config.copy(dotcomBaseUrl = "http://m.code.dev-theguardian.com")
 
-    ReturnUrl(None, None, codeConfig) should be(ReturnUrl(new URI("http://m.code.dev-theguardian.com"), isDefault = true))
+    ReturnUrl(None, None, codeConfig, None) should be(ReturnUrl(new URI("http://m.code.dev-theguardian.com"), isDefault = true))
 
-    ReturnUrl(None, None, config) should be(ReturnUrl(new URI("http://www.theguardian.com"), isDefault = true))
+    ReturnUrl(None, None, config, None) should be(ReturnUrl(new URI("http://www.theguardian.com"), isDefault = true))
+  }
+
+  it should "Use the membership return url for clientId=members as the default fallback" in {
+    val result = ReturnUrl(None, None, config, Some(GuardianMembersClientID))
+
+    result.url shouldEqual config.membershipBaseUrl
+    result shouldBe 'default
   }
 }


### PR DESCRIPTION
- Back button uses `returnUrl` to determine its link
- Logo link will go to membership when `clientId=members`
- `returnUrl` will fallback to membership when `clientId=members`
- Use a model for the header and footer links of the layout