### PR TITLE
Updated base url to https version to prevent (internal) redirect

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -32,7 +32,7 @@ identity {
   frontend {
     cookieDomain = "theguardian.com"
 
-    dotcomBaseUrl = "http://www.theguardian.com"
+    dotcomBaseUrl = "https://www.theguardian.com"
 
     preferredMembershipUrl = "https://membership.theguardian.com/supporter"
 


### PR DESCRIPTION
In Chrome:

![screen shot 2016-12-22 at 18 03 51](https://cloud.githubusercontent.com/assets/406099/21435308/0dafd3c0-c871-11e6-9a4a-9f551c30805b.png)

