### PR TITLE
Use the Supporter landing page as the preferred Membership url

### DIFF
--- a/app/com/gu/identity/frontend/configuration/Configuration.scala
+++ b/app/com/gu/identity/frontend/configuration/Configuration.scala
@@ -17,7 +17,7 @@ case class Configuration(
   identityProfileBaseUrl: String,
 
   dotcomBaseUrl: String,
-  membershipBaseUrl: String,
+  preferredMembershipUrl: String,
 
   jobsBaseUrl: String,
 
@@ -58,7 +58,7 @@ object Configuration {
 
       dotcomBaseUrl = getString("identity.frontend.dotcomBaseUrl"),
 
-      membershipBaseUrl = getString("identity.frontend.membershipBaseUrl"),
+      preferredMembershipUrl = getString("identity.frontend.preferredMembershipUrl"),
 
       jobsBaseUrl = getString("identity.frontend.jobsBaseUrl"),
 
@@ -90,7 +90,7 @@ object Configuration {
     identityProfileBaseUrl = "https://profile.code.dev-theguardian.com",
 
     dotcomBaseUrl = "http://www.theguardian.com",
-    membershipBaseUrl = "https://members.theguardian.com",
+    preferredMembershipUrl = "https://membership.theguardian.com/supporter",
     jobsBaseUrl = "https://jobs.theguardian.com",
 
     googleRecaptchaSiteKey = "--recaptcha-key--",

--- a/app/com/gu/identity/frontend/models/ReturnUrl.scala
+++ b/app/com/gu/identity/frontend/models/ReturnUrl.scala
@@ -41,7 +41,7 @@ object ReturnUrl {
     defaultFromUrl(configuration.dotcomBaseUrl)
 
   def defaultForMembership(configuration: Configuration) =
-    defaultFromUrl(configuration.membershipBaseUrl)
+    defaultFromUrl(configuration.preferredMembershipUrl)
 
   def defaultForClient(configuration: Configuration, clientId: Option[ClientID]) =
     clientId match {

--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -153,7 +153,7 @@ object LayoutLinks {
 
   private def logoUrl(configuration: Configuration, clientId: Option[ClientID]) =
     clientId match {
-      case Some(GuardianMembersClientID) => configuration.membershipBaseUrl
+      case Some(GuardianMembersClientID) => configuration.preferredMembershipUrl
       case Some(GuardianJobsClientID) => configuration.jobsBaseUrl
       case _ => configuration.dotcomBaseUrl
     }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -34,7 +34,7 @@ identity {
 
     dotcomBaseUrl = "http://www.theguardian.com"
 
-    membershipBaseUrl = "https://membership.theguardian.com"
+    preferredMembershipUrl = "https://membership.theguardian.com/supporter"
 
     jobsBaseUrl = "https://jobs.theguardian.com"
   }

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -68,7 +68,7 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
   it should "Use the membership return url for clientId=members as the default fallback" in {
     val result = ReturnUrl(None, None, config, Some(GuardianMembersClientID))
 
-    result.url shouldEqual config.membershipBaseUrl
+    result.url shouldEqual config.preferredMembershipUrl
     result shouldBe 'default
   }
 }


### PR DESCRIPTION
Michael Campbell (Digital Marketing Manager) pointed out that https://profile.theguardian.com/register?returnUrl=https://membership.theguardian.com/join/supporter/enter-details?countryGroup%3Duk%26INTCMP%3DMEM_HOME_SUP&skipConfirmation=true&clientId=members
had a Guardian Members logo that linked to https://membership.theguardian.com, a page that currently doesn't perform conversion as well as well as the supporter landing page.

So switching to link the 'Guardian Members' logo to the Supporter landing page instead!

![image](https://cloud.githubusercontent.com/assets/52038/19597243/5301ddc2-978b-11e6-823c-55ada913bf17.png)

@Ap0c 