### PR TITLE
Membership text changes

### DIFF
--- a/app/com/gu/identity/frontend/models/Text.scala
+++ b/app/com/gu/identity/frontend/models/Text.scala
@@ -4,9 +4,9 @@ import play.api.i18n.Messages
 
 object Text {
   object SignInPageText {
-    def toMap(implicit messages: Messages): Map[String, String] = {
+    def toMap(isMembership: Boolean)(implicit messages: Messages): Map[String, String] = {
       Map (
-        "title" -> messages("signin.title"),
+        "title" -> (if(isMembership) messages("signin.title.membership") else messages("signin.title")),
         "pageTitle" -> messages("signin.pagetitle"),
         "prelude" -> messages("signin.prelude"),
         "preludeMoreInfo" -> messages("signin.prelude.moreinfo"),

--- a/app/com/gu/identity/frontend/models/text/RegisterText.scala
+++ b/app/com/gu/identity/frontend/models/text/RegisterText.scala
@@ -28,7 +28,7 @@ case class RegisterText private(
     becausePhone: String)
 
 object RegisterText {
-  def apply()(implicit messages: Messages): RegisterText =
+  def loadText(isMembership : Boolean)(implicit messages: Messages): RegisterText =
     RegisterText(
       `3rdPartyMarketing` = messages("register.3rdPartyMarketing"),
       createAccount = messages("register.createAccount"),
@@ -45,7 +45,7 @@ object RegisterText {
       signIn = messages("register.signIn"),
       signInCta = messages("register.signInCta"),
       standfirst = messages("register.standfirst"),
-      title = messages("register.title"),
+      title = if(isMembership) messages("register.title.membership") else messages("register.title"),
       username = messages("register.username"),
       usernameHelp = messages("register.usernameHelp"),
       phone = messages("register.phone"),

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -56,12 +56,17 @@ object RegisterViewModel {
     val layout = LayoutViewModel(configuration, activeTests, clientId, Some(returnUrl))
 
     val codes = countryCodes(clientId)
+
+    val isMembership = clientId match {
+      case Some(GuardianMembersClientID) => true
+      case _ => false
+    }
     RegisterViewModel(
       layout = layout,
 
       oauth = OAuthRegistrationViewModel(configuration, returnUrl, skipConfirmation, clientId, group, activeTests),
 
-      registerPageText = RegisterText(),
+      registerPageText = RegisterText.loadText(isMembership),
       terms = Terms.getTermsModel(group),
 
       hasErrors = errors.nonEmpty,

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -3,7 +3,7 @@ package com.gu.identity.frontend.views.models
 import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.controllers.routes
 import com.gu.identity.frontend.csrf.CSRFToken
-import com.gu.identity.frontend.models.{GroupCode, ClientID, UrlBuilder, ReturnUrl}
+import com.gu.identity.frontend.models._
 import com.gu.identity.frontend.models.Text._
 import com.gu.identity.frontend.mvt.ActiveMultiVariantTests
 import play.api.i18n.Messages
@@ -51,16 +51,21 @@ object SignInViewModel {
 
     val layout = LayoutViewModel(configuration, activeTests, clientId, Some(returnUrl))
     val recaptchaModel : Option[GoogleRecaptchaViewModel] =
-      getRecaptchaModel(configuration, isError = !errors.isEmpty, recaptchaEnabled = configuration.recaptchaEnabled)
+      getRecaptchaModel(configuration, isError = errors.nonEmpty, recaptchaEnabled = configuration.recaptchaEnabled)
 
     val resources = getResources(layout, recaptchaModel) ++ Seq(IndirectlyLoadedExternalResources(UrlBuilder(configuration.identityProfileBaseUrl,routes.SigninAction.signInWithSmartLock())))
+
+    val isMembership = clientId match {
+      case Some(GuardianMembersClientID) => true
+      case _ => false
+    }
 
     SignInViewModel(
       layout = layout,
 
       oauth = OAuthSignInViewModel(configuration, returnUrl, skipConfirmation, clientId, group, activeTests),
 
-      signInPageText = SignInPageText.toMap,
+      signInPageText = SignInPageText.toMap(isMembership),
       terms = Terms.getTermsModel(group),
 
       hasErrors = errors.nonEmpty,

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1,6 +1,7 @@
 layout.pagetitle=Identity | The Guardian
 
 signin.title=Sign in to the Guardian
+signin.title.membership=Sign in to the Guardian to become a member
 signin.pagetitle=Sign in
 signin.prelude=Creating an account means you can save articles for later, leave comments, enter competitions, become a member and lots more.
 signin.prelude.moreinfo=Want to know more?
@@ -18,6 +19,7 @@ signin.signup=Sign up
 # com.gu.identity.frontend.models.text.RegisterText
 register.pageTitle=Register
 register.title=Create your Guardian account
+register.title.membership=Create your Guardian account to become a member
 register.standfirst=Register today to shortlist and apply for jobs more easily.
 register.divideText=or
 register.name=Name


### PR DESCRIPTION
Change title on the sign in and registration pages for people coming from the membership flow

'Create your Guardian account' becomes 'Create your Guardian account to become a member'
and  
'Sign in to the Guardian' becomes 'Sign in to the Guardian to become a member'.

More details:
https://trello.com/c/DdaKM6f6/84-update-text-on-create-account-sign-in-pages-to-allude-to-membership