### PR TITLE
Fix fieldset size in Safari

### DIFF
--- a/public/components/form-foundations/_form_foundations.css
+++ b/public/components/form-foundations/_form_foundations.css
@@ -30,6 +30,8 @@
 /** Form fieldset **/
 
 %form__fieldset {
+  @extend %row;
+
   border: none;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Fixes the following issue where the fieldset for the signin and reg forms has an unwanted collapsed margin in Safari.

![signin-fieldset-bug-safari](https://cloud.githubusercontent.com/assets/2298529/13819146/667cdde0-eb90-11e5-86b1-24b26df389a3.png)
