### PR TITLE
Add SG parameter for Vulnerability Scanning

### DIFF
--- a/cloudformation/identity-frontend.template
+++ b/cloudformation/identity-frontend.template
@@ -15,6 +15,10 @@
       "Description": "Security group that is allowed SSH access to the instances",
       "Type": "AWS::EC2::SecurityGroup::Id"
     },
+    "VulnerabilityScanningSecurityGroup": {
+      "Description": "Security group that grants access to the account's Vulnerability Scanner",
+      "Type": "AWS::EC2::SecurityGroup::Id"
+    },
     "VpcId": {
       "Description": "ID of the VPC onto which to launch the application",
       "Type": "AWS::EC2::VPC::Id"
@@ -266,7 +270,8 @@
         "ImageId": {"Ref": "AmiId"},
         "SecurityGroups": [
           {"Ref": "InstanceSecurityGroup"},
-          {"Ref": "SshAccessSecurityGroup"}
+          {"Ref": "SshAccessSecurityGroup"},
+          {"Ref": "VulnerabilityScanningSecurityGroup"}
         ],
         "InstanceType": {
           "Fn::FindInMap": ["StageVariables", {


### PR DESCRIPTION
There is now a vulnerability scanner in the Identity account. This PR lets us add a Security Group to instances to allow vulnerability scans.
