### PR TITLE
#1202 Display specific error message on registration page for invalid email 

### DIFF
--- a/app/com/gu/identity/frontend/errors/RegisterAppException.scala
+++ b/app/com/gu/identity/frontend/errors/RegisterAppException.scala
@@ -15,6 +15,7 @@ object RegisterServiceAppException {
   def apply(clientError: IdentityClientError): RegisterServiceAppException =
     clientError match {
       case ClientRegistrationUsernameConflictError => RegisterUsernameConflictAppException
+      case ClientRegistrationEmailValidationError => RegisterEmailInvalidConflictAppException
       case ClientRegistrationEmailConflictError => RegisterEmailConflictAppException
       case err: ClientBadRequestError => RegisterServiceBadRequestException(clientError)
       case err: ClientGatewayError => RegisterServiceGatewayAppException(clientError)
@@ -42,6 +43,13 @@ case object RegisterEmailConflictAppException
   with RegisterServiceAppException {
 
   val id = RegisterEmailConflictErrorID
+}
+
+case object RegisterEmailInvalidConflictAppException
+  extends ServiceBadRequestAppException(ClientRegistrationEmailValidationError)
+  with RegisterServiceAppException {
+
+  val id = RegisterActionInvalidEmailErrorID
 }
 
 case object RegisterUsernameConflictAppException

--- a/app/com/gu/identity/frontend/models/TrackingData.scala
+++ b/app/com/gu/identity/frontend/models/TrackingData.scala
@@ -11,7 +11,7 @@ case class TrackingData(returnUrl:Option[String],
                         referrer: Option[String],
                         userAgent: Option[String]) {
   def parameters: HttpParameters = List(
-    returnUrl.map("trackingReturnUrl" -> _),
+    returnUrl.map("returnUrl" -> _),
     registrationType.map("trackingRegistrationType" -> _),
     omnitureSVi.map("trackingOmnitureSVI" -> _),
     ipAddress.map("trackingIpAddress" -> _),

--- a/app/com/gu/identity/service/client/Errors.scala
+++ b/app/com/gu/identity/service/client/Errors.scala
@@ -74,6 +74,10 @@ case object ClientRegistrationEmailConflictError
   with ClientBadRequestError
   with NoStackTrace
 
+case object ClientRegistrationEmailValidationError
+  extends AbstractIdentityClientError("Invalid emailAddress:", context = Some("user.primaryEmailAddress"))
+  with ClientBadRequestError
+  with NoStackTrace
 
 case object ClientRateLimitError
   extends AbstractIdentityClientError("Rate limit exceeded")
@@ -99,6 +103,7 @@ object ClientBadRequestError {
       case ClientRegistrationUsernameConflictError.message => ClientRegistrationUsernameConflictError
       case ClientRegistrationUsernameConflictError.messageForReservedUser => ClientRegistrationUsernameConflictError
       case ClientRegistrationEmailConflictError.message => ClientRegistrationEmailConflictError
+      case ClientRegistrationEmailValidationError.message => ClientRegistrationEmailValidationError
       case ClientRateLimitError.message => ClientRateLimitError
       case _ => OtherClientBadRequestError(message, description, context)
     }


### PR DESCRIPTION
Previously if the user entered an invalid email, the generic "one or more inputs
was not valid, please try again" message was displayed.

- Ensure that if the user enters an invalid email address, they are shown an error
saying ""Invalid email address; please try again."