### PR TITLE
Fix Riff-Raff warnings

### DIFF
--- a/deploy.json
+++ b/deploy.json
@@ -8,7 +8,8 @@
       ],
       "data": {
         "port": "8860",
-        "bucket": "gu-identity-frontend-dist"
+        "bucket": "gu-identity-frontend-dist",
+        "publicReadAcl": false
       }
     }
   },

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.6")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.3")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.3")
 


### PR DESCRIPTION
- publicReadAcl

_[16:40:55] DEPRECATED: publicReadAcl should be specified for an autoscaling deploy. Not setting this means that it defaults to true which is insecure and probably not what you want. It is not a good idea for artifacts to be publically available on the internet - it is much better to ensure this is set to false and your instances download the artifact from S3 using IAM instance credentials. If you are CERTAIN that this iswhat you want you can also get rid of this message by explicitly setting publicReadAcl to true._

- Upgrade sbt-riffraff-artifact to latest version to ensure we are not reliant on legacy formats.

CODE build without warnings:


<img width="1169" alt="screen shot 2016-09-29 at 19 29 52" src="https://cloud.githubusercontent.com/assets/406099/18966938/351a6246-867b-11e6-96a3-974d06001b0d.png">
