### PR TITLE
Use t2.small on PROD 

### DIFF
--- a/cloudformation/identity-frontend.template
+++ b/cloudformation/identity-frontend.template
@@ -70,7 +70,7 @@
         "LatencyAlarmThreshold": 0.5,
         "LatencyAlarmPeriod": 60,
         "NotificationAlarmPeriod": 1200,
-        "InstanceType": "t2.medium",
+        "InstanceType": "t2.small",
         "DesiredInstances": 3,
         "MaxInstances": 12
       },


### PR DESCRIPTION
Trusted Advisor is reporting low CPU usage on these instances therefore reducing size to small.  This will reduce costs (slightly).

