### PR TITLE
Better copy for already registered email error.

### DIFF
--- a/app/com/gu/identity/frontend/views/models/ErrorViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/ErrorViewModel.scala
@@ -1,6 +1,5 @@
 package com.gu.identity.frontend.views.models
 
-import com.gu.identity.frontend.errors.ErrorIDs._
 import com.gu.identity.frontend.errors.{ErrorID, ErrorIDs}
 
 case class ErrorViewModel(id: String, message: String) extends ViewModel
@@ -23,7 +22,7 @@ object ErrorViewModel {
     RegisterGatewayErrorID -> "There was a problem creating your account; please try again.",
     RegisterBadRequestErrorID -> "One or more inputs was not valid; please try again.",
     RegisterActionBadRequestErrorID -> "One or more inputs was not valid; please try again.",
-    RegisterEmailConflictErrorID -> "This email is already in use; please check you do not already have an account.",
+    RegisterEmailConflictErrorID -> "You already have a Guardian account. Please sign in or use another email address.",
     RegisterActionInvalidFirstNameErrorID -> minMaxLength("First name", 1, 25),
     RegisterActionInvalidLastNameErrorID -> minMaxLength("Last name", 1, 25),
     RegisterActionInvalidEmailErrorID -> "Invalid email address; please try again.",


### PR DESCRIPTION
## Why are you doing this?

We want to communicate the "already registered email" error better to users. 

## Changes
* Change copy in Error messages.

## Screenshots 

# Current error message
![picture 147](https://cloud.githubusercontent.com/assets/825398/22794682/edae18f6-eeeb-11e6-97a5-b48a1d61d497.png)

# New error message

<img width="528" alt="picture 148" src="https://cloud.githubusercontent.com/assets/825398/22794717/169b874e-eeec-11e6-96b6-fcc1eed6fdb0.png">


