### PR TITLE
Removed the second flow of membership

### DIFF
--- a/app/com/gu/identity/frontend/models/ClientID.scala
+++ b/app/com/gu/identity/frontend/models/ClientID.scala
@@ -23,14 +23,8 @@ sealed trait ClientID extends Product2[ClientID, String] {
   def _2 = id
 }
 
-case object GuardianMembersAClientID extends ClientID {
+case object GuardianMembersClientID extends ClientID {
   val id = "members"
-
-  override def hasSkin = true
-}
-
-case object GuardianMembersBClientID extends ClientID {
-  val id = "membersB"
 
   override def hasSkin = true
 }
@@ -47,7 +41,7 @@ case object GuardianCommentersClientID extends ClientID {
 }
 
 object ClientID {
-  def all: Seq[ClientID] = Seq(GuardianMembersAClientID, GuardianMembersBClientID, GuardianCommentersClientID, GuardianJobsClientID)
+  def all: Seq[ClientID] = Seq(GuardianMembersClientID, GuardianCommentersClientID, GuardianJobsClientID)
 
   def apply(clientId: String): Option[ClientID] =
     all.find(_.id == clientId)

--- a/app/com/gu/identity/frontend/models/ReturnUrl.scala
+++ b/app/com/gu/identity/frontend/models/ReturnUrl.scala
@@ -50,8 +50,7 @@ object ReturnUrl {
 
   def defaultForClient(configuration: Configuration, clientId: Option[ClientID]) =
     clientId match {
-      case Some(GuardianMembersAClientID) => defaultForMembership(configuration)
-      case Some(GuardianMembersBClientID) => defaultForMembership(configuration)
+      case Some(GuardianMembersClientID) => defaultForMembership(configuration)
       case _ => default(configuration)
     }
 

--- a/app/com/gu/identity/frontend/models/text/RegisterText.scala
+++ b/app/com/gu/identity/frontend/models/text/RegisterText.scala
@@ -1,6 +1,6 @@
 package com.gu.identity.frontend.models.text
 
-import com.gu.identity.frontend.models.{ClientID, GuardianMembersAClientID, GuardianMembersBClientID}
+import com.gu.identity.frontend.models.{ClientID, GuardianMembersClientID}
 import play.api.i18n.Messages
 
 case class RegisterText private(
@@ -54,8 +54,7 @@ object RegisterText {
       signInCta = messages("register.signInCta"),
       standfirst = messages("register.standfirst"),
       title = clientId match {
-        case Some(GuardianMembersAClientID) => messages("register.title.membership")
-        case Some(GuardianMembersBClientID) => messages("register.title.supporter")
+        case Some(GuardianMembersClientID) => messages("register.title.supporter")
         case _ => messages("register.title")
       },
       displayName = messages("register.displayName"),

--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -43,7 +43,7 @@ object ViewRenderer {
     )
 
     val view = clientId match {
-      case Some(GuardianMembersBClientID) => "signin-page-membership"
+      case Some(GuardianMembersClientID) => "signin-page-membership"
       case _ => "signin-page"
     }
 
@@ -72,8 +72,7 @@ object ViewRenderer {
       group = group)
 
     clientId match {
-      case Some(GuardianMembersAClientID) => renderViewModel("register-page", model)
-      case Some(GuardianMembersBClientID) => renderViewModel("register-page-membership", model)
+      case Some(GuardianMembersClientID) => renderViewModel("register-page-membership", model)
       case _ => renderViewModel("register-page", model)
     }
   }

--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -2,7 +2,7 @@ package com.gu.identity.frontend.views.models
 
 import buildinfo.BuildInfo
 import com.gu.identity.frontend.configuration.Configuration
-import com.gu.identity.frontend.models.{ClientID, GuardianJobsClientID, GuardianMembersAClientID, GuardianMembersBClientID, ReturnUrl}
+import com.gu.identity.frontend.models.{ClientID, GuardianJobsClientID, GuardianMembersClientID, ReturnUrl}
 import com.gu.identity.frontend.models.Text.{HeaderText, LayoutText}
 import com.gu.identity.frontend.models.text.FooterText
 import com.gu.identity.frontend.mvt
@@ -157,8 +157,7 @@ object LayoutLinks {
 
   private def logoUrl(configuration: Configuration, clientId: Option[ClientID]) =
     clientId match {
-      case Some(GuardianMembersAClientID) => configuration.preferredMembershipUrl
-      case Some(GuardianMembersBClientID) => configuration.preferredMembershipUrl
+      case Some(GuardianMembersClientID) => configuration.preferredMembershipUrl
       case Some(GuardianJobsClientID) => configuration.jobsBaseUrl
       case _ => configuration.dotcomBaseUrl
     }

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -58,10 +58,6 @@ object RegisterViewModel {
 
     val codes = countryCodes(clientId)
 
-    val isMembership = clientId match {
-      case Some(GuardianMembersClientID) => true
-      case _ => false
-    }
     RegisterViewModel(
       layout = layout,
 

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -59,8 +59,7 @@ object RegisterViewModel {
     val codes = countryCodes(clientId)
 
     val isMembership = clientId match {
-      case Some(GuardianMembersAClientID) => true
-      case Some(GuardianMembersBClientID) => true
+      case Some(GuardianMembersClientID) => true
       case _ => false
     }
     RegisterViewModel(

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -56,8 +56,7 @@ object SignInViewModel {
     val resources = getResources(layout, recaptchaModel) ++ Seq(IndirectlyLoadedExternalResources(UrlBuilder(configuration.identityProfileBaseUrl,routes.SigninAction.signInWithSmartLock())))
 
     val isMembership = clientId match {
-      case Some(GuardianMembersAClientID) => true
-      case Some(GuardianMembersBClientID) => true
+      case Some(GuardianMembersClientID) => true
       case _ => false
     }
 

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -55,10 +55,7 @@ object SignInViewModel {
 
     val resources = getResources(layout, recaptchaModel) ++ Seq(IndirectlyLoadedExternalResources(UrlBuilder(configuration.identityProfileBaseUrl,routes.SigninAction.signInWithSmartLock())))
 
-    val isMembership = clientId match {
-      case Some(GuardianMembersClientID) => true
-      case _ => false
-    }
+    val isMembership = clientId.exists(_ == GuardianMembersClientID)
 
     SignInViewModel(
       layout = layout,

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -2,7 +2,6 @@ layout.pagetitle=Identity | The Guardian
 
 signin.title=Sign in to the Guardian
 signin.title.supporter=Become a Supporter
-#signin.title.membership=Sign in to the Guardian to become a member
 signin.pagetitle=Sign in
 signin.prelude=Creating an account means you can save articles for later, leave comments, enter competitions, become a member and lots more.
 signin.prelude.moreinfo=Want to know more?
@@ -21,7 +20,6 @@ signin.continue=Continue
 # com.gu.identity.frontend.models.text.RegisterText
 register.pageTitle=Register
 register.title=Create your Guardian account
-register.title.membership=Create your Guardian account to become a member
 register.title.supporter=Become a Supporter
 register.standfirst=Register today to shortlist and apply for jobs more easily.
 register.divideText=or

--- a/public/components/membership/_membership.css
+++ b/public/components/membership/_membership.css
@@ -1,5 +1,4 @@
-.skin-members,
-.skin-membersB {
+.skin-members {
   .header__logo-link {
     background-image: inline("guardian-members-logo.svg");
     height: height("guardian-members-logo.svg");
@@ -19,8 +18,7 @@
 }
 
 @media (--viewport-min-tablet) {
-  .skin-members,
-  .skin-membersB {
+  .skin-members {
     @mixin header__back-link--dark;
   }
 }
@@ -35,7 +33,7 @@
   }
 }
 
-.skin-membersB {
+.skin-members {
   background-color: #fff;
 
   .page-heading {

--- a/public/components/register-form-mem/_register-form-mem.hbs
+++ b/public/components/register-form-mem/_register-form-mem.hbs
@@ -1,118 +1,34 @@
 <form id="register_form" class="register-form" action="{{ actions.register }}" method="POST">
-    <input type="hidden" name="{{ csrfToken.fieldName }}" value="{{ csrfToken.value }}">
-    <input type="hidden" name="returnUrl" value="{{ returnUrl }}"/>
-    <input type="hidden" name="skipConfirmation" value="{{ skipConfirmation }}"/>
-    {{# hideDisplayName }}
-        <input type="hidden" id="register_field_hideDisplayName" name="hideDisplayName" value="{{ hideDisplayName }}" />
-    {{/hideDisplayName}}
+
+  <input type="hidden" name="{{ csrfToken.fieldName }}" value="{{ csrfToken.value }}">
+  <input type="hidden" name="returnUrl" value="{{ returnUrl }}"/>
+  <input type="hidden" name="skipConfirmation" value="{{ skipConfirmation }}"/>
+
+  {{# hideDisplayName }}
+    <input type="hidden" id="register_field_hideDisplayName" name="hideDisplayName" value="{{ hideDisplayName }}" />
+  {{/hideDisplayName}}
 
   {{# group }}
-      <input type="hidden" name="groupCode" value="{{ group.id }}">
+    <input type="hidden" name="groupCode" value="{{ group.id }}">
   {{/ group }}
 
   {{# clientId }}
-      <input type="hidden" name="clientId" value="{{ clientId.id }}">
+    <input type="hidden" name="clientId" value="{{ clientId.id }}">
   {{/ clientId }}
 
-    <p class="register-form__prelude">{{ registerPageText.divideText }}</p>
+  <p class="register-form__prelude">{{ registerPageText.divideText }}</p>
 
   {{#each errors.otherErrors }}
-      <p id="{{ id }}" class="register-form__error">{{ message }}</p>
+    <p id="{{ id }}" class="register-form__error">{{ message }}</p>
   {{/ each }}
 
-    <fieldset class="register-form__fieldset">
+  <fieldset class="register-form__fieldset">
+    {{> components/register-form/_form-fields}}
+  </fieldset>
 
-        <div class="register-form__control--name">
-            <label class="register-form__label--name" for="register_field_firstname">{{ registerPageText.name }}</label>
+  {{> components/terms/_terms }}
 
-            <div class="register-form__control-column--firstname">
-                <input class="register-form__field--firstname" id="register_field_firstname" type="text" name="firstName" placeholder="{{ registerPageText.firstName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" />
-            </div>
-            <div class="register-form__control-column--lastname">
-                <input class="register-form__field--lastname" id="register_field_lastname" type="text" name="lastName" placeholder="{{ registerPageText.lastName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" />
-            </div>
-        </div>
-
-        <div class="register-form__control--email">
-            <label class="register-form__label--email" for="register_field_email">{{ registerPageText.email }}</label>
-            <input class="register-form__field--email" id="register_field_email" type="email" name="email" placeholder="{{ registerPageText.emailHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" required />
-        </div>
-
-
-      {{#each errors.emailErrors }}
-          <p id="{{ id }}" class="register-form__error">{{ message }}</p>
-      {{/ each }}
-
-      {{# askForPhoneNumber }}
-
-          <div class="register-form__control--phone-number">
-              <div class="register-form__control-column--area-code">
-                  <label class="register-form__label--country-code" for="register_field_countryCode">
-                    {{ registerPageText.countryCode }}
-                  </label>
-                  <input type="hidden" id="register_field_countryIsoName" />
-                  <select class="register-form__select--country-code" id="register_field_countryCode" type="tel"
-                          name="countryCode" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false">
-                {{#each countryCodes.codes }}
-                    <option value="{{ code }}">+ {{ code }}</option>
-                {{/ each }}
-                  </select>
-              </div>
-              <div class="register-form__control-column--local-number">
-                  <label class="register-form__label--local-number" for="register_field_localNumber">
-                    {{ registerPageText.phone }}
-                      <a hidden class="register-form__link--why-phone-number">{{ registerPageText.whyPhone }}</a>
-                  </label>
-                  <input class="register-form__field--local-number" id="register_field_localNumber" type="tel"
-                         name="localNumber" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false"
-                         required minlength="3" maxlength="20"/>
-              </div>
-              <div class="register-form__tooltip--phone-number register-form__tooltip--phone-number--nojs">
-                  <button class="register-form__tooltip--phone-number__close" aria-label="Close tooltip"
-                          type="button">
-                      <i class="register-form__icon--close"></i>
-                  </button>
-                  <p>{{ registerPageText.becausePhone }}</p>
-              </div>
-          </div>
-
-      {{/ askForPhoneNumber }}
-
-    <div class="register-form__control--displayName {{#if hideDisplayName}}hidden{{/if}}">
-        <label class="register-form__label--displayName" for="register_field_displayName"><span>{{ registerPageText.displayName }}</span> <span class="register-form__label--displayName-note">{{ registerPageText.displayNameNote }}</span></label>
-        <input class="register-form__field--displayName" id="register_field_displayName" type="text" name="displayName" placeholder="{{ registerPageText.displayNameHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" title="{{ registerPageText.displayNameHelp }}" {{#unless hideDisplayName}} required minlength="2" maxlength="50" {{/unless}} />
-    </div>
-    {{# unless hideDisplayName}}
-        {{#each errors.displayNameErrors }}
-            <p id="{{ id }}" class="register-form__error">{{ message }}</p>
-        {{/ each }}
-    {{/unless}}
-
-
-        <div class="register-form__control--password">
-            <label class="register-form__label--password" for="register_field_password">{{ registerPageText.password }}</label>
-            <input class="register-form__field--password" id="register_field_password" type="password" name="password" placeholder="{{ registerPageText.passwordHelp }}" required minlength="6" />
-        </div>
-
-      {{#each errors.passwordErrors }}
-          <p id="{{ id }}" class="register-form__error">{{ message }}</p>
-      {{/ each }}
-
-        <div class="register-form__control--gnm-marketing">
-            <input class="register-form__checkbox--gnm-marketing" id="register_field_gnm_marketing" type="checkbox" name="receiveGnmMarketing" checked="checked" value="true"/>
-            <label class="register-form__label--gnm-marketing" for="register_field_gnm_marketing">{{ registerPageText.gnmMarketing }}</label>
-        </div>
-
-        <div class="register-form__control--3rd-party-marketing">
-            <input class="register-form__checkbox--3rd-party-marketing" id="register_field_3rd-party_marketing" type="checkbox" name="receive3rdPartyMarketing" value="true"/>
-            <label class="register-form__label--3rd-party-marketing" for="register_field_3rd-party_marketing">{{ registerPageText.3rdPartyMarketing }}</label>
-        </div>
-
-
-    </fieldset>
-    {{> components/terms/_terms }}
-
-    <div class="register-form__control--submit">
-        <button class="register-form__submit-button" id="register_submit" type="submit">{{ registerPageText.continue }}</button>
-    </div>
+  <div class="register-form__control--submit">
+    <button class="register-form__submit-button" id="register_submit" type="submit">{{ registerPageText.continue }}</button>
+  </div>
 </form>

--- a/public/components/register-form/_form-fields.hbs
+++ b/public/components/register-form/_form-fields.hbs
@@ -1,0 +1,86 @@
+<div class="register-form__control--name">
+  <label class="register-form__label--name" for="register_field_firstname">{{ registerPageText.name }}</label>
+
+  <div class="register-form__control-column--firstname">
+    <input class="register-form__field--firstname" id="register_field_firstname" type="text" name="firstName" placeholder="{{ registerPageText.firstName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" />
+  </div>
+  <div class="register-form__control-column--lastname">
+    <input class="register-form__field--lastname" id="register_field_lastname" type="text" name="lastName" placeholder="{{ registerPageText.lastName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" />
+  </div>
+</div>
+
+<div class="register-form__control--email">
+  <label class="register-form__label--email" for="register_field_email">{{ registerPageText.email }}</label>
+  <input class="register-form__field--email" id="register_field_email" type="email" name="email" placeholder="{{ registerPageText.emailHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" required />
+</div>
+
+
+{{#each errors.emailErrors }}
+  <p id="{{ id }}" class="register-form__error">{{ message }}</p>
+{{/ each }}
+
+
+
+{{# askForPhoneNumber }}
+  <div class="register-form__control--phone-number">
+    <div class="register-form__control-column--area-code">
+      <label class="register-form__label--country-code" for="register_field_countryCode">
+        {{ registerPageText.countryCode }}
+      </label>
+      <input type="hidden" id="register_field_countryIsoName" />
+      <select class="register-form__select--country-code" id="register_field_countryCode" type="tel"
+              name="countryCode" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false">
+        {{#each countryCodes.codes }}
+          <option value="{{ code }}">+ {{ code }}</option>
+        {{/ each }}
+      </select>
+    </div>
+    <div class="register-form__control-column--local-number">
+      <label class="register-form__label--local-number" for="register_field_localNumber">
+        {{ registerPageText.phone }}
+          <a hidden class="register-form__link--why-phone-number">{{ registerPageText.whyPhone }}</a>
+      </label>
+      <input class="register-form__field--local-number" id="register_field_localNumber" type="tel"
+             name="localNumber" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false"
+             required minlength="3" maxlength="20"/>
+        </div>
+        <div class="register-form__tooltip--phone-number register-form__tooltip--phone-number--nojs">
+            <button class="register-form__tooltip--phone-number__close" aria-label="Close tooltip"
+                    type="button">
+                <i class="register-form__icon--close"></i>
+            </button>
+            <p>{{ registerPageText.becausePhone }}</p>
+        </div>
+    </div>
+{{/ askForPhoneNumber }}
+
+<div class="register-form__control--displayName {{#if hideDisplayName}}hidden{{/if}}">
+  <label class="register-form__label--displayName" for="register_field_displayName"><span>{{ registerPageText.displayName }}</span> <span class="register-form__label--displayName-note">{{ registerPageText.displayNameNote }}</span></label>
+  <input class="register-form__field--displayName" id="register_field_displayName" type="text" name="displayName" placeholder="{{ registerPageText.displayNameHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" title="{{ registerPageText.displayNameHelp }}" {{#unless hideDisplayName}} required minlength="2" maxlength="50" {{/unless}} />
+</div>
+
+{{# unless hideDisplayName}}
+  {{#each errors.displayNameErrors }}
+      <p id="{{ id }}" class="register-form__error">{{ message }}</p>
+  {{/ each }}
+{{/unless}}
+
+<div class="register-form__control--password">
+    <label class="register-form__label--password" for="register_field_password">{{ registerPageText.password }}</label>
+    <input class="register-form__field--password" id="register_field_password" type="password" name="password" placeholder="{{ registerPageText.passwordHelp }}" required minlength="6" />
+</div>
+
+{{#each errors.passwordErrors }}
+  <p id="{{ id }}" class="register-form__error">{{ message }}</p>
+{{/ each }}
+
+<div class="register-form__control--gnm-marketing">
+    <input class="register-form__checkbox--gnm-marketing" id="register_field_gnm_marketing" type="checkbox" name="receiveGnmMarketing" checked="checked" value="true"/>
+    <label class="register-form__label--gnm-marketing" for="register_field_gnm_marketing">{{ registerPageText.gnmMarketing }}</label>
+</div>
+
+<div class="register-form__control--3rd-party-marketing">
+    <input class="register-form__checkbox--3rd-party-marketing" id="register_field_3rd-party_marketing" type="checkbox" name="receive3rdPartyMarketing" value="true"/>
+    <label class="register-form__label--3rd-party-marketing" for="register_field_3rd-party_marketing">{{ registerPageText.3rdPartyMarketing }}</label>
+</div>
+

--- a/public/components/register-form/_register-form.hbs
+++ b/public/components/register-form/_register-form.hbs
@@ -1,13 +1,15 @@
 <form id="register_form" class="register-form" action="{{ actions.register }}" method="POST">
+
   <input type="hidden" name="{{ csrfToken.fieldName }}" value="{{ csrfToken.value }}">
   <input type="hidden" name="returnUrl" value="{{ returnUrl }}"/>
   <input type="hidden" name="skipConfirmation" value="{{ skipConfirmation }}"/>
-    {{# hideDisplayName }}
-        <input type="hidden" id="register_field_hideDisplayName" name="hideDisplayName" value="{{ hideDisplayName }}" />
-    {{/hideDisplayName}}
+
+  {{# hideDisplayName }}
+    <input type="hidden" id="register_field_hideDisplayName" name="hideDisplayName" value="{{ hideDisplayName }}" />
+  {{/hideDisplayName}}
 
   {{# group }}
-      <input type="hidden" name="groupCode" value="{{ group.id }}">
+    <input type="hidden" name="groupCode" value="{{ group.id }}">
   {{/ group }}
 
   {{# clientId }}
@@ -21,96 +23,9 @@
   {{/ each }}
 
   <fieldset class="register-form__fieldset">
-
-    <div class="register-form__control--name">
-      <label class="register-form__label--name" for="register_field_firstname">{{ registerPageText.name }}</label>
-
-      <div class="register-form__control-column--firstname">
-        <input class="register-form__field--firstname" id="register_field_firstname" type="text" name="firstName" placeholder="{{ registerPageText.firstName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" />
-      </div>
-      <div class="register-form__control-column--lastname">
-        <input class="register-form__field--lastname" id="register_field_lastname" type="text" name="lastName" placeholder="{{ registerPageText.lastName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" />
-      </div>
-    </div>
-
-    <div class="register-form__control--email">
-      <label class="register-form__label--email" for="register_field_email">{{ registerPageText.email }}</label>
-      <input class="register-form__field--email" id="register_field_email" type="email" name="email" placeholder="{{ registerPageText.emailHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" required />
-    </div>
-
-
-    {{#each errors.emailErrors }}
-        <p id="{{ id }}" class="register-form__error">{{ message }}</p>
-    {{/ each }}
-
-    {{# askForPhoneNumber }}
-
-        <div class="register-form__control--phone-number">
-            <div class="register-form__control-column--area-code">
-                <label class="register-form__label--country-code" for="register_field_countryCode">
-                  {{ registerPageText.countryCode }}
-                </label>
-                <input type="hidden" id="register_field_countryIsoName" />
-                <select class="register-form__select--country-code" id="register_field_countryCode" type="tel"
-                        name="countryCode" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false"/>
-                  {{#each countryCodes.codes }}
-                  <option value="{{ code }}">+ {{ code }}</option>
-                  {{/ each }}
-                </select>
-            </div>
-            <div class="register-form__control-column--local-number">
-                <label class="register-form__label--local-number" for="register_field_localNumber">
-                  {{ registerPageText.phone }}
-                  <a hidden class="register-form__link--why-phone-number">{{ registerPageText.whyPhone }}</a>
-                </label>
-                <input class="register-form__field--local-number" id="register_field_localNumber" type="tel"
-                       name="localNumber" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false"
-                       required minlength="3" maxlength="20"/>
-            </div>
-            <div class="register-form__tooltip--phone-number register-form__tooltip--phone-number--nojs">
-              <button class="register-form__tooltip--phone-number__close" aria-label="Close tooltip"
-              type="button">
-              <i class="register-form__icon--close"></i>
-            </button>
-            <p>{{ registerPageText.becausePhone }}</p>
-          </div>
-        </div>
-
-    {{/ askForPhoneNumber }}
-
-    <div class="register-form__control--displayName {{# hideDisplayName}}hidden{{/hideDisplayName}}">
-        <label class="register-form__label--displayName" for="register_field_displayName"><span>{{ registerPageText.displayName }}</span> <span class="register-form__label--displayName-note">{{ registerPageText.displayNameNote }}</span></label>
-        <input class="register-form__field--displayName" id="register_field_displayName" type="text" name="displayName" placeholder="{{ registerPageText.displayNameHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" title="{{ registerPageText.displayNameHelp }}" {{#unless hideDisplayName}} required minlength="2" maxlength="50" {{/unless}} />
-    </div>
-    {{# unless hideDisplayName}}
-      {{#each errors.displayNameErrors }}
-          <p id="{{ id }}" class="register-form__error">{{ message }}</p>
-      {{/ each }}
-    {{/unless}}
-
-
-      <div class="register-form__control--password">
-      <label class="register-form__label--password" for="register_field_password">{{ registerPageText.password }}</label>
-      <input class="register-form__field--password" id="register_field_password" type="password" name="password" placeholder="{{ registerPageText.passwordHelp }}" required minlength="6" />
-    </div>
-
-      {{#each errors.passwordErrors }}
-          <p id="{{ id }}" class="register-form__error">{{ message }}</p>
-      {{/ each }}
-
-    <div class="register-form__control--gnm-marketing">
-      <input class="register-form__checkbox--gnm-marketing" id="register_field_gnm_marketing" type="checkbox" name="receiveGnmMarketing" checked="checked" value="true"/>
-      <label class="register-form__label--gnm-marketing" for="register_field_gnm_marketing">{{ registerPageText.gnmMarketing }}</label>
-    </div>
-
-    <div class="register-form__control--3rd-party-marketing">
-        <input class="register-form__checkbox--3rd-party-marketing" id="register_field_3rd-party_marketing" type="checkbox" name="receive3rdPartyMarketing" value="true"/>
-        <label class="register-form__label--3rd-party-marketing" for="register_field_3rd-party_marketing">{{ registerPageText.3rdPartyMarketing }}</label>
-    </div>
-
+    {{> components/register-form/_form-fields}}
     <div class="register-form__control--submit">
       <button class="register-form__submit-button" id="register_submit" type="submit">{{ registerPageText.createAccount }}</button>
     </div>
-
   </fieldset>
 </form>

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -73,7 +73,7 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
   }
 
   it should "Use the membership return url for clientId=members as the default fallback" in {
-    val result = ReturnUrl(None, None, config, Some(GuardianMembersAClientID))
+    val result = ReturnUrl(None, None, config, Some(GuardianMembersClientID))
 
     result.url shouldEqual config.preferredMembershipUrl
     result shouldBe 'default


### PR DESCRIPTION
## Why?

The checkout A/B test has finished. Flow B won the test. Therefore, we need to remove **membersB** from identity and the changes that were under membersB identifier, now will be under members.

## Screenshots
### Before

**Old identity flow for Membership**
![identitya](https://cloud.githubusercontent.com/assets/825398/21348594/bfa97752-c6a5-11e6-9cab-dda2ddc1ed10.png)

**New identity flow for Membership**
![identityb](https://cloud.githubusercontent.com/assets/825398/21348604/cb2fe0fc-c6a5-11e6-9a4f-7636e2ef2ffd.png)

## Related PRs

https://github.com/guardian/membership-frontend/pull/1416