### PR TITLE
Fix broken Guardian T&C's links

### DIFF
--- a/app/com/gu/identity/frontend/models/text/TermsText.scala
+++ b/app/com/gu/identity/frontend/models/text/TermsText.scala
@@ -5,7 +5,9 @@ import play.api.i18n.Messages
 case class TermsText private(
      conditionsText: String,
      termsOfServiceText: String,
-     privacyPolicyText: String)
+     termsOfServiceUrl: String,
+     privacyPolicyText: String,
+     privacyPolicyUrl: String)
 
 case class TeachersTermsText private(
     basicTermsText: TermsText,
@@ -20,7 +22,9 @@ object TermsText {
     TermsText(
       conditionsText = messages("terms.conditions"),
       termsOfServiceText = messages("terms.termsOfService"),
-      privacyPolicyText = messages("terms.privacyPolicy")
+      termsOfServiceUrl = messages("terms.termsOfServiceUrl"),
+      privacyPolicyText = messages("terms.privacyPolicy"),
+      privacyPolicyUrl = messages("terms.privacyPolicyUrl")
     )
 }
 

--- a/app/com/gu/identity/frontend/views/models/TermsViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/TermsViewModel.scala
@@ -8,21 +8,25 @@ sealed trait TermsViewModel{
   def conditionsText: String
   def termsOfServiceText: String
   def privacyPolicyText: String
-  val termsOfServiceUrl: String = "http://www.theguardian.com/help/terms-of-service"
-  val privacyPolicyUrl: String = "http://www.theguardian.com/help/privacy-policy"
+  def termsOfServiceUrl: String
+  def privacyPolicyUrl: String
 }
 
 case class BasicTermsViewModel private(
     conditionsText: String,
     termsOfServiceText: String,
-    privacyPolicyText: String)
+    termsOfServiceUrl: String,
+    privacyPolicyText: String,
+    privacyPolicyUrl: String)
   extends ViewModel with TermsViewModel {
 }
 
 case class TeachersTermsViewModel private(
     conditionsText: String,
     termsOfServiceText: String,
+    termsOfServiceUrl: String,
     privacyPolicyText: String,
+    privacyPolicyUrl: String,
     extendedConditionsText: String,
     extendedTermsOfServiceUrl: String,
     extendedPrivacyPolicyUrl: String)
@@ -33,7 +37,9 @@ case class TeachersTermsViewModel private(
 case class JobsTermsViewModel(
     conditionsText: String,
     termsOfServiceText: String,
+    termsOfServiceUrl: String,
     privacyPolicyText: String,
+    privacyPolicyUrl: String,
     extendedConditionsText: String,
     extendedTermsOfServiceUrl: String,
     extendedPrivacyPolicyUrl: String)
@@ -47,7 +53,9 @@ object BasicTermsViewModel {
     BasicTermsViewModel(
       conditionsText = text.conditionsText,
       termsOfServiceText = text.termsOfServiceText,
-      privacyPolicyText = text.privacyPolicyText
+      termsOfServiceUrl = text.termsOfServiceUrl,
+      privacyPolicyText = text.privacyPolicyText,
+      privacyPolicyUrl = text.privacyPolicyUrl
     )
   }
 }
@@ -58,7 +66,9 @@ object TeachersTermsViewModel {
     TeachersTermsViewModel(
       conditionsText = text.basicTermsText.conditionsText,
       termsOfServiceText = text.basicTermsText.termsOfServiceText,
+      termsOfServiceUrl = text.basicTermsText.termsOfServiceUrl,
       privacyPolicyText = text.basicTermsText.privacyPolicyText,
+      privacyPolicyUrl = text.basicTermsText.privacyPolicyUrl,
       extendedConditionsText = text.conditionsText,
       extendedTermsOfServiceUrl = "http://teachers.theguardian.com/Terms.htm",
       extendedPrivacyPolicyUrl = "http://teachers.theguardian.com/privacypolicy.htm"
@@ -72,7 +82,9 @@ object JobsTermsViewModel {
     JobsTermsViewModel(
       conditionsText = text.basicTermsText.conditionsText,
       termsOfServiceText = text.basicTermsText.termsOfServiceText,
+      termsOfServiceUrl = text.basicTermsText.termsOfServiceUrl,
       privacyPolicyText = text.basicTermsText.privacyPolicyText,
+      privacyPolicyUrl = text.basicTermsText.privacyPolicyUrl,
       extendedConditionsText = text.conditionsText,
       extendedTermsOfServiceUrl = "https://jobs.theguardian.com/terms-and-conditions/",
       extendedPrivacyPolicyUrl = "https://jobs.theguardian.com/privacy-policy/"

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -38,7 +38,9 @@ register.createAccount=Create account
 # com.gu.identity.frontend.models.text.TermsText
 terms.conditions=By proceeding, you agree to the Guardian''s
 terms.termsOfService=Terms of Service
+terms.termsOfServiceUrl=http://www.theguardian.com/help/terms-of-service
 terms.privacyPolicy=Privacy Policy
+terms.privacyPolicyUrl=http://www.theguardian.com/help/privacy-policy
 terms.teachersConditions=and Guardian Teacher Network''s
 terms.jobsConditions=and Guardian Jobs''
 


### PR DESCRIPTION
Oddly the vals in `TermsViewModel` did not propagate properly to HandleBars.

This makes them part of the case class, which ensures they get through correctly.