### PR TITLE
Use referrer if signout returnUrl isn't provided.

### DIFF
--- a/app/com/gu/identity/frontend/controllers/SignoutAction.scala
+++ b/app/com/gu/identity/frontend/controllers/SignoutAction.scala
@@ -10,6 +10,7 @@ import com.gu.identity.frontend.utils.ExecutionContexts
 import play.api.http.HttpErrorHandler
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._
+import play.api.http.HeaderNames
 
 import scala.concurrent.Future
 
@@ -18,7 +19,8 @@ class SignOutAction(identityService: IdentityService, val messagesApi: MessagesA
   implicit def cookieNameToString(cookieName: Name): String = cookieName.toString
 
   def signOut(returnUrl: Option[String]) = Action.async { implicit request =>
-    val validReturnUrl = ReturnUrl(returnUrl, config)
+    val referrer = request.headers.get(HeaderNames.REFERER)
+    val validReturnUrl = ReturnUrl(returnUrl ,referrer, config, None)
     val trackingData = TrackingData(request, None)
     request.cookies.get(CookieName.SC_GU_U).map { cookie =>
       identityService.deauthenticate(cookie, trackingData).map {


### PR DESCRIPTION
This PR adds functionality to return the user to the page they were viewing before signing out when a return url is not provided on the signout request.  

It fixes this bug:

User navigates to: (https://www.theguardian.com/uk/business) and clicks Sign Out.  User is returned to: (https://www.theguardian.com/uk)  

Once this PR is deployed the user will be returned to: (https://www.theguardian.com/uk/business)