### PR TITLE
Allow Sign Out to redirect to register page

### DIFF
--- a/app/com/gu/identity/frontend/controllers/SignoutAction.scala
+++ b/app/com/gu/identity/frontend/controllers/SignoutAction.scala
@@ -20,7 +20,7 @@ class SignOutAction(identityService: IdentityService, val messagesApi: MessagesA
 
   def signOut(returnUrl: Option[String]) = Action.async { implicit request =>
     val referrer = request.headers.get(HeaderNames.REFERER)
-    val validReturnUrl = ReturnUrl(returnUrl ,referrer, config, None)
+    val validReturnUrl = ReturnUrl(returnUrl ,referrer, config, None, List("/signin"))
     val trackingData = TrackingData(request, None)
     request.cookies.get(CookieName.SC_GU_U).map { cookie =>
       identityService.deauthenticate(cookie, trackingData).map {

--- a/test/com/gu/identity/frontend/controllers/ThirdPartyTsAndCsSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/ThirdPartyTsAndCsSpec.scala
@@ -4,10 +4,10 @@ import akka.util.Timeout
 import com.gu.identity.cookie.{IdentityCookieDecoder, IdentityKeys}
 import com.gu.identity.frontend.authentication.CookieName
 import com.gu.identity.frontend.configuration.Configuration
-import com.gu.identity.frontend.errors.{GetUserAppException, AssignGroupAppException, ErrorHandler}
+import com.gu.identity.frontend.errors.{AssignGroupAppException, ErrorHandler, GetUserAppException}
 import com.gu.identity.frontend.models.{GroupCode, ReturnUrl}
 import com.gu.identity.frontend.services.IdentityService
-import com.gu.identity.service.client.{ClientGatewayError, AssignGroupResponse}
+import com.gu.identity.service.client.{AssignGroupResponse, ClientGatewayError}
 import com.gu.identity.service.client.models.{User, UserGroup}
 import com.gu.identity.model.{User => CookieUser}
 import org.mockito.Matchers.{any => argAny}

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -36,14 +36,18 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
 
     ReturnUrl(None, Some("sso.com.theguardian.teachers://hello"), config, None) should be(ReturnUrl(new URI("http://www.theguardian.com"), isDefault = true))
 
+    ReturnUrl(Some("https://profile.theguardian.com/register"), None, config, None, List("/signin")) should be(ReturnUrl(new URI("https://profile.theguardian.com/register")))
+
+
   }
 
   it should "Determine valid url path" in {
-    validUrlPath(new URI("http://theguardian.com/signin")) should be(false)
-    validUrlPath(new URI("http://theguardian.com/register")) should be(false)
-    validUrlPath(new URI("http://theguardian.com/register/confirm")) should be(true)
-    validUrlPath(new URI("http://theguardian.com")) should be(true)
-    validUrlPath(new URI("http://theguardian.com/politics")) should be(true)
+    validUrlPath(new URI("http://theguardian.com/signin"), defaultInvalidUrlPaths) should be(false)
+    validUrlPath(new URI("http://theguardian.com/register"), defaultInvalidUrlPaths) should be(false)
+    validUrlPath(new URI("http://theguardian.com/register"), List("/signin")) should be(true)
+    validUrlPath(new URI("http://theguardian.com/register/confirm"), defaultInvalidUrlPaths) should be(true)
+    validUrlPath(new URI("http://theguardian.com"), defaultInvalidUrlPaths) should be(true)
+    validUrlPath(new URI("http://theguardian.com/politics"), defaultInvalidUrlPaths) should be(true)
   }
 
   it should "Retrieve default Return URL" in {

--- a/test/com/gu/identity/frontend/models/UrlBuilderSpec.scala
+++ b/test/com/gu/identity/frontend/models/UrlBuilderSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.identity.frontend.models
 
-import java.net.{URLEncoder, URI}
+import java.net.{URI, URLEncoder}
 
 import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.errors.{SeqAppExceptions, SignInActionBadRequestAppException, UnexpectedAppException}


### PR DESCRIPTION
Use case:

User is signed-in under the another account (shared device).  Allow sign-out and redirect to registration page.

N.B. Initially I attempted to use default parameters to archive this but scalac doesn't like this due to

`multiple overloaded alternatives of method apply define
default arguments.`

See [Why does the Scala compiler disallow overloaded methods with default arguments?](http://stackoverflow.com/questions/4652095/why-does-the-scala-compiler-disallow-overloaded-methods-with-default-arguments)

Therefore I added additional constructors to work around this.

