### PR TITLE
Add . to cookie domain to meet rfc2109

### DIFF
--- a/conf/CODE.conf
+++ b/conf/CODE.conf
@@ -2,7 +2,7 @@ include "application"
 
 identity.api.host=idapi.code.dev-theguardian.com
 
-identity.frontend.cookieDomain=code.dev-theguardian.com
+identity.frontend.cookieDomain=.code.dev-theguardian.com
 
 identity.frontend.baseUrl="https://profile.code.dev-theguardian.com"
 

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -2,7 +2,7 @@ include "application"
 
 identity.api.host=idapi.code.dev-theguardian.com
 
-identity.frontend.cookieDomain=thegulocal.com
+identity.frontend.cookieDomain=.thegulocal.com
 
 identity.frontend.baseUrl="https://profile-origin.thegulocal.com"
 

--- a/conf/PROD.conf
+++ b/conf/PROD.conf
@@ -2,7 +2,7 @@ include "application"
 
 identity.api.host=idapi.theguardian.com
 
-identity.frontend.cookieDomain=theguardian.com
+identity.frontend.cookieDomain=.theguardian.com
 
 identity.frontend.baseUrl="https://profile.theguardian.com"
 


### PR DESCRIPTION
Updated the domain to meet [rfc2109](https://www.ietf.org/rfc/rfc2109.txt):

This is to prevent inconsistent behaviour across different browsers.

`Domain=domain
      Optional.  The Domain attribute specifies the domain for which the
      cookie is valid.  An explicitly specified domain must always start
      with a dot.`

After:

![screen shot 2016-12-22 at 13 15 17](https://cloud.githubusercontent.com/assets/406099/21426874/44df51ea-c849-11e6-82ae-314deebe4b41.png)



