### PR TITLE
Fix handlebars for terms and conditions

### DIFF
--- a/app/com/gu/identity/frontend/authentication/UserAuthenticatedAction.scala
+++ b/app/com/gu/identity/frontend/authentication/UserAuthenticatedAction.scala
@@ -32,11 +32,11 @@ object UserAuthenticatedActionBuilder extends Logging{
             case Some(cookie) => Right(new UserAuthenticatedRequest[A](cookie, request))
             case _ => {
               logger.error("Cookie not found on successfully authenticated request.")
-              Left(SeeOther(routes.Application.signIn(Seq.empty, returnUrl, skipConfirmation, clientId.map(_.id), groupCode.map(_.getCodeValue)).url))
+              Left(SeeOther(routes.Application.signIn(Seq.empty, returnUrl, skipConfirmation, clientId.map(_.id), groupCode.map(_.id)).url))
             }
           }
         }
-        case _ => Left(SeeOther(routes.Application.signIn(Seq.empty, returnUrl, skipConfirmation, clientId.map(_.id), groupCode.map(_.getCodeValue)).url))
+        case _ => Left(SeeOther(routes.Application.signIn(Seq.empty, returnUrl, skipConfirmation, clientId.map(_.id), groupCode.map(_.id)).url))
       }
     }
   }

