### PR TITLE
Sentry integration in JS

### DIFF
--- a/app/com/gu/identity/frontend/configuration/Configuration.scala
+++ b/app/com/gu/identity/frontend/configuration/Configuration.scala
@@ -29,6 +29,9 @@ case class Configuration(
 
   identityCookiePublicKey: String,
 
+  // endpoint for reporting errors to Sentry
+  sentryDsn: String,
+
   underlying: PlayConfiguration)
 
 
@@ -66,6 +69,8 @@ object Configuration {
 
       identityCookiePublicKey = getString("identityCookie.publicKey"),
 
+      sentryDsn = getString("sentry.dsn"),
+
       underlying = appConfiguration
     )
   }
@@ -93,6 +98,8 @@ object Configuration {
     recaptchaEnabled = true,
 
     identityCookiePublicKey = "",
+
+    sentryDsn = "--stubbed-sentry-dsn--",
 
     underlying = PlayConfiguration.empty
   )

--- a/app/com/gu/identity/frontend/views/models/ContentSecurityPolicy.scala
+++ b/app/com/gu/identity/frontend/views/models/ContentSecurityPolicy.scala
@@ -5,6 +5,7 @@ import com.gu.identity.frontend.controllers._
 object ContentSecurityPolicy {
 
   val CSP_DEFAULT_SRC = "default-src"
+  val CSP_CONNECT_SRC = "connect-src"
   val CSP_SCRIPT_SRC = "script-src"
   val CSP_STYLE_SRC = "style-src"
   val CSP_FONT_SRC = "font-src"
@@ -30,6 +31,7 @@ object ContentSecurityPolicy {
   def cspForViewModel(viewModel: ViewModel with ViewModelResources) = {
     val allResources = viewModel.resources ++ viewModel.indirectResources
     val grouped = allResources.filter(noPolicyRequirement).groupBy {
+      case r: ConnectResource => CSP_CONNECT_SRC
       case r: ScriptResource => CSP_SCRIPT_SRC
       case r: StylesResource => CSP_STYLE_SRC
       case r: ImageResource => CSP_IMG_SRC

--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -1,5 +1,6 @@
 package com.gu.identity.frontend.views.models
 
+import buildinfo.BuildInfo
 import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.models.{GuardianMembersClientID, ReturnUrl, ClientID}
 import com.gu.identity.frontend.models.Text.{HeaderText, LayoutText}
@@ -47,7 +48,11 @@ case class LayoutViewModel private(
 /**
  * Config that will be exposed as Javascript inlined into the html response.
  */
-case class JavascriptConfig(omnitureAccount: String, sentryDsn: String, mvtTests: Seq[MultiVariantTest]) {
+case class JavascriptConfig(
+    omnitureAccount: String,
+    sentryDsn: String,
+    mvtTests: Seq[MultiVariantTest],
+    appVersion: String = BuildInfo.gitCommitId) {
   self =>
 
   import mvt.Implicits._

--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -23,6 +23,7 @@ case object BaseLayoutViewModel extends ViewModel with ViewModelResources {
     IndirectlyLoadedImageResources,
     IndirectlyLoadedInlinedImageResources,
     IndirectlyLoadedExternalScriptResources("https://j.ophan.co.uk"),
+    IndirectlyLoadedExternalResources("https://app.getsentry.com/api/"),
     IndirectlyLoadedExternalImageResources("https://hits-secure.theguardian.com"),
     IndirectlyLoadedExternalImageResources("https://sb.scorecardresearch.com"),
     IndirectlyLoadedExternalImageResources("https://ophan.theguardian.com")
@@ -46,7 +47,7 @@ case class LayoutViewModel private(
 /**
  * Config that will be exposed as Javascript inlined into the html response.
  */
-case class JavascriptConfig(omnitureAccount: String, mvtTests: Seq[MultiVariantTest]) {
+case class JavascriptConfig(omnitureAccount: String, sentryDsn: String, mvtTests: Seq[MultiVariantTest]) {
   self =>
 
   import mvt.Implicits._
@@ -93,6 +94,7 @@ object LayoutViewModel {
 
     val config = JavascriptConfig(
       omnitureAccount = configuration.omnitureAccount,
+      sentryDsn = configuration.sentryDsn,
       mvtTests = MultiVariantTests.all.toSeq
     )
 

--- a/app/com/gu/identity/frontend/views/models/PageResources.scala
+++ b/app/com/gu/identity/frontend/views/models/PageResources.scala
@@ -39,6 +39,7 @@ sealed trait LinkedResource {
   val url: String
 }
 
+sealed trait ConnectResource extends PageResource
 sealed trait ScriptResource extends PageResource
 sealed trait StylesResource extends PageResource
 sealed trait ImageResource extends PageResource
@@ -117,5 +118,7 @@ case class IndirectlyLoadedExternalImageResources(domain: String) extends ImageR
 case object IndirectlyLoadedScriptResources extends ScriptResource with LocalResource
 case object IndirectlyLoadedInlinedScriptResources extends ScriptResource with InlinedResource
 case class IndirectlyLoadedExternalScriptResources(domain: String) extends ScriptResource with ExternalResource
+
+case class IndirectlyLoadedExternalResources(domain: String) extends ConnectResource with ExternalResource
 
 case class IndirectlyLoadedExternalFrameResource(domain: String) extends FrameResource with ExternalResource

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -43,3 +43,5 @@ identity {
     }
   }
 }
+
+sentry.dsn = ${?IDENTITY_SENTRY_DSN}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "cookie-cutter": "^0.1.1",
     "curl-amd": "^0.8.12",
-    "lodash": "^4.0.1"
+    "lodash": "^4.0.1",
+    "raven-js": "2.2.1"
   }
 }

--- a/public/components/configuration/configuration.js
+++ b/public/components/configuration/configuration.js
@@ -3,14 +3,15 @@
 import { getElementById } from '../browser/browser';
 
 class Configuration {
-  constructor( omnitureAccount, sentryDsn, mvtTests ) {
+  constructor( omnitureAccount, sentryDsn, mvtTests, appVersion ) {
     this.omnitureAccount = omnitureAccount;
     this.sentryDsn = sentryDsn;
     this.mvtTests = mvtTests;
+    this.appVersion = appVersion;
   }
 
-  static fromObject( { omnitureAccount, sentryDsn, mvtTests } ) {
-    return new Configuration( omnitureAccount, sentryDsn, mvtTests );
+  static fromObject( { omnitureAccount, sentryDsn, mvtTests, appVersion } ) {
+    return new Configuration( omnitureAccount, sentryDsn, mvtTests, appVersion );
   }
 
   static fromDocument() {

--- a/public/components/configuration/configuration.js
+++ b/public/components/configuration/configuration.js
@@ -3,13 +3,14 @@
 import { getElementById } from '../browser/browser';
 
 class Configuration {
-  constructor( omnitureAccount, mvtTests ) {
+  constructor( omnitureAccount, sentryDsn, mvtTests ) {
     this.omnitureAccount = omnitureAccount;
+    this.sentryDsn = sentryDsn;
     this.mvtTests = mvtTests;
   }
 
-  static fromObject( { omnitureAccount, mvtTests } ) {
-    return new Configuration( omnitureAccount, mvtTests );
+  static fromObject( { omnitureAccount, sentryDsn, mvtTests } ) {
+    return new Configuration( omnitureAccount, sentryDsn, mvtTests );
   }
 
   static fromDocument() {

--- a/public/components/sentry/sentry.js
+++ b/public/components/sentry/sentry.js
@@ -10,9 +10,12 @@ import { configuration } from '../configuration/configuration';
 
 function init() {
   const dsn = configuration.sentryDsn;
+  const ravenOptions = {
+    release: configuration.appVersion
+  };
 
   if ( typeof dsn === 'string' ) {
-    Raven.config( dsn ).install();
+    Raven.config( dsn, ravenOptions ).install();
 
 
   } else if ( console ) {

--- a/public/components/sentry/sentry.js
+++ b/public/components/sentry/sentry.js
@@ -1,0 +1,23 @@
+/**
+ * Use sentry to record Javascript errors
+ */
+
+/*global console*/
+
+import Raven from 'raven-js';
+
+import { configuration } from '../configuration/configuration';
+
+function init() {
+  const dsn = configuration.sentryDsn;
+
+  if ( typeof dsn === 'string' ) {
+    Raven.config( dsn ).install();
+
+
+  } else if ( console ) {
+    console.warn( 'Sentry configuration not found' );
+  }
+}
+
+init();

--- a/public/main.js
+++ b/public/main.js
@@ -1,3 +1,5 @@
+import './components/sentry/sentry';
+
 import { isSupported as isBrowserSupported } from './components/browser/browser';
 
 import { logPageView } from './components/analytics/analytics';


### PR DESCRIPTION
Initial Sentry integration in Javascript. Will log JS errors with Sentry, associating the Git hash as the Release Version for tracking errors between releases.

For example, this: [reported error](https://app.getsentry.com/the-guardian/identity-frontend-dev/issues/117568067/)