### PR TITLE
GA Smart Lock Sign-in

### DIFF
--- a/public/components/analytics/ga.js
+++ b/public/components/analytics/ga.js
@@ -14,6 +14,15 @@ function record(gaUID) {
   ga('send', 'pageview');
 }
 
+export function customMetric(event) {
+  console.log("Custom event");
+
+  var metricValue = '1';
+  ga('send', 'event', 'category', 'action', {
+    'metric2': metricValue
+  });
+}
+
 function loadGA() {
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/public/components/analytics/ga.js
+++ b/public/components/analytics/ga.js
@@ -29,6 +29,7 @@ function buildGoogleAnalyticsEvent(event) {
   const fieldsObject = {
     eventCategory: 'identity',
     eventAction: event.name,
+    eventLabel: event.type,
     dimension3: 'profile.theguardian.com',
     dimension4: navigator.userAgent,
     dimension5: window.location.href,

--- a/public/components/analytics/ga.js
+++ b/public/components/analytics/ga.js
@@ -15,8 +15,7 @@ export function init() {
 }
 
 export function customMetric(event) {
-  ga(gaTracker + '.send', 'event',
-    buildGoogleAnalyticsEvent(event));
+  ga(gaTracker + '.send', 'event', buildGoogleAnalyticsEvent(event));
 }
 
 function record(gaUID) {

--- a/public/components/analytics/ga.js
+++ b/public/components/analytics/ga.js
@@ -26,7 +26,6 @@ function record(gaUID) {
 }
 
 function buildGoogleAnalyticsEvent(event) {
-
   const category = 'identity';
   const action = event.name;
   const fieldsObject = {

--- a/public/components/analytics/ga.js
+++ b/public/components/analytics/ga.js
@@ -3,6 +3,12 @@
  */
 import { configuration } from '../configuration/configuration';
 
+const gaTracker = 'IdentityPropertyTracker';
+const events = {
+  metricMap: {
+    'SmartLockSignin': 'metric3',
+  }};
+
 export function init() {
   const gaUID = configuration.gaUID;
   return record(gaUID);
@@ -15,12 +21,28 @@ function record(gaUID) {
 }
 
 export function customMetric(event) {
-  console.log("Custom event");
+  ga('send', 'event',
+    buildGoogleAnalyticsEvent(event, '1'));
+}
 
-  var metricValue = '1';
-  ga('send', 'event', 'category', 'action', {
-    'metric2': metricValue
-  });
+function buildGoogleAnalyticsEvent(event) {
+
+  const category = 'identity';
+  const action = event.name;
+  const fieldsObject = {
+    eventCategory: category,
+    eventAction: action,
+    dimension3: 'profile.theguardian.com',
+    forceSSL: true
+  };
+
+  // Increment the appropriate metric based on the event type
+  const metricId = events.metricMap[event.type];
+  if (metricId) {
+    fieldsObject[metricId] = 1;
+  }
+
+  return fieldsObject;
 }
 
 function loadGA() {

--- a/public/components/analytics/ga.js
+++ b/public/components/analytics/ga.js
@@ -33,6 +33,8 @@ function buildGoogleAnalyticsEvent(event) {
     eventCategory: category,
     eventAction: action,
     dimension3: 'profile.theguardian.com',
+    dimension27: navigator.userAgent,
+    dimension29: window.location.href,
     forceSSL: true
   };
 

--- a/public/components/analytics/ga.js
+++ b/public/components/analytics/ga.js
@@ -14,15 +14,15 @@ export function init() {
   return record(gaUID);
 }
 
+export function customMetric(event) {
+  ga(gaTracker + '.send', 'event',
+    buildGoogleAnalyticsEvent(event));
+}
+
 function record(gaUID) {
   loadGA();
   ga('create', gaUID, 'auto', gaTracker);
   ga(gaTracker + '.send', 'pageview');
-}
-
-export function customMetric(event) {
-  ga(gaTracker + '.send', 'event',
-    buildGoogleAnalyticsEvent(event, '1'));
 }
 
 function buildGoogleAnalyticsEvent(event) {

--- a/public/components/analytics/ga.js
+++ b/public/components/analytics/ga.js
@@ -7,7 +7,8 @@ const gaTracker = 'IdentityPropertyTracker';
 const events = {
   metricMap: {
     'SmartLockSignin': 'metric3',
-  }};
+  }
+};
 
 export function init() {
   const gaUID = configuration.gaUID;
@@ -25,11 +26,9 @@ function record(gaUID) {
 }
 
 function buildGoogleAnalyticsEvent(event) {
-  const category = 'identity';
-  const action = event.name;
   const fieldsObject = {
-    eventCategory: category,
-    eventAction: action,
+    eventCategory: 'identity',
+    eventAction: event.name,
     dimension3: 'profile.theguardian.com',
     dimension4: navigator.userAgent,
     dimension5: window.location.href,

--- a/public/components/analytics/ga.js
+++ b/public/components/analytics/ga.js
@@ -16,12 +16,12 @@ export function init() {
 
 function record(gaUID) {
   loadGA();
-  ga('create', gaUID, 'auto');
-  ga('send', 'pageview');
+  ga('create', gaUID, 'auto', gaTracker);
+  ga(gaTracker + '.send', 'pageview');
 }
 
 export function customMetric(event) {
-  ga('send', 'event',
+  ga(gaTracker + '.send', 'event',
     buildGoogleAnalyticsEvent(event, '1'));
 }
 

--- a/public/components/analytics/ga.js
+++ b/public/components/analytics/ga.js
@@ -33,8 +33,8 @@ function buildGoogleAnalyticsEvent(event) {
     eventCategory: category,
     eventAction: action,
     dimension3: 'profile.theguardian.com',
-    dimension27: navigator.userAgent,
-    dimension29: window.location.href,
+    dimension4: navigator.userAgent,
+    dimension5: window.location.href,
     forceSSL: true
   };
 

--- a/public/components/signin-form/signin-form.js
+++ b/public/components/signin-form/signin-form.js
@@ -1,7 +1,7 @@
 /*global window, document*/
 
 import { getElementById, sessionStorage } from '../browser/browser';
-import { customMetric as customMetric } from '../analytics/ga';
+import { customMetric } from '../analytics/ga';
 
 const STORAGE_KEY = 'gu_id_signIn_state';
 const SMART_LOCK_STORAGE_KEY = 'gu_id_smartLock_state';

--- a/public/components/signin-form/signin-form.js
+++ b/public/components/signin-form/signin-form.js
@@ -1,6 +1,7 @@
 /*global window, document*/
 
 import { getElementById, sessionStorage } from '../browser/browser';
+import { customMetric as customMetric } from '../analytics/ga';
 
 const STORAGE_KEY = 'gu_id_signIn_state';
 const SMART_LOCK_STORAGE_KEY = 'gu_id_smartLock_state';
@@ -9,6 +10,10 @@ class SignInFormModel {
   constructor( formElement, emailField ) {
     this.formElement = formElement;
     this.emailFieldElement = emailField;
+
+    const event = { name: 'signin', value: 'signin'};
+
+    customMetric(event);
 
     this.addBindings();
     this.smartLock();
@@ -36,7 +41,7 @@ class SignInFormModel {
     if (navigator.credentials) {
       const formElement = this.formElement.elem;
 
-      var c = new PasswordCredential(formElement);
+      const c = new PasswordCredential(formElement);
       this.updateSmartLockStatus(true);
       this.smartLockSignIn(c);
     }

--- a/public/components/signin-form/signin-form.js
+++ b/public/components/signin-form/signin-form.js
@@ -10,11 +10,6 @@ class SignInFormModel {
   constructor( formElement, emailField ) {
     this.formElement = formElement;
     this.emailFieldElement = emailField;
-
-    const event = { name: 'signin', value: 'signin'};
-
-    customMetric(event);
-
     this.addBindings();
     this.smartLock();
   }
@@ -74,6 +69,7 @@ class SignInFormModel {
           .then(r => {
             if (r.status == 200) {
               this.updateSmartLockStatus(true);
+              customMetric({ name: 'SigninSuccessful', type: 'SmartLockSignin'});
               this.storeRedirect(c);
               return;
             }


### PR DESCRIPTION
This PR fires a GA custom metric when a user successfully authenticates using Smart Lock.  Additional PR's will be raised with more meta-data (ophanId etc) and log other events (regular sign-in etc) in the near future 