### PR TITLE
Bug fix for the title of the sign up form in the Flow B of membership.

### DIFF
--- a/app/com/gu/identity/frontend/models/text/RegisterText.scala
+++ b/app/com/gu/identity/frontend/models/text/RegisterText.scala
@@ -1,7 +1,8 @@
 package com.gu.identity.frontend.models.text
 
-import com.gu.identity.frontend.models.{ClientID, GuardianMembersAClientID, GuardianMembersBClientID}
+import com.gu.identity.frontend.models.{ClientID, GuardianMembersAClientID, GuardianMembersBClientID, ReturnUrl}
 import play.api.i18n.Messages
+import play.mvc.Http
 
 case class RegisterText private(
     `3rdPartyMarketing`: String,
@@ -33,7 +34,7 @@ case class RegisterText private(
     becausePhone: String)
 
 object RegisterText {
-  def loadText(clientId : Option[ClientID])(implicit messages: Messages): RegisterText =
+  def loadText(clientId : Option[ClientID], returnUrl: ReturnUrl)(implicit messages: Messages): RegisterText =
     RegisterText(
       `3rdPartyMarketing` = messages("register.3rdPartyMarketing"),
       createAccount = messages("register.createAccount"),
@@ -53,7 +54,7 @@ object RegisterText {
       standfirst = messages("register.standfirst"),
       title = clientId match {
         case Some(GuardianMembersAClientID) => messages("register.title.membership")
-        case Some(GuardianMembersBClientID) => messages("register.title.supporter")
+        case Some(GuardianMembersBClientID) => if(returnUrl.url contains "supporter") messages("register.title.supporter") else messages("register.title.member")
         case _ => messages("register.title")
       },
       username = messages("register.username"),

--- a/app/com/gu/identity/frontend/models/text/RegisterText.scala
+++ b/app/com/gu/identity/frontend/models/text/RegisterText.scala
@@ -2,7 +2,6 @@ package com.gu.identity.frontend.models.text
 
 import com.gu.identity.frontend.models.{ClientID, GuardianMembersAClientID, GuardianMembersBClientID, ReturnUrl}
 import play.api.i18n.Messages
-import play.mvc.Http
 
 case class RegisterText private(
     `3rdPartyMarketing`: String,

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -67,7 +67,7 @@ object RegisterViewModel {
 
       oauth = OAuthRegistrationViewModel(configuration, returnUrl, skipConfirmation, clientId, group, activeTests),
 
-      registerPageText = RegisterText.loadText(clientId),
+      registerPageText = RegisterText.loadText(clientId, returnUrl),
       terms = Terms.getTermsModel(group),
 
       hasErrors = errors.nonEmpty,

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -23,6 +23,7 @@ register.pageTitle=Register
 register.title=Create your Guardian account
 register.title.membership=Create your Guardian account to become a member
 register.title.supporter=Become a Supporter
+register.title.member=Become a Member
 register.standfirst=Register today to shortlist and apply for jobs more easily.
 register.divideText=or
 register.name=Name


### PR DESCRIPTION
## Problem

Currently, when a user wants to create a _Patron_ or a _Partner_ account and he or she is in the Flow B (`clientId=membersB`), the following identity screen is shown:

![bugidendity](https://cloud.githubusercontent.com/assets/825398/20673731/2af87690-b57e-11e6-9686-6b5e5bdb5d40.png)

This lead to confusion of the user because "Supporter" is the name of one of the tiers.

## Solution

When the user clicks on "Become a Patron" or "Become a Partner", we show **Become a Member** in the title.

![bugidentitysolution](https://cloud.githubusercontent.com/assets/825398/20673955/ef93c69e-b57e-11e6-9b01-6e6b834c2cee.png)







