### PR TITLE
Put the build commit id into the registration page so Prout can read it

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -5,6 +5,6 @@
       "overdue": "15M",
       "disableSSLVerification": true
     },
-    "PROD": { "url": "https://profile-origin.theguardian.com/management/manifest", "overdue": "1H" }
+    "PROD": { "url": "https://profile.theguardian.com/register", "overdue": "1H" }
   }
 }

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -1,5 +1,6 @@
 package com.gu.identity.frontend.views.models
 
+import buildinfo.BuildInfo
 import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.controllers.routes
 import com.gu.identity.frontend.csrf.CSRFToken
@@ -33,7 +34,8 @@ case class RegisterViewModel(
 
     resources: Seq[PageResource with Product],
     indirectResources: Seq[PageResource with Product],
-    countryCodes: Option[CountryCodes]
+    countryCodes: Option[CountryCodes],
+    gitCommitId: String
   )
   extends ViewModel with ViewModelResources
 
@@ -80,8 +82,8 @@ object RegisterViewModel {
       resources = layout.resources,
       indirectResources = layout.indirectResources,
 
-      countryCodes = codes
-
+      countryCodes = codes,
+      gitCommitId = BuildInfo.gitCommitId
     )
   }
 

--- a/public/register-page.hbs
+++ b/public/register-page.hbs
@@ -1,8 +1,7 @@
 {{# partial "pageTitle" }}{{ registerPageText.pageTitle }}{{/ partial }}
 
 {{# partial "content" }}
-
-  <h1 class="page-heading{{# showStandfirst }}--with-standfirst{{/ showStandfirst }}">{{ registerPageText.title }}</h1>
+  <h1 class="page-heading{{# showStandfirst }}--with-standfirst{{/ showStandfirst }} commitId="{{ gitCommitId }}">{{ registerPageText.title }}</h1>
 
   {{# showStandfirst }}
     <section class="page-standfirst">


### PR DESCRIPTION
Previously the manifest at https://profile-origin.theguardian.com/management/manifest
was the only way to get the Git commit id out of the profile site, unfortunately the certificate on that endpoint is only valid for `profile-beta.theguardian.com`, so Prout wouldn't read it, and declared all PRs overdue-on-PROD.

This fix is an alternative to https://github.com/guardian/identity-frontend/pull/173 ("Tell Prout not to worry about the cert on profile-origin.theguardian.com")

cc @markjamesbutler 