--- a/app/com/gu/identity/frontend/controllers/RegisterAction.scala
+++ b/app/com/gu/identity/frontend/controllers/RegisterAction.scala
@@ -92,7 +92,7 @@ class RegisterAction(identityService: IdentityService, val messagesApi: Messages
     val params = Seq(
       Some("returnUrl" -> returnUrl.url),
       skipConfirmation.map("skipConfirmation" -> _.toString),
-      group.map("group" -> _.getCodeValue),
+      group.map("group" -> _.id),
       clientId.map("clientId" -> _.id)
     ).flatten
 

--- a/app/com/gu/identity/frontend/controllers/ThirdPartyTsAndCs.scala
+++ b/app/com/gu/identity/frontend/controllers/ThirdPartyTsAndCs.scala
@@ -79,7 +79,7 @@ class ThirdPartyTsAndCs(identityService: IdentityService, config: Configuration,
   }
 
   def addToGroup(group: GroupCode, sc_gu_uCookie: Cookie, returnUrl: ReturnUrl): Future[Either[Seq[ServiceError], Result]] = {
-    val response = identityService.assignGroupCode(group.getCodeValue, sc_gu_uCookie)
+    val response = identityService.assignGroupCode(group.id, sc_gu_uCookie)
     response.map{
       case Left(errors) => Left(errors)
       case Right(_) => Right(SeeOther(returnUrl.url))
@@ -89,7 +89,7 @@ class ThirdPartyTsAndCs(identityService: IdentityService, config: Configuration,
   def checkUserForGroupMembership(group: GroupCode, cookie: Cookie): Future[Either[Seq[ServiceError], Boolean]] = {
     identityService.getUser(cookie).map{
       case Right(user) => {
-        Right(isUserInGroup(user, group.getCodeValue))
+        Right(isUserInGroup(user, group.id))
       }
       case Left(errors) => {
         logger.error("Request did not have a SC_GU_U cookie could not get user.")

--- a/app/com/gu/identity/frontend/models/GroupCode.scala
+++ b/app/com/gu/identity/frontend/models/GroupCode.scala
@@ -3,8 +3,13 @@ package com.gu.identity.frontend.models
 import play.api.data.format.Formatter
 import play.api.data.{FormError, Forms, FieldMapping}
 
-sealed trait GroupCode {
-  def getCodeValue: String
+sealed trait GroupCode extends Product2[GroupCode, String] {
+  self =>
+
+  val id: String
+
+  def _1 = self
+  def _2 = id
 }
 
 object GroupCode {
@@ -32,14 +37,14 @@ object GroupCode {
       }
 
       def unbind(key: String, value: GroupCode): Map[String, String] =
-        Map(key -> value.getCodeValue)
+        Map(key -> value.id)
     }
   }
 }
 
 case object GuardianTeachersNetwork extends GroupCode {
-  val getCodeValue: String = "GTNF"
+  val id: String = "GTNF"
 }
 case object GuardianJobs extends GroupCode {
-  val getCodeValue: String = "GRS"
+  val id: String = "GRS"
 }

--- a/app/com/gu/identity/frontend/models/UrlBuilder.scala
+++ b/app/com/gu/identity/frontend/models/UrlBuilder.scala
@@ -54,7 +54,7 @@ object UrlBuilder {
       group: GroupCode,
       configuration: Configuration): ReturnUrl = {
 
-    val baseThirdPartyReturnUrl = configuration.identityProfileBaseUrl + "/agree/" + group.getCodeValue
+    val baseThirdPartyReturnUrl = configuration.identityProfileBaseUrl + "/agree/" + group.id
     val thirdPartyReturnUrl = apply(baseThirdPartyReturnUrl, returnUrl, skipConfirmation, clientId, group = None, Some(skipThirdPartyLandingPage))
     ReturnUrl(Some(thirdPartyReturnUrl), configuration)
   }
@@ -68,7 +68,7 @@ object UrlBuilder {
       configuration: Configuration): String = {
 
     val thirdPartyReturnUrl = buildThirdPartyReturnUrl(returnUrl, skipConfirmation, skipThirdPartyLandingPage = true, clientId, group, configuration)
-    apply(baseUrl, thirdPartyReturnUrl, skipConfirmation, clientId, Some(group.getCodeValue), skipThirdPartyLandingPage = None)
+    apply(baseUrl, thirdPartyReturnUrl, skipConfirmation, clientId, Some(group.id), skipThirdPartyLandingPage = None)
   }
 
   private def buildParams(

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -57,7 +57,7 @@ object RegisterViewModel {
       oauth = OAuthRegistrationViewModel(configuration, returnUrl, skipConfirmation, clientId, group, activeTests),
 
       registerPageText = RegisterText(),
-      terms = Terms.getTermsModel(group.map(_.id)),
+      terms = Terms.getTermsModel(group),
 
       hasErrors = errors.nonEmpty,
       errors = errors,

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -26,6 +26,7 @@ case class RegisterViewModel(
     returnUrl: String,
     skipConfirmation: Boolean,
     clientId: Option[ClientID],
+    group: Option[GroupCode],
 
     actions: RegisterActions,
     links: RegisterLinks,
@@ -56,7 +57,7 @@ object RegisterViewModel {
       oauth = OAuthRegistrationViewModel(configuration, returnUrl, skipConfirmation, clientId, group, activeTests),
 
       registerPageText = RegisterText(),
-      terms = Terms.getTermsModel(group.map(_.getCodeValue)),
+      terms = Terms.getTermsModel(group.map(_.id)),
 
       hasErrors = errors.nonEmpty,
       errors = errors,
@@ -67,6 +68,7 @@ object RegisterViewModel {
       returnUrl = returnUrl.url,
       skipConfirmation = skipConfirmation.getOrElse(false),
       clientId = clientId,
+      group = group,
 
       actions = RegisterActions(),
       links = RegisterLinks(returnUrl, skipConfirmation, clientId),

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -61,7 +61,7 @@ object SignInViewModel {
       oauth = OAuthSignInViewModel(configuration, returnUrl, skipConfirmation, clientId, group, activeTests),
 
       signInPageText = SignInPageText.toMap,
-      terms = Terms.getTermsModel(group.map(_.id)),
+      terms = Terms.getTermsModel(group),
 
       hasErrors = errors.nonEmpty,
       errors = errors,

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -24,7 +24,7 @@ case class SignInViewModel private(
     returnUrl: String = "",
     skipConfirmation: Boolean = false,
     clientId: Option[ClientID],
-    groupCode: Option[String],
+    group: Option[GroupCode],
 
     registerUrl: String = "",
     forgotPasswordUrl: String = "",
@@ -61,7 +61,7 @@ object SignInViewModel {
       oauth = OAuthSignInViewModel(configuration, returnUrl, skipConfirmation, clientId, group, activeTests),
 
       signInPageText = SignInPageText.toMap,
-      terms = Terms.getTermsModel(group.map(_.getCodeValue)),
+      terms = Terms.getTermsModel(group.map(_.id)),
 
       hasErrors = errors.nonEmpty,
       errors = errors,
@@ -70,10 +70,10 @@ object SignInViewModel {
       returnUrl = returnUrl.url,
       skipConfirmation = skipConfirmation.getOrElse(false),
       clientId = clientId,
-      groupCode = group.map(_.getCodeValue),
+      group = group,
 
-      registerUrl = UrlBuilder(routes.Application.register(), returnUrl, skipConfirmation, clientId, group.map(_.getCodeValue)),
-      forgotPasswordUrl = UrlBuilder("/reset", returnUrl, skipConfirmation, clientId, group.map(_.getCodeValue)),
+      registerUrl = UrlBuilder(routes.Application.register(), returnUrl, skipConfirmation, clientId, group.map(_.id)),
+      forgotPasswordUrl = UrlBuilder("/reset", returnUrl, skipConfirmation, clientId, group.map(_.id)),
 
       recaptchaModel = recaptchaModel,
 

--- a/app/com/gu/identity/frontend/views/models/TermsViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/TermsViewModel.scala
@@ -1,5 +1,6 @@
 package com.gu.identity.frontend.views.models
 
+import com.gu.identity.frontend.models.{GroupCode, GuardianJobs, GuardianTeachersNetwork}
 import com.gu.identity.frontend.models.text.{JobsTermsText, TeachersTermsText, TermsText}
 import play.api.i18n.Messages
 
@@ -80,10 +81,10 @@ object JobsTermsViewModel {
 }
 
 object Terms {
-  def getTermsModel(groupCode: Option[String])(implicit messages: Messages): TermsViewModel = {
-    groupCode match {
-      case Some("GTNF") => {TeachersTermsViewModel()}
-      case Some("GRS") => JobsTermsViewModel()
+  def getTermsModel(group: Option[GroupCode])(implicit messages: Messages): TermsViewModel = {
+    group match {
+      case Some(GuardianTeachersNetwork) => {TeachersTermsViewModel()}
+      case Some(GuardianJobs) => JobsTermsViewModel()
       case _ => BasicTermsViewModel()
     }
   }

--- a/app/com/gu/identity/frontend/views/models/TsAndCsViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/TsAndCsViewModel.scala
@@ -32,7 +32,7 @@ object TsAndCsViewModel {
       indirectResources = layout.indirectResources,
       clientId = clientId,
       tsAndCsPageText = TsAndCsPageText.getPageText(group),
-      groupCode = group.getCodeValue,
+      groupCode = group.id,
       returnUrl = returnUrl.url
     )
   }

--- a/public/components/register-form/_register-form.hbs
+++ b/public/components/register-form/_register-form.hbs
@@ -3,9 +3,9 @@
   <input type="hidden" name="returnUrl" value="{{ returnUrl }}"/>
   <input type="hidden" name="skipConfirmation" value="{{ skipConfirmation }}"/>
 
-  {{# groupCode }}
-      <input type="hidden" name="groupCode" value="{{ groupCode }}">
-  {{/ groupCode }}
+  {{# group }}
+      <input type="hidden" name="groupCode" value="{{ group.id }}">
+  {{/ group }}
 
   {{# clientId }}
     <input type="hidden" name="clientId" value="{{ clientId.id }}">

--- a/public/components/signin-form/_signin-form.hbs
+++ b/public/components/signin-form/_signin-form.hbs
@@ -3,13 +3,13 @@
   <input type="hidden" name="returnUrl" value="{{returnUrl}}">
   <input type="hidden" name="skipConfirmation" value="{{skipConfirmation}}">
 
+  {{# group }}
+      <input type="hidden" name="groupCode" value="{{ group.id }}">
+  {{/ group }}
+
   {{# clientId }}
     <input type="hidden" name="clientId" value="{{ clientId.id }}">
   {{/ clientId }}
-
-  {{# groupCode }}
-      <input type="hidden" name="groupCode" value="{{ groupCode }}">
-  {{/ groupCode }}
 
   <p class="signin-form__prelude">{{signInPageText.divideText}}</p>
 


### PR DESCRIPTION
This change fixes an issue with the group code not being rendered in the Handlebars templates.

`GroupCode` has been changed to follow the same pattern as for `ClientId`.