### PR TITLE
CSS changes to the Sign Up form for Flow B in members

### DIFF
--- a/public/components/membership/_membership.css
+++ b/public/components/membership/_membership.css
@@ -206,10 +206,13 @@
     @extend %content-container--with-padding;
     padding-right: 0;
     padding-left: 0;
-    padding-bottom: 1.2rem;
 
     @media (--viewport-min-mobile-landscape) {
       display: none;
     }
+  }
+
+  .register__bottom-progress-bar-mem > ul > li {
+    margin-bottom: 1.2rem;
   }
 }

--- a/public/components/membership/_membership.css
+++ b/public/components/membership/_membership.css
@@ -105,7 +105,7 @@
   .oauth__cta--facebook,
   .oauth__cta--google {
 
-    padding-left: 1rem;
+    padding-left: 1.8rem;
     font-weight: bold;
     text-align: center;
 
@@ -134,6 +134,11 @@
   .signin-form__fieldset {
     background-color: #f6f6f6;
     padding: 0 0.5rem;
+  }
+
+  .register-form__fieldset > div > input,
+  .register-form__control--name > div > input {
+    font-size: 1.4rem;
   }
 
   .signin-form__error {

--- a/public/register-page-membership.hbs
+++ b/public/register-page-membership.hbs
@@ -16,11 +16,11 @@
     <section class="register__section">
       {{> components/oauth-cta/_oauth-cta }}
       {{> components/register-form-mem/_register-form-mem }}
+      <section class="register__bottom-progress-bar-mem">
+        {{> components/progress-bar-mem/_progress-bar-mem }}
+      </section>
     </section>
 
-    <section class="register__bottom-progress-bar-mem">
-      {{> components/progress-bar-mem/_progress-bar-mem }}
-    </section>
 {{/ partial }}
 
 {{> layout}}

--- a/public/signin-page-membership.hbs
+++ b/public/signin-page-membership.hbs
@@ -22,13 +22,11 @@
   <section class="signin__section">
     {{> components/oauth-cta/_oauth-cta }}
     {{> components/signin-form-mem/_signin-form-mem }}
+    <section class="signin__bottom-progress-bar-mem">
+      {{> components/progress-bar-mem/_progress-bar-mem }}
+    </section>
   </section>
-
-  <section class="signin__bottom-progress-bar-mem">
-    {{> components/progress-bar-mem/_progress-bar-mem }}
-  </section>
-
-
+  
 {{/partial}}
 
 {{> layout}}


### PR DESCRIPTION
# CSS changes in the Sign Up/Sign in Form for membership

## Trello card: [Here](https://trello.com/c/eNgI63iS/196-ux-fix-for-the-signup-page-in-identity)

## Why?
The designer requested minor changes to the current implementation of the Sign up and Sign in form of membership. These forms are only applicable in the **flow B** of Sign in and Sign Up.

## Changes
* `_membership.css`: Modified the `padding-left` property of the social buttons and the `font-size` of text fields. Finally, added `margin-bottom` for the bottom progess bar. The `font-weight` property of the button was already `normal`.
* `register-page-membership.hbs`: Changed the structure of the HTML. Moved the bottom progress bar inside the form, so we can use the [`flex-grow`](https://css-tricks.com/almanac/properties/f/flex-grow/) property.
* `signin-page-membership.hbs`: Same changes than above.

## Images

![reg_page 1](https://cloud.githubusercontent.com/assets/825398/20829500/390e4e14-b874-11e6-8e5a-3100d00b1004.png)
