### PR TITLE
Whitelist Jobs App URL

### DIFF
--- a/app/com/gu/identity/frontend/models/ReturnUrl.scala
+++ b/app/com/gu/identity/frontend/models/ReturnUrl.scala
@@ -19,8 +19,7 @@ object ReturnUrl {
 
   val domains = List(".theguardian.com", ".code.dev-theguardian.com", ".thegulocal.com")
   val invalidUrlPaths = List("/signin", "/register")
-  val validJobsAppLogoutDomain = "sso.com.theguardian.jobs"
-  val validJobsAppLogoutPath = "://ssologoutsuccess"
+  val validUris = List(new URI("sso.com.theguardian.jobs://ssologoutsuccess"))
 
   def apply(returnUrlParam: Option[String], configuration: Configuration): ReturnUrl =
     apply(returnUrlParam, refererHeader = None, configuration, clientId = None)
@@ -29,9 +28,9 @@ object ReturnUrl {
     returnUrlParam
       .flatMap(uriOpt)
       .orElse(refererHeader.flatMap(uriOpt))
-      .filter(validDomain)
-      .filter(validUrlPath)
-        .filter()
+      .filter { uri =>
+        validDomain(uri) && validUrlPath(uri) || validUrl(uri)
+      }
       .map(uri => ReturnUrl(uri))
 
   def apply(returnUrlParam: Option[String], refererHeader: Option[String], configuration: Configuration, clientId: Option[ClientID]): ReturnUrl =
@@ -76,11 +75,8 @@ object ReturnUrl {
     domains.exists(s".$hostname".endsWith(_))
   }
 
-  private[models] def validJobsAppLogout(uri: URI): Boolean = {
-    if (uri.getHost == validJobsAppLogoutDomain) {
-      uri.getPath.equals(validJobsAppLogoutPath)
-    }
-    else true
+  private[models] def validUrl(uri: URI): Boolean = {
+    validUris.contains(uri)
   }
 
   private[models] def validUrlPath(uri: URI): Boolean = {

--- a/app/com/gu/identity/frontend/models/ReturnUrl.scala
+++ b/app/com/gu/identity/frontend/models/ReturnUrl.scala
@@ -19,6 +19,8 @@ object ReturnUrl {
 
   val domains = List(".theguardian.com", ".code.dev-theguardian.com", ".thegulocal.com")
   val invalidUrlPaths = List("/signin", "/register")
+  val validJobsAppLogoutDomain = "sso.com.theguardian.jobs"
+  val validJobsAppLogoutPath = "://ssologoutsuccess"
 
   def apply(returnUrlParam: Option[String], configuration: Configuration): ReturnUrl =
     apply(returnUrlParam, refererHeader = None, configuration, clientId = None)
@@ -29,6 +31,7 @@ object ReturnUrl {
       .orElse(refererHeader.flatMap(uriOpt))
       .filter(validDomain)
       .filter(validUrlPath)
+        .filter()
       .map(uri => ReturnUrl(uri))
 
   def apply(returnUrlParam: Option[String], refererHeader: Option[String], configuration: Configuration, clientId: Option[ClientID]): ReturnUrl =
@@ -71,6 +74,13 @@ object ReturnUrl {
   private[models] def validDomain(uri: URI): Boolean = {
     val hostname = uri.getHost
     domains.exists(s".$hostname".endsWith(_))
+  }
+
+  private[models] def validJobsAppLogout(uri: URI): Boolean = {
+    if (uri.getHost == validJobsAppLogoutDomain) {
+      uri.getPath.equals(validJobsAppLogoutPath)
+    }
+    else true
   }
 
   private[models] def validUrlPath(uri: URI): Boolean = {

--- a/app/com/gu/identity/frontend/models/ReturnUrl.scala
+++ b/app/com/gu/identity/frontend/models/ReturnUrl.scala
@@ -29,7 +29,7 @@ object ReturnUrl {
       .flatMap(uriOpt)
       .orElse(refererHeader.flatMap(uriOpt))
       .filter { uri =>
-        validDomain(uri) && validUrlPath(uri) || validUrl(uri)
+        validUris.contains(uri) || validDomain(uri) && validUrlPath(uri)
       }
       .map(uri => ReturnUrl(uri))
 
@@ -73,10 +73,6 @@ object ReturnUrl {
   private[models] def validDomain(uri: URI): Boolean = {
     val hostname = uri.getHost
     domains.exists(s".$hostname".endsWith(_))
-  }
-
-  private[models] def validUrl(uri: URI): Boolean = {
-    validUris.contains(uri)
   }
 
   private[models] def validUrlPath(uri: URI): Boolean = {

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -48,11 +48,6 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
     validUrlPath(new URI("http://theguardian.com/politics")) should be(true)
   }
 
-  it should "Determine valid uri" in {
-    validUrl(new URI("sso.com.theguardian.jobs://ssologoutsuccess")) should be(true)
-    validUrl(new URI("sso.com.theguardian.teachers://hello")) should be(false)
-  }
-
   it should "Retrieve default Return URL" in {
     def assertDefaultFallbackFor(in: ReturnUrl) = {
       in.url should be(config.dotcomBaseUrl)

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -31,6 +31,11 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
     ReturnUrl(None, Some("http://www.thegulocal.com/"), config, None) should be(ReturnUrl(new URI("http://www.thegulocal.com/")))
 
     ReturnUrl(None, Some("http://profile-origin2.thegulocal.com"), config, None) should be(ReturnUrl(new URI("http://profile-origin2.thegulocal.com")))
+
+    ReturnUrl(None, Some("sso.com.theguardian.jobs://ssologoutsuccess"), config, None) should be(ReturnUrl(new URI("sso.com.theguardian.jobs://ssologoutsuccess")))
+
+    ReturnUrl(None, Some("sso.com.theguardian.teachers://hello"), config, None) should be(ReturnUrl(new URI("http://www.theguardian.com"), isDefault = true))
+
   }
 
 
@@ -43,10 +48,10 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
     validUrlPath(new URI("http://theguardian.com/politics")) should be(true)
   }
 
-  it should "Determine valid jobs app logout url" in {
-    validUrlPath(new URI("sso.com.theguardian.jobs")) should be(false)
+  it should "Determine valid uri" in {
+    validUrl(new URI("sso.com.theguardian.jobs://ssologoutsuccess")) should be(true)
+    validUrl(new URI("sso.com.theguardian.teachers://hello")) should be(false)
   }
-
 
   it should "Retrieve default Return URL" in {
     def assertDefaultFallbackFor(in: ReturnUrl) = {

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -45,7 +45,6 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
     validUrlPath(new URI("http://theguardian.com/register/confirm")) should be(true)
     validUrlPath(new URI("http://theguardian.com")) should be(true)
     validUrlPath(new URI("http://theguardian.com/politics")) should be(true)
-    validUrlPath(new URI("http://theguardian.com/politics")) should be(true)
   }
 
   it should "Retrieve default Return URL" in {

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -38,7 +38,6 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
 
   }
 
-
   it should "Determine valid url path" in {
     validUrlPath(new URI("http://theguardian.com/signin")) should be(false)
     validUrlPath(new URI("http://theguardian.com/register")) should be(false)

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -40,6 +40,11 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
     validUrlPath(new URI("http://theguardian.com/register/confirm")) should be(true)
     validUrlPath(new URI("http://theguardian.com")) should be(true)
     validUrlPath(new URI("http://theguardian.com/politics")) should be(true)
+    validUrlPath(new URI("http://theguardian.com/politics")) should be(true)
+  }
+
+  it should "Determine valid jobs app logout url" in {
+    validUrlPath(new URI("sso.com.theguardian.jobs")) should be(false)
   }
 
 


### PR DESCRIPTION
The Jobs iOS app listens for the URL:

    sso.com.theguardian.jobs://ssologoutsuccess

This PR whitelists this ReturnURL allowing Identity-Frontend to redirect to this valid URL.  I've including the entire URL narrow-down attack vectors.