### PR TITLE
Replace send password email endpoint

### DIFF
--- a/app/com/gu/identity/frontend/services/IdentityServiceRequestHandler.scala
+++ b/app/com/gu/identity/frontend/services/IdentityServiceRequestHandler.scala
@@ -28,6 +28,8 @@ class IdentityServiceRequestHandler (ws: WSClient) extends IdentityClientRequest
   implicit val registerRequestBodyStatusFieldsFormat = Json.format[RegisterRequestBodyStatusFields]
   implicit val registerRequestBodyFormat = Json.format[RegisterRequestBody]
 
+  implicit val sendResetPasswordEmailRequestBody = Json.format[SendResetPasswordEmailRequestBody]
+
   implicit val registerResponseUserGroupsFormat = Json.format[RegisterResponseUserGroups]
   implicit val registerResponseUserFormat = Json.format[RegisterResponseUser]
   implicit val registerResponseFormat = Json.format[RegisterResponse]
@@ -54,6 +56,7 @@ class IdentityServiceRequestHandler (ws: WSClient) extends IdentityClientRequest
   def handleRequestBody(body: ApiRequestBody): String = body match {
     case b: RegisterRequestBody => Json.stringify(Json.toJson(b))
     case AuthenticateCookiesApiRequestBody(email, password) => encodeBody("email" -> email, "password" -> password)
+    case b: SendResetPasswordEmailRequestBody => Json.stringify(Json.toJson(b))
   }
 
   private def encodeBody(params: (String, String)*) = {

--- a/app/com/gu/identity/service/client/IdentityClient.scala
+++ b/app/com/gu/identity/service/client/IdentityClient.scala
@@ -34,8 +34,14 @@ class IdentityClient extends Logging {
 
   def sendResetPasswordEmail(request: SendResetPasswordEmailApiRequest)(implicit configuration: IdentityClientConfiguration, ec: ExecutionContext): Future[Either[IdentityClientErrors, SendResetPasswordEmailResponse ]] = {
     configuration.requestHandler.handleRequest(request).map {
-      case Left(error) => Left(error)
-      case Right(r: SendResetPasswordEmailResponse) => Right(r)
+      case Left(error) => {
+        logger.info("Failed to send reset password email request")
+        Left(error)
+      }
+      case Right(r: SendResetPasswordEmailResponse) => {
+        logger.info("Successfully sent reset password email request")
+        Right(r)
+      }
       case Right(other) => Left(Seq(GatewayError("Unknown response")))
     }
   }

--- a/app/com/gu/identity/service/client/IdentityClient.scala
+++ b/app/com/gu/identity/service/client/IdentityClient.scala
@@ -35,7 +35,7 @@ class IdentityClient extends Logging {
   def sendResetPasswordEmail(request: SendResetPasswordEmailApiRequest)(implicit configuration: IdentityClientConfiguration, ec: ExecutionContext): Future[Either[IdentityClientErrors, SendResetPasswordEmailResponse ]] = {
     configuration.requestHandler.handleRequest(request).map {
       case Left(error) => {
-        logger.info("Failed to send reset password email request")
+        logger.error("Failed to send reset password email request")
         Left(error)
       }
       case Right(r: SendResetPasswordEmailResponse) => {

--- a/app/com/gu/identity/service/client/request/SendResetPasswordEmailApiRequest.scala
+++ b/app/com/gu/identity/service/client/request/SendResetPasswordEmailApiRequest.scala
@@ -13,12 +13,10 @@ case class SendResetPasswordEmailApiRequest(data: ResetPasswordData, clientIp: C
     "Content-Type" -> "application/json")
   override val url = ApiRequest.apiEndpoint("pwd-reset/send-password-reset-email")
   override val body = Some(SendResetPasswordEmailRequestBody(
-    `email-address` = data.email,
-    `type` = "reset"
+    `email-address` = data.email
   ))
 }
 
 case class SendResetPasswordEmailRequestBody(
-  `email-address`: String,
-  `type`: String
+  `email-address`: String
 ) extends ApiRequestBody

--- a/app/com/gu/identity/service/client/request/SendResetPasswordEmailApiRequest.scala
+++ b/app/com/gu/identity/service/client/request/SendResetPasswordEmailApiRequest.scala
@@ -6,8 +6,16 @@ import com.gu.identity.service.client._
 
 case class SendResetPasswordEmailApiRequest(data: ResetPasswordData, clientIp: ClientIp)
                                            (implicit configuration: IdentityClientConfiguration) extends ApiRequest {
-  override val method = GET
+  override val method = POST
   override val headers = Iterable(ApiRequest.apiKeyHeader, ApiRequest.ipHeader(clientIp))
   override val url = ApiRequest.apiEndpoint("pwd-reset/send-password-reset-email")
-  override val parameters = Seq("type" -> "reset", "email-address" -> data.email)
+  override val body = Some(SendResetPasswordEmailRequestBody(
+    `email-address` = data.email,
+    `type` = "reset"
+  ))
 }
+
+case class SendResetPasswordEmailRequestBody(
+  `email-address`: String,
+  `type`: String
+) extends ApiRequestBody

--- a/app/com/gu/identity/service/client/request/SendResetPasswordEmailApiRequest.scala
+++ b/app/com/gu/identity/service/client/request/SendResetPasswordEmailApiRequest.scala
@@ -7,7 +7,10 @@ import com.gu.identity.service.client._
 case class SendResetPasswordEmailApiRequest(data: ResetPasswordData, clientIp: ClientIp)
                                            (implicit configuration: IdentityClientConfiguration) extends ApiRequest {
   override val method = POST
-  override val headers = Iterable(ApiRequest.apiKeyHeader, ApiRequest.ipHeader(clientIp))
+  override val headers = Iterable(
+    ApiRequest.apiKeyHeader,
+    ApiRequest.ipHeader(clientIp),
+    "Content-Type" -> "application/json")
   override val url = ApiRequest.apiEndpoint("pwd-reset/send-password-reset-email")
   override val body = Some(SendResetPasswordEmailRequestBody(
     `email-address` = data.email,

--- a/test/com/gu/identity/frontend/services/IdentityServiceRequestHandlerSpec.scala
+++ b/test/com/gu/identity/frontend/services/IdentityServiceRequestHandlerSpec.scala
@@ -57,15 +57,13 @@ class IdentityServiceRequestHandlerSpec extends WordSpec with Matchers with Mock
 
     "Encode correct json when using a SendResetPasswordEmailRequest" in {
       val email = "test@guardian.co.uk"
-      val resetType = "reset"
 
-      val requestBody = SendResetPasswordEmailRequestBody(email, resetType)
+      val requestBody = SendResetPasswordEmailRequestBody(email)
 
       val result: String = handler.handleRequestBody(requestBody)
       val jsonResult = Json.parse(result)
 
       (jsonResult \ "email-address").validate[String].asOpt.value should equal(email)
-      (jsonResult \ "type").validate[String].asOpt.value should equal(resetType)
     }
   }
 }

--- a/test/com/gu/identity/frontend/services/IdentityServiceRequestHandlerSpec.scala
+++ b/test/com/gu/identity/frontend/services/IdentityServiceRequestHandlerSpec.scala
@@ -53,5 +53,19 @@ class IdentityServiceRequestHandlerSpec extends WordSpec with Matchers with Mock
       (jsonResult \ "statusFields" \ "receiveGnmMarketing").validate[Boolean].asOpt.value should equal(receiveGnmMarketing)
       (jsonResult \ "statusFields" \ "receive3rdPartyMarketing").validate[Boolean].asOpt.value should equal(receive3rdPartyMarketing)
     }
+
+
+    "Encode correct json when using a SendResetPasswordEmailRequest" in {
+      val email = "test@guardian.co.uk"
+      val resetType = "reset"
+
+      val requestBody = SendResetPasswordEmailRequestBody(email, resetType)
+
+      val result: String = handler.handleRequestBody(requestBody)
+      val jsonResult = Json.parse(result)
+
+      (jsonResult \ "email-address").validate[String].asOpt.value should equal(email)
+      (jsonResult \ "type").validate[String].asOpt.value should equal(resetType)
+    }
   }
 }


### PR DESCRIPTION
Replaces the call to the Identity API pwd-reset endpoint (POST instead of GET)