### PR TITLE
Membership Signup/Signin Buttons - Reverted to Guardian Blue

### DIFF
--- a/public/components/membership/_membership.css
+++ b/public/components/membership/_membership.css
@@ -1,7 +1,3 @@
-:root {
-  --c-members-button: #7d0068;
-}
-
 .skin-members {
   .header__logo-link {
     background-image: inline("guardian-members-logo.svg");
@@ -16,21 +12,6 @@
 
     @media (--viewport-max-tablet) {
       background-position: -1010px top;
-    }
-  }
-
-  .register-form__submit-button,
-  .signin-form__submit-button,
-  .register-confirm__complete-registration-button {
-    background-color: var(--c-members-button);
-
-    &:focus,
-    &:hover {
-      background-color: color(var(--c-members-button) lightness(- 10%));
-    }
-
-    &:focus {
-      box-shadow: 0 0 2px 2px color(var(--c-members-button) alpha(50%));
     }
   }
 


### PR DESCRIPTION
# Changes

Major update? Not really... tweaked the membership-specific signup/signin buttons from purple to the standard Guardian blue.

# Screenshots

**Old:**
![old-create-button](https://cloud.githubusercontent.com/assets/5131341/19526036/fc735038-961a-11e6-8573-ad29414d3e55.png)
![old-signin-button](https://cloud.githubusercontent.com/assets/5131341/19526048/0361db12-961b-11e6-92a2-ef7e93313160.png)

**New:**
![new-create-button](https://cloud.githubusercontent.com/assets/5131341/19526051/057f15ae-961b-11e6-837d-1da6e9ea1990.png)
![new-signin-button](https://cloud.githubusercontent.com/assets/5131341/19526041/ff6657fe-961a-11e6-808f-51e0fc761c28.png)

