### PR TITLE
Cloudwatch small datapoints

### DIFF
--- a/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
+++ b/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
@@ -5,7 +5,7 @@ import com.gu.identity.frontend.controllers._
 import com.gu.identity.frontend.csrf.CSRFConfig
 import com.gu.identity.frontend.errors.ErrorHandler
 import com.gu.identity.frontend.filters.{HtmlCompressorFilter, SecurityHeadersFilter, Filters}
-import com.gu.identity.frontend.logging.MetricsLoggingActor
+import com.gu.identity.frontend.logging.{SmallDataPointCloudwatchLogging, MetricsLoggingActor}
 import com.gu.identity.frontend.services.{GoogleRecaptchaServiceHandler, IdentityServiceRequestHandler, IdentityServiceImpl, IdentityService}
 import com.gu.identity.service.client.IdentityClient
 import jp.co.bizreach.play2handlebars.HandlebarsPlugin
@@ -61,6 +61,10 @@ class ApplicationComponents(context: Context) extends BuiltInComponentsFromConte
   // Makes sure the logback.xml file is being found in DEV environments
   if (environment.mode == Mode.Dev) {
     Logger.configure(environment)
+  }
+
+  if (environment.mode == Mode.Prod) {
+    new SmallDataPointCloudwatchLogging(actorSystem).start
   }
 
   applicationLifecycle.addStopHook(() => terminateActor()(defaultContext))

--- a/cloudformation/identity-frontend.template
+++ b/cloudformation/identity-frontend.template
@@ -467,7 +467,7 @@
         "AlarmDescription": "Low number of users signing in.",
         "Namespace": "SuccessfulSignIns",
         "MetricName": "SuccessfulSignIn",
-        "Statistic": "Average",
+        "Statistic": "Sum",
         "ComparisonOperator": "LessThanThreshold",
         "Threshold": "0.9",
         "Period": "1200",
@@ -475,6 +475,12 @@
         "AlarmActions": [
           { "Ref": "TopicSendEmail" },
           { "Ref": "TopicPagerDutyAlerts" }
+        ],
+        "Dimensions": [
+          {
+            "Name": "Stage",
+            "Value": { "Ref": "Stage"}
+          }
         ]
       }
     },


### PR DESCRIPTION
Sends a data point with a very small value to the CloudWatch Signin metric every 10 seconds. This makes sure the SigninInactivity alarm is never into an "INSUFFICIENT_DATA" state. Also updates the alarm to include the stage dimension
