### PR TITLE
Check email demain on registration

### DIFF
--- a/app/com/gu/identity/frontend/configuration/Configuration.scala
+++ b/app/com/gu/identity/frontend/configuration/Configuration.scala
@@ -114,7 +114,7 @@ object Configuration {
       val provider = new AWSCredentialsProviderChain(
         new EnvironmentVariableCredentialsProvider(),
         new SystemPropertiesCredentialsProvider(),
-        new ProfileCredentialsProvider("identity"),
+        new ProfileCredentialsProvider(),
         new InstanceProfileCredentialsProvider
       )
       provider

--- a/app/com/gu/identity/frontend/configuration/Configuration.scala
+++ b/app/com/gu/identity/frontend/configuration/Configuration.scala
@@ -114,7 +114,7 @@ object Configuration {
       val provider = new AWSCredentialsProviderChain(
         new EnvironmentVariableCredentialsProvider(),
         new SystemPropertiesCredentialsProvider(),
-        new ProfileCredentialsProvider(),
+        new ProfileCredentialsProvider("identity"),
         new InstanceProfileCredentialsProvider
       )
       provider

--- a/app/com/gu/identity/frontend/configuration/Configuration.scala
+++ b/app/com/gu/identity/frontend/configuration/Configuration.scala
@@ -33,6 +33,11 @@ case class Configuration(
   sentryDsnJs: String,
   sentryDsnScala: String,
 
+  //S£ bucket details for infosex
+
+  infoSecS3BucketName: String,
+  infoSecS3BucketKey: String,
+
   underlying: PlayConfiguration)
 
 
@@ -74,6 +79,10 @@ object Configuration {
 
       sentryDsnScala = getString("sentry.dsn.scala"),
 
+      infoSecS3BucketName = getString("infosec.s3.bucket.name"),
+
+      infoSecS3BucketKey = getString("infosec.s3.bucket.key"),
+
       underlying = appConfiguration
     )
   }
@@ -105,6 +114,10 @@ object Configuration {
     sentryDsnJs = "--stubbed-sentry-dsn-js--",
 
     sentryDsnScala = "--stubbed-sentry-dsn-scala--",
+
+    infoSecS3BucketName = "infosec.s3.bucket.name",
+
+    infoSecS3BucketKey = "infosec.s3.bucket.key",
 
     underlying = PlayConfiguration.empty
   )

--- a/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
+++ b/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
@@ -29,17 +29,14 @@ import scala.concurrent.duration.Duration
 
 class FrontendApplicationLoader extends ApplicationLoader with ExecutionContexts {
 
-  //lazy val actorSystem = PlayAkka.system(Play.current)
-
   def load(context: Context) = {
-    println("++Wotcha")
     val app = new ApplicationComponents(context).application
+
     app.actorSystem.scheduler.schedule(
       Duration.create(0, TimeUnit.SECONDS),
       Duration.create(30, TimeUnit.SECONDS),
       BlockedEmailDomainList
     )
-    println("++Wotcha II")
     new HandlebarsPlugin(app)
     app
   }
@@ -86,8 +83,6 @@ class ApplicationComponents(context: Context) extends BuiltInComponentsFromConte
   if (environment.mode == Mode.Prod) {
     new SmallDataPointCloudwatchLogging(actorSystem).start
   }
-
-
 
   applicationLifecycle.addStopHook(() => terminateActor()(defaultContext))
 

--- a/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
+++ b/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
@@ -34,7 +34,7 @@ class FrontendApplicationLoader extends ApplicationLoader with ExecutionContexts
 
     app.actorSystem.scheduler.schedule(
       Duration.create(0, TimeUnit.SECONDS),
-      Duration.create(30, TimeUnit.SECONDS),
+      Duration.create(30, TimeUnit.MINUTES),
       BlockedEmailDomainList
     )
     new HandlebarsPlugin(app)

--- a/app/com/gu/identity/frontend/jobs/BlockedEmailDomainList.scala
+++ b/app/com/gu/identity/frontend/jobs/BlockedEmailDomainList.scala
@@ -27,10 +27,7 @@ object BlockedEmailDomainList extends ExecutionContexts with Logging {
 
 }
 
-class BlockedEmailDomainListJob(theActorSystem: ActorSystem, configuration: Configuration) extends ExecutionContexts with Logging  {
-
-  //Need to do this to avoid an "There is no started Application" error: We want the executionContext from the trait but not the actor syatem
-  override lazy val actorSystem = theActorSystem
+class BlockedEmailDomainListJob(actorSystem: ActorSystem, configuration: Configuration) extends ExecutionContexts with Logging  {
 
   def start = {
     logger.info("Starting job to update list of barred registration domains every half houe");

--- a/app/com/gu/identity/frontend/jobs/BlockedEmailDomainList.scala
+++ b/app/com/gu/identity/frontend/jobs/BlockedEmailDomainList.scala
@@ -16,13 +16,10 @@ object BlockedEmailDomainList extends ExecutionContexts with Runnable with Loggi
     val t = Set("one","two","three")
     val domains = S3InfoSec.getBlockedEmailDomains map {
       blockedDomains => blockedDomains.split("\n").toSet
-
     } getOrElse Set()
     blockedDomainsAgent.send(domains)
-
   }
 
   def getBlockedDomains = blockedDomainsAgent.get()
-
 
 }

--- a/app/com/gu/identity/frontend/jobs/BlockedEmailDomainList.scala
+++ b/app/com/gu/identity/frontend/jobs/BlockedEmailDomainList.scala
@@ -13,7 +13,6 @@ object BlockedEmailDomainList extends ExecutionContexts with Runnable with Loggi
 
     logger.info("Getting list of blocked domains");
 
-    val t = Set("one","two","three")
     val domains = S3InfoSec.getBlockedEmailDomains map {
       blockedDomains => blockedDomains.split("\n").toSet
     } getOrElse Set()

--- a/app/com/gu/identity/frontend/jobs/BlockedEmailDomainList.scala
+++ b/app/com/gu/identity/frontend/jobs/BlockedEmailDomainList.scala
@@ -1,0 +1,28 @@
+package com.gu.identity.frontend.jobs
+
+import akka.agent.Agent
+import com.gu.identity.frontend.logging.Logging
+import com.gu.identity.frontend.services.S3InfoSec
+import com.gu.identity.frontend.utils.ExecutionContexts
+
+object BlockedEmailDomainList extends ExecutionContexts with Runnable with Logging {
+
+  private val blockedDomainsAgent = Agent[Set[String]](Set.empty)
+
+  def run() {
+
+    logger.info("Getting list of blocked domains");
+
+    val t = Set("one","two","three")
+    val domains = S3InfoSec.getBlockedEmailDomains map {
+      blockedDomains => blockedDomains.split("\n").toSet
+
+    } getOrElse Set()
+    blockedDomainsAgent.send(domains)
+
+  }
+
+  def getBlockedDomains = blockedDomainsAgent.get()
+
+
+}

--- a/app/com/gu/identity/frontend/jobs/BlockedEmailDomainList.scala
+++ b/app/com/gu/identity/frontend/jobs/BlockedEmailDomainList.scala
@@ -1,24 +1,42 @@
 package com.gu.identity.frontend.jobs
 
+import akka.actor.ActorSystem
 import akka.agent.Agent
+import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.logging.Logging
 import com.gu.identity.frontend.services.S3InfoSec
 import com.gu.identity.frontend.utils.ExecutionContexts
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
 
-object BlockedEmailDomainList extends ExecutionContexts with Runnable with Logging {
+object BlockedEmailDomainList extends ExecutionContexts with Logging {
 
   private val blockedDomainsAgent = Agent[Set[String]](Set.empty)
 
-  def run() {
+  def run(configuration: Configuration): Unit = {
 
-    logger.info("Getting list of blocked domains");
+    logger.info("Getting list of blocked domains from" );
 
-    val domains = S3InfoSec.getBlockedEmailDomains map {
+    val domains = S3InfoSec.getBlockedEmailDomains(configuration.infoSecS3BucketName,configuration.infoSecS3BucketKey) map {
       blockedDomains => blockedDomains.split("\n").toSet
     } getOrElse Set()
     blockedDomainsAgent.send(domains)
   }
 
-  def getBlockedDomains = blockedDomainsAgent.get()
+  def isDomainBlocked(domain: String) = blockedDomainsAgent.get().contains(domain)
 
+}
+
+class BlockedEmailDomainListJob(theActorSystem: ActorSystem, configuration: Configuration) extends ExecutionContexts with Logging  {
+
+  //Need to do this to avoid an "There is no started Application" error: We want the executionContext from the trait but not the actor syatem
+  override lazy val actorSystem = theActorSystem
+
+  def start = {
+    logger.info("Starting job to update list of barred registration domains every half houe");
+
+    actorSystem.scheduler.schedule(20.seconds, 30.minutes) {
+      BlockedEmailDomainList.run(configuration)
+    }
+  }
 }

--- a/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
+++ b/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
@@ -73,7 +73,7 @@ object RegisterActionRequestBody {
       email =>
         if (email.matches(EmailPattern.toString())) {
           val EmailPattern(name, domain) = email
-          BlockedEmailDomainList.getBlockedDomains.contains(domain) match {
+          BlockedEmailDomainList.isDomainBlocked(domain) match {
             case true => Invalid(ValidationError("error.email"))
             case false => Valid
           }

--- a/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
+++ b/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
@@ -67,7 +67,6 @@ object RegisterActionRequestBody {
     import GroupCode.FormMappings.groupCode
     import ReturnUrl.FormMapping.returnUrl
 
-
     private val EmailPattern = """(.*)@(.*)""".r
 
     def registrationEmailAddress: Constraint[String] = Constraint[String]("constraint.email") {
@@ -85,7 +84,6 @@ object RegisterActionRequestBody {
 
     private val registrationEmail: Mapping[String] = text.verifying(Constraints.emailAddress, registrationEmailAddress)
 
-
     private val username: Mapping[String] = text.verifying(
       "error.username", name => name.matches("[A-z0-9]+") && name.length > 5 && name.length < 21
     )
@@ -93,7 +91,6 @@ object RegisterActionRequestBody {
     private val password: Mapping[String] = text.verifying(
       "error.password", name => name.length > 5 && name.length < 73
     )
-
 
     def registerFormMapping(refererHeader: Option[String]): Mapping[RegisterActionRequestBody] =
       mapping(

--- a/app/com/gu/identity/frontend/services/S3.scala
+++ b/app/com/gu/identity/frontend/services/S3.scala
@@ -1,0 +1,51 @@
+package com.gu.identity.frontend.services
+
+import com.amazonaws.regions.{Region, Regions}
+import com.gu.identity.frontend.logging.Logging
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.{AmazonS3Exception, GetObjectRequest, S3Object}
+import com.gu.identity.frontend.configuration.Configuration.AWSConfig
+
+import scala.io.{Codec, Source}
+
+trait S3 extends Logging {
+
+
+  private lazy val region = Region.getRegion(Regions.fromName(AWSConfig.region.getName))
+  val bucket: String
+
+  lazy val client = new AmazonS3Client(AWSConfig.credentials)
+  client.setEndpoint(region.getServiceEndpoint("s3"))
+
+  private def withS3Result[T](key: String)(action: S3Object => T): Option[T] = {
+     try {
+       val request = new GetObjectRequest(bucket, key)
+       val result = client.getObject(request)
+       logger.info(s"S3 got ${result.getObjectMetadata.getContentLength} bytes from ${result.getKey}")
+
+       try {
+         Some(action(result))
+       }
+       catch {
+         case ex: Exception => throw ex
+       }
+       finally { result.close() }
+     } catch {
+       case ex: AmazonS3Exception if ex.getStatusCode == 404 => {
+         logger.warn(s"Not found at $bucket  - $key");
+         None
+       }
+       case ex: Exception => throw ex
+     }
+  }
+
+  def get(key: String)(implicit codec: Codec): Option[String] = withS3Result(key) {
+      result => Source.fromInputStream(result.getObjectContent).mkString
+  }
+}
+
+object S3InfoSec extends S3 {
+  override val bucket = "gu-identity-infosec" //TODO put it config
+  val key = "blocked-email-domains.txt"
+  def getBlockedEmailDomains = get(key)
+}

--- a/app/com/gu/identity/frontend/utils/ExecutionContexts.scala
+++ b/app/com/gu/identity/frontend/utils/ExecutionContexts.scala
@@ -1,7 +1,6 @@
 package com.gu.identity.frontend.utils
 
 import akka.actor.ActorSystem
-
 import scala.concurrent.ExecutionContext
 import play.api.libs.concurrent.{Akka => PlayAkka}
 import play.api.Play

--- a/app/com/gu/identity/frontend/utils/ExecutionContexts.scala
+++ b/app/com/gu/identity/frontend/utils/ExecutionContexts.scala
@@ -8,6 +8,5 @@ import play.api.Play
 trait ExecutionContexts {
 
   implicit lazy val executionContext: ExecutionContext = play.api.libs.concurrent.Execution.Implicits.defaultContext
-  lazy val actorSystem: ActorSystem = PlayAkka.system(Play.current)
 
 }

--- a/app/com/gu/identity/frontend/utils/ExecutionContexts.scala
+++ b/app/com/gu/identity/frontend/utils/ExecutionContexts.scala
@@ -1,9 +1,14 @@
 package com.gu.identity.frontend.utils
 
+import akka.actor.ActorSystem
+
 import scala.concurrent.ExecutionContext
+import play.api.libs.concurrent.{Akka => PlayAkka}
+import play.api.Play
 
 trait ExecutionContexts {
 
   implicit lazy val executionContext: ExecutionContext = play.api.libs.concurrent.Execution.Implicits.defaultContext
+  lazy val actorSystem: ActorSystem = PlayAkka.system(Play.current)
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+
 name := "identity-frontend"
 
 organization := "com.gu.identity"
@@ -23,8 +24,10 @@ libraryDependencies ++= Seq(
   "com.mohiva" %% "play-html-compressor" % "0.5.0",
   "com.gu.identity" %% "identity-cookie" % "3.51",
   "com.typesafe.akka" %% "akka-actor" % "2.4.1",
+  "com.typesafe.akka" %% "akka-agent" % "2.4.1",
   "com.typesafe.akka" %% "akka-slf4j" % "2.4.0",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.10.54",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.10.54",
   "com.getsentry.raven" % "raven-logback" % "7.2.1"
 )
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -45,3 +45,8 @@ identity {
 }
 
 sentry.dsn = ${?IDENTITY_SENTRY_DSN}
+
+//
+// S3 Bucket and key for a list of domains from which to bar registrations - supplied by infosec
+infosec.s3.bucket.name="gu-identity-infosec"
+infosec.s3.bucket.key="blocked-email-domains.txt"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint-css": "stylelint 'public/**/*.css'"
   },
   "devDependencies": {
+    "grunt": "~0.4.2",
     "babel-core": "^6.2.1",
     "babel-loader": "^6.2.0",
     "babel-preset-es2015": "^6.1.18",
@@ -35,6 +36,11 @@
     "cookie-cutter": "^0.1.1",
     "curl-amd": "^0.8.12",
     "lodash": "^4.0.1",
+    "postcss-cli": "^2.5.2",
+    "postcss-cssnext": "^2.7.0",
+    "postcss-discard-comments": "^2.0.4",
+    "postcss-import": "^7.1.3",
+    "postcss-reporter": "^1.4.1",
     "raven-js": "3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "lint-css": "stylelint 'public/**/*.css'"
   },
   "devDependencies": {
-    "grunt": "~0.4.2",
     "babel-core": "^6.2.1",
     "babel-loader": "^6.2.0",
     "babel-preset-es2015": "^6.1.18",
@@ -36,11 +35,6 @@
     "cookie-cutter": "^0.1.1",
     "curl-amd": "^0.8.12",
     "lodash": "^4.0.1",
-    "postcss-cli": "^2.5.2",
-    "postcss-cssnext": "^2.7.0",
-    "postcss-discard-comments": "^2.0.4",
-    "postcss-import": "^7.1.3",
-    "postcss-reporter": "^1.4.1",
     "raven-js": "3.0.2"
   }
 }


### PR DESCRIPTION
Implements the email domain blacklist formerly implemented on frontend on the updated frontend app: (Here's the original PR: https://github.com/guardian/frontend/pull/6730). This is at the requesr of infosec and the mod-tools guys. 

@jamespamplin @nlindblad Can you guys take a look at this?  I've kind of shoe horned something a little bit nasty here. Really, I'd like to be able to make the job and the S3 stuff singletons that I can pass the configuration into, but I can't quite find a way of doing that. Thanks