### PR TITLE
Add a/b test for social permissions copy

### DIFF
--- a/app/com/gu/identity/frontend/models/text/OAuthText.scala
+++ b/app/com/gu/identity/frontend/models/text/OAuthText.scala
@@ -44,3 +44,12 @@ object OAuthRegistrationText {
       google = messages("oauth.register", google)
     )
 }
+
+case class OAuthPermissionsText private(a: String, b: String)
+
+object OAuthPermissionsText {
+  def apply()(implicit messages: Messages): OAuthPermissionsText = OAuthPermissionsText(
+    a = messages("oauth.permission.a"),
+    b = messages("oauth.permission.b")
+  )
+}

--- a/app/com/gu/identity/frontend/mvt/MultiVariantTests.scala
+++ b/app/com/gu/identity/frontend/mvt/MultiVariantTests.scala
@@ -87,6 +87,17 @@ case object RegisterMembershipStandfirstTest extends MultiVariantTest {
 
 case object RegisterMembershipStandfirstVariantA extends MultiVariantTestVariant { val id = "A" }
 
+case object SocialSigninPermissionCopyTest extends MultiVariantTest {
+  val name = "SocialSigninPermissionCopy"
+  val audience = 0.5
+  val audienceOffset = 0.0
+  val isServerSide = true
+  val variants = Seq(SocialSigninPermissionCopyVariantA, SocialSigninPermissionCopyVariantB)
+}
+
+case object SocialSigninPermissionCopyVariantA extends MultiVariantTestVariant { val id = "A" }
+case object SocialSigninPermissionCopyVariantB extends MultiVariantTestVariant { val id = "B" }
+
 /**
  * Define a MVT at runtime - should only be used for tests.
  */
@@ -101,7 +112,7 @@ private[mvt] trait RuntimeMultiVariantTestVariant extends MultiVariantTestVarian
 
 object MultiVariantTests {
 
-  def all: Set[MultiVariantTest] = Set(RegisterMembershipStandfirstTest)
+  def all: Set[MultiVariantTest] = Set(RegisterMembershipStandfirstTest, SocialSigninPermissionCopyTest)
 
   def allActive = all.filter(_.active)
 

--- a/app/com/gu/identity/frontend/views/models/OAuthViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/OAuthViewModel.scala
@@ -1,13 +1,15 @@
 package com.gu.identity.frontend.views.models
 
 import com.gu.identity.frontend.configuration.Configuration
-import com.gu.identity.frontend.models.{ClientID, UrlBuilder, ReturnUrl}
-import com.gu.identity.frontend.models.text.{OAuthText, OAuthRegistrationText, OAuthSignInText}
+import com.gu.identity.frontend.models.{GuardianMembersClientID, ClientID, UrlBuilder, ReturnUrl}
+import com.gu.identity.frontend.models.text.{OAuthText, OAuthRegistrationText, OAuthSignInText, OAuthPermissionsText}
+import com.gu.identity.frontend.mvt._
 import play.api.i18n.Messages
 
 
 sealed trait OAuthViewModel extends ViewModel {
   val all: Seq[OAuthProviderViewModel]
+  val permission: Option[String]
 }
 
 case class OAuthProviderViewModel(
@@ -59,34 +61,45 @@ case object GoogleOAuth extends SupportedOAuthProvider {
 
 
 case class OAuthSignInViewModel private(
-    all: Seq[OAuthProviderViewModel])
+    all: Seq[OAuthProviderViewModel], permission: Option[String])
   extends OAuthViewModel
 
 object OAuthSignInViewModel {
 
-  def apply(configuration: Configuration, returnUrl: ReturnUrl, skipConfirmation: Option[Boolean], clientId: Option[ClientID])(implicit messages: Messages): OAuthSignInViewModel = {
+  def apply(configuration: Configuration, returnUrl: ReturnUrl, skipConfirmation: Option[Boolean], clientId: Option[ClientID], activeTests: ActiveMultiVariantTests)(implicit messages: Messages): OAuthSignInViewModel = {
     val text = OAuthSignInText()
+    val permission = PermissionCopy(activeTests, OAuthPermissionsText())
 
     OAuthSignInViewModel(
-      SupportedOAuthProvider.all.map(OAuthProviderViewModel(_, configuration, text, returnUrl, skipConfirmation, clientId))
+      SupportedOAuthProvider.all.map(OAuthProviderViewModel(_, configuration, text, returnUrl, skipConfirmation, clientId)), permission
     )
   }
-
 }
 
-
 case class OAuthRegistrationViewModel(
-    all: Seq[OAuthProviderViewModel])
+    all: Seq[OAuthProviderViewModel], permission: Option[String])
   extends OAuthViewModel
 
 object OAuthRegistrationViewModel {
 
-  def apply(configuration: Configuration, returnUrl: ReturnUrl, skipConfirmation: Option[Boolean], clientId: Option[ClientID])(implicit messages: Messages): OAuthRegistrationViewModel = {
+  def apply(configuration: Configuration, returnUrl: ReturnUrl, skipConfirmation: Option[Boolean], clientId: Option[ClientID], activeTests: ActiveMultiVariantTests)(implicit messages: Messages): OAuthRegistrationViewModel = {
     val text = OAuthRegistrationText()
+    val permission = PermissionCopy(activeTests, OAuthPermissionsText())
 
     OAuthRegistrationViewModel(
-      SupportedOAuthProvider.all.map(OAuthProviderViewModel(_, configuration, text, returnUrl, skipConfirmation, clientId))
+      SupportedOAuthProvider.all.map(OAuthProviderViewModel(_, configuration, text, returnUrl, skipConfirmation, clientId)), permission
     )
   }
-
 }
+
+object PermissionCopy {
+
+  def apply(activeTests: ActiveMultiVariantTests, text: OAuthPermissionsText): Option[String] = {
+    activeTests.get(SocialSigninPermissionCopyTest) match {
+      case Some(SocialSigninPermissionCopyVariantA) => Some(text.a)
+      case Some(SocialSigninPermissionCopyVariantB) => Some(text.b)
+      case _ => None
+      }
+    }
+  }
+

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -52,7 +52,7 @@ object RegisterViewModel {
     RegisterViewModel(
       layout = layout,
 
-      oauth = OAuthRegistrationViewModel(configuration, returnUrl, skipConfirmation, clientId),
+      oauth = OAuthRegistrationViewModel(configuration, returnUrl, skipConfirmation, clientId, activeTests),
 
       registerPageText = RegisterText(),
       terms = TermsViewModel(),

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -49,7 +49,7 @@ object SignInViewModel {
     SignInViewModel(
       layout = layout,
 
-      oauth = OAuthSignInViewModel(configuration, returnUrl, skipConfirmation, clientId),
+      oauth = OAuthSignInViewModel(configuration, returnUrl, skipConfirmation, clientId, activeTests),
 
       signInPageText = SignInPageText.toMap,
       terms = TermsViewModel(),

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -45,6 +45,8 @@ oauth.signIn=Sign in with {0}
 oauth.register=Sign up with {0}
 oauth.facebook=Facebook
 oauth.google=Google
+oauth.permission.a=We won''t share or post any activity to Facebook or Google
+oauth.permission.b=We''ll never post without your permission
 
 header.backtext=Back to the Guardian
 header.logo=The Guardian

--- a/public/components/oauth-cta/_oauth-cta.css
+++ b/public/components/oauth-cta/_oauth-cta.css
@@ -39,3 +39,10 @@
   @extend %oauth__cta;
   background-image: inline("icon-facebook.svg");
 }
+
+.oauth__cta--permission {
+  @extend %font-text-sans-1;
+  text-align: center;
+  color: #333;
+  margin: 1.2rem 0 0 0;
+}

--- a/public/components/oauth-cta/_oauth-cta.hbs
+++ b/public/components/oauth-cta/_oauth-cta.hbs
@@ -4,4 +4,7 @@
       <a class="oauth__cta--{{ id }}" id="oauth_cta_{{ id }}" href="{{ url }}">{{ text }}</a>
     </div>
   {{/each }}
+  {{#if oauth.permission }}
+    <p class="oauth__cta--permission">{{ oauth.permission }}</p>
+  {{/if}}
 </div>


### PR DESCRIPTION
This PR tests additional copy around social sign-in to encourage the usage of these authentication methods.

![screen shot 2016-03-15 at 14 57 09](https://cloud.githubusercontent.com/assets/406099/13782178/04ae8370-eabe-11e5-9690-3f7657d79a57.png)

See [Test Parameters](https://docs.google.com/document/d/1rNZWBpS7CMnO74uya9UX3l76vqRdydKOvhyZKY4qOMY/edit#heading=h.i2h2thoif3nr) for more detail.