### PR TITLE
Hide display name for all clients

### DIFF
--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -76,7 +76,7 @@ object RegisterViewModel {
 
       showStandfirst = showStandfirst(clientId),
       askForPhoneNumber = askForPhoneNumber(clientId),
-      hideDisplayName = List(Some(GuardianMembersAClientID), Some(GuardianMembersBClientID)).contains(clientId),
+      hideDisplayName = true,
 
       csrfToken = csrfToken,
       returnUrl = returnUrl.url,


### PR DESCRIPTION
@mario-galic is updating discussion to collect username on first comment.  Once this change has been merged we can remove display name entirely.  As displayname will be removed entirely once @mario-galic's change has been merged, I am simply hiding it for all clients.  