### PR TITLE
Add additional helper for Chrome native form hint

### DIFF
--- a/public/components/register-form/_register-form.hbs
+++ b/public/components/register-form/_register-form.hbs
@@ -76,7 +76,7 @@
 
     <div class="register-form__control--username">
         <label class="register-form__label--username" for="register_field_username">{{ registerPageText.username }}</label>
-        <input class="register-form__field--username" id="register_field_username" type="text" name="username" placeholder="{{ registerPageText.usernameHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" required minlength="6" maxlength="20" pattern="[a-zA-Z0-9]+" />
+        <input class="register-form__field--username" id="register_field_username" type="text" name="username" placeholder="{{ registerPageText.usernameHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" required minlength="6" maxlength="20" title="{{ registerPageText.usernameHelp }}" pattern="[a-zA-Z0-9]+" />
     </div>
 
       {{#each errors.usernameErrors }}


### PR DESCRIPTION
**Before**:

![screen shot 2016-09-02 at 13 35 03](https://cloud.githubusercontent.com/assets/164991/18203994/32b2d138-7112-11e6-9ac0-dcf478cb0921.png)

**After**:

![screen shot 2016-09-02 at 13 34 38](https://cloud.githubusercontent.com/assets/164991/18204013/4daea836-7112-11e6-84bf-b3f3b11886c8.png)

It was already checking the format, but the native error message is not very helpful without a `title` attribute.

Based on http://www.html5rocks.com/en/tutorials/forms/constraintvalidation/