### PR TITLE
Add TiP

### DIFF
--- a/app/com/gu/identity/frontend/controllers/RegisterAction.scala
+++ b/app/com/gu/identity/frontend/controllers/RegisterAction.scala
@@ -13,6 +13,8 @@ import com.gu.identity.frontend.services.{IdentityService, ServiceAction, Servic
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc.{BodyParser, Controller, Request, Cookie => PlayCookie}
+import Configuration.Environment._
+import com.gu.tip.Tip
 
 
 class RegisterAction(
@@ -82,6 +84,7 @@ class RegisterAction(
   }
 
   private def registerSuccessResult(returnUrl: ReturnUrl, cookies: Seq[PlayCookie])(implicit request: Request[RegisterActionRequestBody]) = {
+    if (stage == "PROD") Tip.verify("Account Registration")
     metricsLoggingActor.logSuccessfulRegister()
 
     if(request.body.gaClientId.isDefined) {

--- a/app/com/gu/identity/frontend/controllers/SigninAction.scala
+++ b/app/com/gu/identity/frontend/controllers/SigninAction.scala
@@ -12,7 +12,8 @@ import com.gu.identity.frontend.services._
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc._
-
+import Configuration.Environment._
+import com.gu.tip.Tip
 
 /**
  * Form actions controller
@@ -77,6 +78,7 @@ class SigninAction(
     identityService.authenticate(body, trackingData).map {
       case Left(errors) => Left(errors)
       case Right(cookies) => Right {
+        if (stage == "PROD") Tip.verify("Account Signin")
         metricsLogger(request)
         successResponse(successfulReturnUrl, cookies)
       }

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,8 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-slf4j" % "2.4.0",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.10.54",
   "com.getsentry.raven" % "raven-logback" % "7.2.1",
-  "com.googlecode.libphonenumber" % "libphonenumber" % "7.2.4"
+  "com.googlecode.libphonenumber" % "libphonenumber" % "7.2.4",
+  "com.gu" %% "tip" % "0.3.2"
 )
 
 // Set logs options and default local resource for running locally (run and test)

--- a/conf/tip.yaml
+++ b/conf/tip.yaml
@@ -1,0 +1,5 @@
+- name: Account Registration
+  description: User registered an account
+
+- name: Account Signin
+  description: User signed into the account


### PR DESCRIPTION
Verifies account registration and signin using [TiP](https://github.com/guardian/tip) library.

It will set the the following label on the PR, the first time users in production complete the above two critical journeys:

![image](https://cloud.githubusercontent.com/assets/13835317/25528231/a3fe3ca2-2c14-11e7-803b-4bf21b735174.png)

I've added the corresponding private config to the secrets file:

```
tip { 
  owner = "guardian"
  repo = "identity-frontend"
  personalAccessToken = "***********"
  label = "Verified in PROD"
}
```
