### PR TITLE
Remember the country code on phone validation

### DIFF
--- a/public/components/register-form/_register-form.hbs
+++ b/public/components/register-form/_register-form.hbs
@@ -47,11 +47,12 @@
                 <label class="register-form__label--country-code" for="register_field_countryCode">
                   {{ registerPageText.countryCode }}
                 </label>
+                <input type="hidden" id="register_field_countryIsoName" />
                 <select class="register-form__select--country-code" id="register_field_countryCode" type="tel"
                         name="countryCode" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false"/>
-              {{#each countryCodes.codes }}
-              <option value="{{ code }}">+ {{ code }}</option>
-              {{/ each }}
+                  {{#each countryCodes.codes }}
+                  <option value="{{ code }}">+ {{ code }}</option>
+                  {{/ each }}
                 </select>
             </div>
             <div class="register-form__control-column--local-number">

--- a/public/components/register-form/register-form.js
+++ b/public/components/register-form/register-form.js
@@ -9,16 +9,17 @@ const STORAGE_KEY = 'gu_id_register_state';
 
 
 class RegisterFormFields {
-  constructor(firstNameField, lastNameField, emailField, usernameField, optionalCountryCode, optionalPhoneNumber) {
+  constructor(firstNameField, lastNameField, emailField, usernameField, optionalCountryCode, optionalCountryIsoName, optionalPhoneNumber) {
     this.firstName = firstNameField;
     this.lastName = lastNameField;
     this.email = emailField;
     this.username = usernameField;
     this.optionalCountryCode = optionalCountryCode;
+    this.optionalCountryIsoName = optionalCountryIsoName;
     this.optionalPhoneNumber = optionalPhoneNumber;
   }
 
-  setValues( { firstName, lastName, email, username, optionalCountryCode, optionalPhoneNumber } = {} ) {
+  setValues( { firstName, lastName, email, username, optionalCountryCode, optionalCountryIsoName, optionalPhoneNumber } = {} ) {
     this.firstName.setValue( firstName );
     this.lastName.setValue( lastName );
     this.email.setValue( email );
@@ -28,6 +29,9 @@ class RegisterFormFields {
     }
     if (this.optionalCountryCode) {
       this.optionalCountryCode.setValue(optionalCountryCode);
+    }
+    if (this.optionalCountryIsoName) {
+      this.optionalCountryIsoName.setValue(optionalCountryIsoName);
     }
   }
 
@@ -42,10 +46,10 @@ class RegisterFormFields {
 
 
 class RegisterFormModel {
-  constructor( formElement, firstNameField, lastNameField, emailField, usernameField, optionalCountryCode, optionalPhoneNumber ) {
+  constructor( formElement, firstNameField, lastNameField, emailField, usernameField, optionalCountryCode, optionalCountryIsoName, optionalPhoneNumber ) {
     this.formElement = formElement;
 
-    this.fields = new RegisterFormFields( firstNameField, lastNameField, emailField, usernameField, optionalCountryCode, optionalPhoneNumber );
+    this.fields = new RegisterFormFields( firstNameField, lastNameField, emailField, usernameField, optionalCountryCode, optionalCountryIsoName, optionalPhoneNumber );
 
     this.addBindings();
   }
@@ -76,21 +80,23 @@ class RegisterFormModel {
     const usernameField = getElementById( 'register_field_username' );
     const optionalPhoneNumber = getElementById('register_field_localNumber');
     const optionalCountryCode = getElementById('register_field_countryCode');
+    const optionalCountryIsoName = getElementById('register_field_countryIsoName');
 
     if ( form && firstNameField && lastNameField && emailField && usernameField ) {
-      return new RegisterFormModel( form, firstNameField, lastNameField, emailField, usernameField, optionalCountryCode, optionalPhoneNumber );
+      return new RegisterFormModel( form, firstNameField, lastNameField, emailField, usernameField, optionalCountryCode, optionalCountryIsoName, optionalPhoneNumber );
     }
   }
 }
 
 
 class RegisterFormState {
-  constructor( firstName = "", lastName = "", email = "", username = "", optionalCountryCode = "", optionalPhoneNumber = "" ) {
+  constructor( firstName = "", lastName = "", email = "", username = "", optionalCountryCode = "", optionalCountryIsoName = "", optionalPhoneNumber = "" ) {
     this.firstName = firstName;
     this.lastName = lastName;
     this.email = email;
     this.username = username;
     this.optionalCountryCode = optionalCountryCode;
+    this.optionalCountryIsoName = optionalCountryIsoName;
     this.optionalPhoneNumber = optionalPhoneNumber;
   }
 
@@ -101,8 +107,8 @@ class RegisterFormState {
   /**
    * @return {RegisterFormState}
    */
-  static fromObject( { firstName, lastName, email, username, optionalCountryCode, optionalPhoneNumber } = {} ) {
-    return new RegisterFormState( firstName, lastName, email, username, optionalCountryCode, optionalPhoneNumber );
+  static fromObject( { firstName, lastName, email, username, optionalCountryCode, optionalCountryIsoName, optionalPhoneNumber } = {} ) {
+    return new RegisterFormState( firstName, lastName, email, username, optionalCountryCode, optionalCountryIsoName, optionalPhoneNumber );
   }
 
   /**
@@ -131,7 +137,7 @@ export function init() {
     form.loadState();
 
     if (form.fields.optionalPhoneNumber) {
-      initPhoneField(form, form.fields.optionalCountryCode, form.fields.optionalPhoneNumber);
+      initPhoneField(form, form.fields.optionalCountryCode, form.fields.optionalCountryIsoName, form.fields.optionalPhoneNumber);
     }
   }
 


### PR DESCRIPTION
When the form is persisted in local storage the country code gets lost for two reasons.

1. The fields are update after storing in local storage
2. The stored field is never used to change the initial country

This PR fixes both, when you register and validation brings you back to the form, the country flag should be the same as what you previously selected

@guardian/identity @NathanielBennett 