### PR TITLE
Set GU_U secure flag to true

### DIFF
--- a/app/com/gu/identity/frontend/authentication/AuthenticationService.scala
+++ b/app/com/gu/identity/frontend/authentication/AuthenticationService.scala
@@ -13,7 +13,7 @@ object AuthenticationService {
   val knownCookies: Seq[GuardianCookie] = Seq(
     DotComCookie(CookieName.gu_user_features_expiry, secure = false),
     DotComCookie(CookieName.gu_paying_member, secure = false),
-    IdentityCookie(CookieName.GU_U, secure = false),
+    IdentityCookie(CookieName.GU_U, secure = true),
     IdentityCookie(CookieName.GU_ID_CSRF, secure = true),
     IdentityCookie(CookieName.GU_PROFILE_CSRF, secure = true),
     IdentityCookie(CookieName.SC_GU_U, secure = true)

--- a/app/com/gu/identity/frontend/authentication/AuthenticationService.scala
+++ b/app/com/gu/identity/frontend/authentication/AuthenticationService.scala
@@ -11,12 +11,12 @@ case class AuthenticatedUser(userId: String)
 object AuthenticationService {
 
   val knownCookies: Seq[GuardianCookie] = Seq(
-    DotComCookie(CookieName.gu_user_features_expiry, secure = false),
-    DotComCookie(CookieName.gu_paying_member, secure = false),
-    IdentityCookie(CookieName.GU_U, secure = true),
-    IdentityCookie(CookieName.GU_ID_CSRF, secure = true),
-    IdentityCookie(CookieName.GU_PROFILE_CSRF, secure = true),
-    IdentityCookie(CookieName.SC_GU_U, secure = true)
+    DotComCookie(CookieName.gu_user_features_expiry),
+    DotComCookie(CookieName.gu_paying_member),
+    IdentityCookie(CookieName.GU_U),
+    IdentityCookie(CookieName.GU_ID_CSRF),
+    IdentityCookie(CookieName.GU_PROFILE_CSRF),
+    IdentityCookie(CookieName.SC_GU_U)
   )
 
   implicit def cookieNameToString(cookieName: Name): String = cookieName.toString
@@ -34,7 +34,7 @@ object AuthenticationService {
       newCookies: Seq[Cookie] = Seq.empty): Result = {
 
     val cookiesToDiscard: Seq[DiscardingCookie] = knownCookies.map { cookie =>
-      DiscardingCookie(name = cookie.name, path = "/", domain = Some(cookieDomain), secure = cookie.secure)
+      DiscardingCookie(name = cookie.name, path = "/", domain = Some(cookieDomain), secure = true)
     }
 
     NoCache(

--- a/app/com/gu/identity/frontend/authentication/CookieName.scala
+++ b/app/com/gu/identity/frontend/authentication/CookieName.scala
@@ -5,11 +5,9 @@ object CookieName extends Enumeration {
 
   type Name = Value
   val GU_U, SC_GU_U, SC_GU_LA, GU_SO, GU_ID_CSRF, GU_PROFILE_CSRF, gu_user_features_expiry, gu_paying_member = Value
-  val secureCookies = List(GU_U, SC_GU_U, SC_GU_LA, GU_ID_CSRF, GU_PROFILE_CSRF)
 
   val SECURE_COOKIE_PREFIX = "SC"
   def isHttpOnly(cookieName: String) = cookieName.startsWith(SECURE_COOKIE_PREFIX)
-  def isSecureCookie(cookieName: String) = secureCookies.map(_.toString).contains(cookieName)
 
 
 }

--- a/app/com/gu/identity/frontend/authentication/CookieName.scala
+++ b/app/com/gu/identity/frontend/authentication/CookieName.scala
@@ -3,10 +3,10 @@ package com.gu.identity.frontend.authentication
 
 object CookieName extends Enumeration {
 
-  val SECURE_COOKIE_PREFIX = "SC"
-  def isSecureCookie(cookieName: String) = cookieName.startsWith(SECURE_COOKIE_PREFIX)
-
   type Name = Value
   val GU_U, SC_GU_U, SC_GU_LA, GU_SO, GU_ID_CSRF, GU_PROFILE_CSRF, gu_user_features_expiry, gu_paying_member = Value
+  val secureCookies = List(GU_U, SC_GU_U, SC_GU_LA, GU_ID_CSRF, GU_PROFILE_CSRF)
+
+  def isSecureCookie(cookieName: String) = secureCookies.map(_.toString).contains(cookieName)
 
 }

--- a/app/com/gu/identity/frontend/authentication/CookieName.scala
+++ b/app/com/gu/identity/frontend/authentication/CookieName.scala
@@ -7,6 +7,9 @@ object CookieName extends Enumeration {
   val GU_U, SC_GU_U, SC_GU_LA, GU_SO, GU_ID_CSRF, GU_PROFILE_CSRF, gu_user_features_expiry, gu_paying_member = Value
   val secureCookies = List(GU_U, SC_GU_U, SC_GU_LA, GU_ID_CSRF, GU_PROFILE_CSRF)
 
+  val SECURE_COOKIE_PREFIX = "SC"
+  def isHttpOnly(cookieName: String) = cookieName.startsWith(SECURE_COOKIE_PREFIX)
   def isSecureCookie(cookieName: String) = secureCookies.map(_.toString).contains(cookieName)
+
 
 }

--- a/app/com/gu/identity/frontend/authentication/CookieService.scala
+++ b/app/com/gu/identity/frontend/authentication/CookieService.scala
@@ -22,7 +22,8 @@ object CookieService {
   def signInCookies(cookies: Seq[IdentityApiCookie], rememberMe: Boolean, now: Option[DateTime] = None)(config: Configuration): Seq[PlayCookie] = {
     cookies.map { c =>
       val maxAge = if (rememberMe) Some(getMaxAge(c.expires, now)) else None
-      val secureHttpOnly = CookieName.isSecureCookie(c.name)
+      val secureCookie = CookieName.isSecureCookie(c.name)
+      val httpOnlyCookie = CookieName.isHttpOnly(c.name)
       val cookieMaxAgeOpt = maxAge.filterNot(_ => c.isSession)
 
       PlayCookie(
@@ -31,8 +32,8 @@ object CookieService {
         maxAge = cookieMaxAgeOpt,
         path = "/",
         domain = Some(config.identityCookieDomain),
-        secure = secureHttpOnly,
-        httpOnly = secureHttpOnly
+        secure = secureCookie,
+        httpOnly = httpOnlyCookie
       )
     }
   }

--- a/app/com/gu/identity/frontend/authentication/CookieService.scala
+++ b/app/com/gu/identity/frontend/authentication/CookieService.scala
@@ -6,12 +6,11 @@ import play.api.mvc.{Cookie => PlayCookie}
 
 sealed trait GuardianCookie {
   def name: CookieName.Name
-  def secure: Boolean
 }
 
-final case class DotComCookie(name: CookieName.Name, secure: Boolean) extends GuardianCookie
+final case class DotComCookie(name: CookieName.Name) extends GuardianCookie
 
-final case class IdentityCookie(name: CookieName.Name, secure: Boolean) extends GuardianCookie
+final case class IdentityCookie(name: CookieName.Name) extends GuardianCookie
 
 final case class IdentityApiCookie(name: String, value: String, isSession: Boolean, expires: DateTime)
 
@@ -22,7 +21,6 @@ object CookieService {
   def signInCookies(cookies: Seq[IdentityApiCookie], rememberMe: Boolean, now: Option[DateTime] = None)(config: Configuration): Seq[PlayCookie] = {
     cookies.map { c =>
       val maxAge = if (rememberMe) Some(getMaxAge(c.expires, now)) else None
-      val secureCookie = CookieName.isSecureCookie(c.name)
       val httpOnlyCookie = CookieName.isHttpOnly(c.name)
       val cookieMaxAgeOpt = maxAge.filterNot(_ => c.isSession)
 
@@ -32,7 +30,7 @@ object CookieService {
         maxAge = cookieMaxAgeOpt,
         path = "/",
         domain = Some(config.identityCookieDomain),
-        secure = secureCookie,
+        secure = true,
         httpOnly = httpOnlyCookie
       )
     }
@@ -48,7 +46,7 @@ object CookieService {
         maxAge = maxAgeOpt,
         path = "/",
         domain = Some(config.identityCookieDomain),
-        secure = false,
+        secure = true,
         httpOnly = false
       )
 

--- a/test/com/gu/identity/frontend/authentication/CookieServiceSpec.scala
+++ b/test/com/gu/identity/frontend/authentication/CookieServiceSpec.scala
@@ -82,7 +82,7 @@ class CookieServiceSpec extends PlaySpec {
 
       "set correct flag on GU_SO cookie" in {
         val cookieResult = CookieService.signOutCookies(signOutCookiesFromApi)(configuration)
-        cookieResult.filter(c => c.name == CookieName.GU_SO.toString).head.secure mustEqual false
+        cookieResult.filter(c => c.name == CookieName.GU_SO.toString).head.secure mustEqual true
         cookieResult.filter(c => c.name == CookieName.GU_SO.toString).head.httpOnly mustEqual false
       }
 

--- a/test/com/gu/identity/frontend/authentication/CookieServiceSpec.scala
+++ b/test/com/gu/identity/frontend/authentication/CookieServiceSpec.scala
@@ -56,6 +56,7 @@ class CookieServiceSpec extends PlaySpec {
 
     "set correct flags on secure cookies" in {
       val cookieResult = CookieService.signInCookies(signInCookiesFromApi, rememberMe = false)(configuration)
+      cookieResult.filter(c => c.name == CookieName.GU_U.toString).head.secure mustEqual true
       cookieResult.filter(c => c.name == CookieName.SC_GU_U.toString).head.secure mustEqual true
       cookieResult.filter(c => c.name == CookieName.SC_GU_U.toString).head.httpOnly mustEqual true
       cookieResult.filter(c => c.name == CookieName.SC_GU_LA.toString).head.secure mustEqual true

--- a/test/com/gu/identity/frontend/controllers/SignOutActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/SignOutActionSpec.scala
@@ -32,7 +32,7 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
   val signedInCookies = Seq(
     secureCookie,
     Cookie(name = CookieName.SC_GU_LA.toString, value = "SC_GU_LA", maxAge = None, path = "/", domain = Some("dev-theguardian.com"), secure = true, httpOnly = true),
-    Cookie(name = CookieName.GU_U.toString, value = "GU_U", maxAge = None, path = "/", domain = Some("dev-theguardian.com"), secure = false, httpOnly = false)
+    Cookie(name = CookieName.GU_U.toString, value = "GU_U", maxAge = None, path = "/", domain = Some("dev-theguardian.com"), secure = true, httpOnly = false)
   )
 
   val referer = "http://www.theguardian.com/refs"


### PR DESCRIPTION
Now the site is fully [HTTPS](https://www.theguardian.com/info/developer-blog/2016/nov/29/the-guardian-has-moved-to-https) we can use a secure GU_U cookie to ensure data is sent of TLS.  

@adamnfish 

After registering locally:

![screen shot 2016-12-16 at 17 38 08](https://cloud.githubusercontent.com/assets/406099/21272335/afb226c4-c3b6-11e6-9f40-17bf384ac1b5.png)

