### PR TITLE
Fixes for a few client-side errors reported in Sentry

### DIFF
--- a/public/components/analytics/ophan.js
+++ b/public/components/analytics/ophan.js
@@ -16,8 +16,19 @@ const curlOptions = {
 };
 
 
-function getOphan() {
-  return curl(curlOptions, ['ophan/ng']);
+function getOphan( retryCount = 1 ) {
+  return curl( curlOptions, [ 'ophan/ng' ] )
+    .then(
+      ophan => ophan,
+      error => {
+        console.log('here: ' + retryCount + error);
+        if ( retryCount <= 2 ) {
+          return getOphan( retryCount + 1 );
+        } else {
+          throw error;
+        }
+      }
+    )
 }
 
 export function init() {

--- a/public/components/sentry/sentry.js
+++ b/public/components/sentry/sentry.js
@@ -11,6 +11,9 @@ import { configuration } from '../configuration/configuration';
 function init() {
   const dsn = configuration.sentryDsn;
   const ravenOptions = {
+    whitelistUrls: [
+      /ophan\.co\.uk/
+    ],
     release: configuration.appVersion
   };
 


### PR DESCRIPTION
- Ignore all errors from Ophan (same as dotcom)
- Catch all sessionStorage errors and perform checks before using it
- Retry loading of Ophan script, in case of network error