### PR TITLE
Loosen constraints on firstname, lastname and displayname

### DIFF
--- a/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
+++ b/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
@@ -65,8 +65,8 @@ object RegisterActionRequestBody {
     import GroupCode.FormMappings.groupCode
     import ReturnUrl.FormMapping.returnUrl
 
-    def alphaNumericMinMaxLength(min : Int, max: Int): Mapping[String] = text.verifying(
-      "error.displayName", name => name.matches("[A-z0-9\\ ]+") && name.length >= min && name.length <= max
+    def minMaxLength(min : Int, max: Int): Mapping[String] = text.verifying(
+      "error.displayName", name => name.length >= min && name.length <= max
     )
 
     private val password: Mapping[String] = text.verifying(
@@ -75,10 +75,10 @@ object RegisterActionRequestBody {
 
     def registerFormMapping(refererHeader: Option[String]): Mapping[RegisterActionRequestBody] =
       mapping(
-        "firstName" -> alphaNumericMinMaxLength(1, 20),
-        "lastName" -> alphaNumericMinMaxLength(1, 20),
+        "firstName" -> minMaxLength(1, 25),
+        "lastName" -> minMaxLength(1, 25),
         "email" -> email,
-        "displayName" -> alphaNumericMinMaxLength(2, 40),
+        "displayName" -> minMaxLength(2, 50),
         "password" -> password,
         "countryCode" -> optional(text),
         "localNumber" -> optional(text),

--- a/app/com/gu/identity/frontend/views/models/ErrorViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/ErrorViewModel.scala
@@ -24,10 +24,10 @@ object ErrorViewModel {
     RegisterBadRequestErrorID -> "One or more inputs was not valid; please try again.",
     RegisterActionBadRequestErrorID -> "One or more inputs was not valid; please try again.",
     RegisterEmailConflictErrorID -> "This email is already in use; please check you do not already have an account.",
-    RegisterActionInvalidFirstNameErrorID -> alphaOnlyMinMaxLength("first name", 1, 20),
-    RegisterActionInvalidLastNameErrorID -> alphaOnlyMinMaxLength("last name", 1, 20),
+    RegisterActionInvalidFirstNameErrorID -> minMaxLength("First name", 1, 25),
+    RegisterActionInvalidLastNameErrorID -> minMaxLength("Last name", 1, 25),
     RegisterActionInvalidEmailErrorID -> "Invalid email address; please try again.",
-    RegisterActionInvalidDisplayNameErrorID -> "Invalid display name; your display name must be between 2 and 40 characters long and contain only letters and numbers.",
+    RegisterActionInvalidDisplayNameErrorID -> minMaxLength("Display name", 2, 50),
     RegisterActionInvalidPasswordErrorID -> "Invalid password; your password must be between 6 and 72 characters long.",
 
     SocialRegistrationFacebookEmailErrorID -> "We need your email address when you sign in with Facebook so that we can keep in touch (you can choose which emails you receive in your account settings). Try again and allow access to your email address or provide it manually below.",
@@ -49,7 +49,7 @@ object ErrorViewModel {
 
   private def nonEmptyField(fieldName: String) = s"${fieldName.capitalize} field must not be blank."
 
-  private def alphaOnlyMinMaxLength(fieldName: String, min: Int, max: Int) = s"${fieldName.capitalize} field must be between $min and $max characters long and contain only letters."
+  private def minMaxLength(fieldName: String, min: Int, max: Int) = s"${fieldName.capitalize} field must be between $min and $max characters long."
 
   val default: String = "There was an unexpected problem; please try again."
 

--- a/public/components/register-form-mem/_register-form-mem.hbs
+++ b/public/components/register-form-mem/_register-form-mem.hbs
@@ -26,10 +26,10 @@
             <label class="register-form__label--name" for="register_field_firstname">{{ registerPageText.name }}</label>
 
             <div class="register-form__control-column--firstname">
-                <input class="register-form__field--firstname" id="register_field_firstname" type="text" name="firstName" placeholder="{{ registerPageText.firstName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="[a-zA-Z0-9]+" />
+                <input class="register-form__field--firstname" id="register_field_firstname" type="text" name="firstName" placeholder="{{ registerPageText.firstName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" />
             </div>
             <div class="register-form__control-column--lastname">
-                <input class="register-form__field--lastname" id="register_field_lastname" type="text" name="lastName" placeholder="{{ registerPageText.lastName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="[a-zA-Z0-9]+" />
+                <input class="register-form__field--lastname" id="register_field_lastname" type="text" name="lastName" placeholder="{{ registerPageText.lastName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" />
             </div>
         </div>
 
@@ -80,7 +80,7 @@
 
     <div class="register-form__control--displayName {{#if hideDisplayName}}hidden{{/if}}">
         <label class="register-form__label--displayName" for="register_field_displayName"><span>{{ registerPageText.displayName }}</span> <span class="register-form__label--displayName-note">{{ registerPageText.displayNameNote }}</span></label>
-        <input class="register-form__field--displayName" id="register_field_displayName" type="text" name="displayName" placeholder="{{ registerPageText.displayNameHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" title="{{ registerPageText.displayNameHelp }}" {{#unless hideDisplayName}} required minlength="2" maxlength="40" pattern="[a-zA-Z0-9\ ]+" {{/unless}} />
+        <input class="register-form__field--displayName" id="register_field_displayName" type="text" name="displayName" placeholder="{{ registerPageText.displayNameHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" title="{{ registerPageText.displayNameHelp }}" {{#unless hideDisplayName}} required minlength="2" maxlength="50" {{/unless}} />
     </div>
     {{# unless hideDisplayName}}
         {{#each errors.displayNameErrors }}

--- a/public/components/register-form/_register-form.hbs
+++ b/public/components/register-form/_register-form.hbs
@@ -26,10 +26,10 @@
       <label class="register-form__label--name" for="register_field_firstname">{{ registerPageText.name }}</label>
 
       <div class="register-form__control-column--firstname">
-        <input class="register-form__field--firstname" id="register_field_firstname" type="text" name="firstName" placeholder="{{ registerPageText.firstName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="[a-zA-Z0-9]+" />
+        <input class="register-form__field--firstname" id="register_field_firstname" type="text" name="firstName" placeholder="{{ registerPageText.firstName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" />
       </div>
       <div class="register-form__control-column--lastname">
-        <input class="register-form__field--lastname" id="register_field_lastname" type="text" name="lastName" placeholder="{{ registerPageText.lastName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="[a-zA-Z0-9]+" />
+        <input class="register-form__field--lastname" id="register_field_lastname" type="text" name="lastName" placeholder="{{ registerPageText.lastName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" />
       </div>
     </div>
 
@@ -80,7 +80,7 @@
 
     <div class="register-form__control--displayName {{# hideDisplayName}}hidden{{/hideDisplayName}}">
         <label class="register-form__label--displayName" for="register_field_displayName"><span>{{ registerPageText.displayName }}</span> <span class="register-form__label--displayName-note">{{ registerPageText.displayNameNote }}</span></label>
-        <input class="register-form__field--displayName" id="register_field_displayName" type="text" name="displayName" placeholder="{{ registerPageText.displayNameHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" title="{{ registerPageText.displayNameHelp }}" {{#unless hideDisplayName}} required minlength="2" maxlength="40" pattern="[a-zA-Z0-9\ ]+" {{/unless}} />
+        <input class="register-form__field--displayName" id="register_field_displayName" type="text" name="displayName" placeholder="{{ registerPageText.displayNameHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" title="{{ registerPageText.displayNameHelp }}" {{#unless hideDisplayName}} required minlength="2" maxlength="50" {{/unless}} />
     </div>
     {{# unless hideDisplayName}}
       {{#each errors.displayNameErrors }}

--- a/test/com/gu/identity/frontend/controllers/RegisterActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/RegisterActionSpec.scala
@@ -425,21 +425,7 @@ class RegisterActionSpec extends PlaySpec with MockitoSugar {
     }
 
     "return register-error-displayName if displayName is too long" in new WithControllerMockedDependencies {
-      val displayName = "12345678901234567890123456789012345678901"
-
-      val result = call(controller.register, fakeRegisterRequest(displayName = displayName))
-
-      val queryParams = UrlDecoder.getQueryParams(redirectLocation(result).get)
-      status(result) mustEqual SEE_OTHER
-
-      queryParams.contains("error") mustEqual true
-      queryParams.get("error") mustEqual Some("register-error-displayName")
-
-      redirectLocation(result).get must startWith (routes.Application.register(Seq.empty, None).url)
-    }
-
-    "return register-error-displayName if displayName contains a non alphanumeric character" in new WithControllerMockedDependencies {
-      val displayName = "123456$"
+      val displayName = "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901"
 
       val result = call(controller.register, fakeRegisterRequest(displayName = displayName))
 


### PR DESCRIPTION
I'm worried that the alphanumeric constraints on firstname, lastname and displayname in the register form are too strict and will prevent people with names such as O'hare or Rees-Mogg from registering.

As there doesn't seem to be a reason why these are here now that we are using displayname rather than username (which did require non-alphanumeric values) I think we should remove the constraints.
