### PR TITLE
Send GA client ID to federation API

### DIFF
--- a/public/components/analytics/ga.js
+++ b/public/components/analytics/ga.js
@@ -21,7 +21,6 @@ export function customMetric(event) {
 
 export function fetchTracker(callback) {
   ga(function() {
-    // Save the GA client id to be passed with the form submission
     const tracker = ga.getByName(gaTracker);
     return callback(tracker);
   });

--- a/public/components/analytics/ga.js
+++ b/public/components/analytics/ga.js
@@ -19,10 +19,17 @@ export function customMetric(event) {
   ga(gaTracker + '.send', 'event', buildGoogleAnalyticsEvent(event));
 }
 
+export function fetchTracker(callback) {
+  ga(function() {
+    // Save the GA client id to be passed with the form submission
+    const tracker = ga.getByName(gaTracker);
+    return callback(tracker);
+  });
+}
+
 function record(gaUID) {
   loadGA();
   ga('create', gaUID, 'auto', gaTracker);
-  saveClientId();
   ga(gaTracker + '.send', 'pageview');
 }
 
@@ -44,15 +51,6 @@ function buildGoogleAnalyticsEvent(event) {
   }
 
   return fieldsObject;
-}
-
-function saveClientId() {
-  ga(function() {
-    // Save the GA client id to be passed with the form submission
-    const tracker = ga.getByName(gaTracker);
-    const clientIdElem = document.getElementsByClassName('js-ga-client-id')[0];
-    if(clientIdElem) clientIdElem.value = tracker.get('clientId');
-  });
 }
 
 function loadGA() {

--- a/public/components/oauth-cta/_oauth-cta.hbs
+++ b/public/components/oauth-cta/_oauth-cta.hbs
@@ -1,7 +1,7 @@
 <div class="oauth">
   {{#each oauth.all }}
     <div class="oauth__cta-wrapper">
-      <a class="oauth__cta--{{ id }}" id="oauth_cta_{{ id }}" href="{{ url }}">{{ text }}</a>
+      <a class="oauth__cta--{{ id }} oauth__cta--anchor" id="oauth_cta_{{ id }}" href="{{ url }}">{{ text }}</a>
     </div>
   {{/each }}
 </div>

--- a/public/components/oauth-cta/_oauth-cta.js
+++ b/public/components/oauth-cta/_oauth-cta.js
@@ -1,0 +1,31 @@
+import { fetchTracker } from '../analytics/ga'
+
+export default class OAuthCtaModel {
+  constructor( oAuthCtaAnchors ) {
+    this.oAuthCtaAnchors = oAuthCtaAnchors;
+    this.saveClientId();
+  }
+
+  saveClientId() {
+    fetchTracker((tracker) => {
+      // Save the GA client id to be passed with the form submission
+      const clientId = encodeURI(tracker.get( 'clientId' ));
+
+      for ( var elem of this.oAuthCtaAnchors ) {
+        const connector = window.location.search.length ? '&' : '?';
+        elem.setAttribute( 'href', `${elem.getAttribute( 'href' )}${connector}gaClientId=${clientId}` );
+      }
+    });
+  }
+
+  static fromDocument() {
+    const oAuthCtaAnchors = document.getElementsByClassName( 'oauth__cta--anchor' );
+
+    if ( oAuthCtaAnchors ) {
+      return new OAuthCtaModel( oAuthCtaAnchors );
+    }
+  }
+}
+
+
+export const init = OAuthCtaModel.fromDocument;

--- a/public/components/oauth-cta/_oauth-cta.js
+++ b/public/components/oauth-cta/_oauth-cta.js
@@ -11,7 +11,7 @@ export default class OAuthCtaModel {
       // Save the GA client id to be passed with the form submission
       const clientId = encodeURI(tracker.get( 'clientId' ));
 
-      for ( var elem of this.oAuthCtaAnchors ) {
+      for ( let elem of this.oAuthCtaAnchors ) {
         const connector = window.location.search.length ? '&' : '?';
         elem.setAttribute( 'href', `${elem.getAttribute( 'href' )}${connector}gaClientId=${clientId}` );
       }

--- a/public/components/register-form-mem/_register-form-mem.hbs
+++ b/public/components/register-form-mem/_register-form-mem.hbs
@@ -16,9 +16,9 @@
     <input type="hidden" name="clientId" value="{{ clientId.id }}">
   {{/ clientId }}
 
-    <input type="hidden" class="js-ga-client-id" name="gaClientId" value="">
+  <input id="js-ga-client-id" type="hidden" name="gaClientId" value="">
 
-    <p class="register-form__prelude">{{ registerPageText.divideText }}</p>
+  <p class="register-form__prelude">{{ registerPageText.divideText }}</p>
 
   {{#each errors.otherErrors }}
     <p id="{{ id }}" class="register-form__error">{{ message }}</p>

--- a/public/components/register-form-mem/_register-form-mem.hbs
+++ b/public/components/register-form-mem/_register-form-mem.hbs
@@ -16,7 +16,7 @@
     <input type="hidden" name="clientId" value="{{ clientId.id }}">
   {{/ clientId }}
 
-  <input id="js-ga-client-id" type="hidden" name="gaClientId" value="">
+  <input id="register_ga_client_id" type="hidden" name="gaClientId" value="">
 
   <p class="register-form__prelude">{{ registerPageText.divideText }}</p>
 

--- a/public/components/register-form/_register-form.hbs
+++ b/public/components/register-form/_register-form.hbs
@@ -16,7 +16,7 @@
     <input type="hidden" name="clientId" value="{{ clientId.id }}">
   {{/ clientId }}
 
-  <input type="hidden" class="js-ga-client-id" name="gaClientId" value="">
+  <input id="js-ga-client-id" type="hidden" name="gaClientId" value="">
 
   <p class="register-form__prelude">{{ registerPageText.divideText }}</p>
 

--- a/public/components/register-form/_register-form.hbs
+++ b/public/components/register-form/_register-form.hbs
@@ -16,7 +16,7 @@
     <input type="hidden" name="clientId" value="{{ clientId.id }}">
   {{/ clientId }}
 
-  <input id="js-ga-client-id" type="hidden" name="gaClientId" value="">
+  <input id="register_ga_client_id" type="hidden" name="gaClientId" value="">
 
   <p class="register-form__prelude">{{ registerPageText.divideText }}</p>
 

--- a/public/components/register-form/register-form.js
+++ b/public/components/register-form/register-form.js
@@ -4,6 +4,8 @@ import { mapValues as _mapValues } from '../lib/lodash';
 
 import { initPhoneField } from '../lib/phone-field';
 
+import { fetchTracker } from '../analytics/ga';
+
 const STORAGE_KEY = 'gu_id_register_state';
 
 
@@ -82,7 +84,7 @@ class RegisterFormModel {
   saveClientId() {
     fetchTracker((tracker) => {
       // Save the GA client id to be passed with the form submission
-      this.gaClientIdElement.value = tracker.get( 'clientId' );
+      this.gaClientIdElement.setValue(tracker.get( 'clientId' ));
     });
   }
 

--- a/public/components/register-form/register-form.js
+++ b/public/components/register-form/register-form.js
@@ -56,7 +56,7 @@ class RegisterFormModel {
     this.gaClientIdElement = gaClientIdElement;
 
     this.fields = new RegisterFormFields( firstNameField, lastNameField, emailField, displayNameField, optionalCountryCode, optionalCountryIsoName, optionalPhoneNumber, optionalHideUsername );
-    
+
     this.addBindings();
     this.saveClientId();
     initOAuthBindings();
@@ -88,7 +88,9 @@ class RegisterFormModel {
   saveClientId() {
     fetchTracker((tracker) => {
       // Save the GA client id to be passed with the form submission
-      this.gaClientIdElement.setValue(tracker.get( 'clientId' ));
+      if(this.gaClientIdElement) {
+        this.gaClientIdElement.setValue(tracker.get('clientId'));
+      }
     });
   }
 

--- a/public/components/register-form/register-form.js
+++ b/public/components/register-form/register-form.js
@@ -6,6 +6,9 @@ import { initPhoneField } from '../lib/phone-field';
 
 import { fetchTracker } from '../analytics/ga';
 
+import { init as initOAuthBindings } from '../oauth-cta/_oauth-cta.js';
+
+
 const STORAGE_KEY = 'gu_id_register_state';
 
 
@@ -56,6 +59,7 @@ class RegisterFormModel {
     
     this.addBindings();
     this.saveClientId();
+    initOAuthBindings();
   }
 
   addBindings() {

--- a/public/components/register-form/register-form.js
+++ b/public/components/register-form/register-form.js
@@ -1,4 +1,3 @@
-
 import { getElementById, sessionStorage } from '../browser/browser';
 
 import { mapValues as _mapValues } from '../lib/lodash';
@@ -53,6 +52,7 @@ class RegisterFormModel {
     this.fields = new RegisterFormFields( firstNameField, lastNameField, emailField, displayNameField, optionalCountryCode, optionalCountryIsoName, optionalPhoneNumber, optionalHideUsername );
 
     this.addBindings();
+    this.saveClientId();
   }
 
   addBindings() {
@@ -76,6 +76,14 @@ class RegisterFormModel {
   saveState() {
     this.state = RegisterFormState.fromForm( this );
     this.state.save();
+  }
+
+  saveClientId() {
+    fetchTracker(function(tracker) {
+      // Save the GA client id to be passed with the form submission
+      const clientIdElem = document.getElementsByClassName('js-ga-client-id')[0];
+      if(clientIdElem) clientIdElem.value = tracker.get('clientId');
+    });
   }
 
   formSubmitted() {

--- a/public/components/register-form/register-form.js
+++ b/public/components/register-form/register-form.js
@@ -46,11 +46,12 @@ class RegisterFormFields {
 
 
 class RegisterFormModel {
-  constructor( formElement, firstNameField, lastNameField, emailField, displayNameField, optionalCountryCode, optionalCountryIsoName, optionalPhoneNumber, optionalHideUsername ) {
+  constructor( formElement, firstNameField, lastNameField, emailField, displayNameField, optionalCountryCode, optionalCountryIsoName, optionalPhoneNumber, optionalHideUsername, gaClientIdElement ) {
     this.formElement = formElement;
+    this.gaClientIdElement = gaClientIdElement;
 
     this.fields = new RegisterFormFields( firstNameField, lastNameField, emailField, displayNameField, optionalCountryCode, optionalCountryIsoName, optionalPhoneNumber, optionalHideUsername );
-
+    
     this.addBindings();
     this.saveClientId();
   }
@@ -79,10 +80,9 @@ class RegisterFormModel {
   }
 
   saveClientId() {
-    fetchTracker(function(tracker) {
+    fetchTracker((tracker) => {
       // Save the GA client id to be passed with the form submission
-      const clientIdElem = document.getElementsByClassName('js-ga-client-id')[0];
-      if(clientIdElem) clientIdElem.value = tracker.get('clientId');
+      this.gaClientIdElement.value = tracker.get( 'clientId' );
     });
   }
 
@@ -100,9 +100,10 @@ class RegisterFormModel {
     const optionalCountryCode = getElementById('register_field_countryCode');
     const optionalCountryIsoName = getElementById('register_field_countryIsoName');
     const optionalHideUsername = getElementById('register_field_hideDisplayName');
+    const gaClientIdElement = getElementById('register_ga_client_id');
 
-    if ( form && firstNameField && lastNameField && emailField && displayNameField ) {
-      return new RegisterFormModel( form, firstNameField, lastNameField, emailField, displayNameField, optionalCountryCode, optionalCountryIsoName, optionalPhoneNumber, optionalHideUsername);
+    if ( form && firstNameField && lastNameField && emailField && displayNameField && gaClientIdElement ) {
+      return new RegisterFormModel( form, firstNameField, lastNameField, emailField, displayNameField, optionalCountryCode, optionalCountryIsoName, optionalPhoneNumber, optionalHideUsername, gaClientIdElement );
     }
   }
 }

--- a/public/components/signin-form-mem/_signin-form-mem.hbs
+++ b/public/components/signin-form-mem/_signin-form-mem.hbs
@@ -11,7 +11,7 @@
       <input type="hidden" name="clientId" value="{{ clientId.id }}">
   {{/ clientId }}
 
-  <input id="js-ga-client-id" type="hidden" name="gaClientId" value="">
+  <input id="signin_ga_client_id" type="hidden" name="gaClientId" value="">
 
   <p class="signin-form__prelude">{{signInPageText.divideText}}</p>
 

--- a/public/components/signin-form-mem/_signin-form-mem.hbs
+++ b/public/components/signin-form-mem/_signin-form-mem.hbs
@@ -11,9 +11,9 @@
       <input type="hidden" name="clientId" value="{{ clientId.id }}">
   {{/ clientId }}
 
-    <input type="hidden" class="js-ga-client-id" name="gaClientId" value="">
+  <input id="js-ga-client-id" type="hidden" name="gaClientId" value="">
 
-    <p class="signin-form__prelude">{{signInPageText.divideText}}</p>
+  <p class="signin-form__prelude">{{signInPageText.divideText}}</p>
 
   {{#each errors }}
       <p id="{{ id }}" class="signin-form__error">{{ message }}</p>

--- a/public/components/signin-form/_signin-form.hbs
+++ b/public/components/signin-form/_signin-form.hbs
@@ -11,7 +11,7 @@
     <input type="hidden" name="clientId" value="{{ clientId.id }}">
   {{/ clientId }}
 
-  <input id="js-ga-client-id" type="hidden" name="gaClientId" value="">
+  <input id="signin_ga_client_id" type="hidden" name="gaClientId" value="">
 
   <p class="signin-form__prelude">{{signInPageText.divideText}}</p>
 

--- a/public/components/signin-form/_signin-form.hbs
+++ b/public/components/signin-form/_signin-form.hbs
@@ -11,7 +11,7 @@
     <input type="hidden" name="clientId" value="{{ clientId.id }}">
   {{/ clientId }}
 
-  <input type="hidden" class="js-ga-client-id" name="gaClientId" value="">
+  <input id="js-ga-client-id" type="hidden" name="gaClientId" value="">
 
   <p class="signin-form__prelude">{{signInPageText.divideText}}</p>
 

--- a/public/components/signin-form/signin-form.js
+++ b/public/components/signin-form/signin-form.js
@@ -96,7 +96,9 @@ class SignInFormModel {
   saveClientId() {
     fetchTracker((tracker) => {
       // Save the GA client id to be passed with the form submission
-      this.gaClientIdElement.setValue(tracker.get('clientId'));
+      if(this.gaClientIdElement) {
+        this.gaClientIdElement.setValue(tracker.get('clientId'));
+      }
     });
   }
 

--- a/public/components/signin-form/signin-form.js
+++ b/public/components/signin-form/signin-form.js
@@ -1,7 +1,7 @@
 /*global window, document*/
 
 import { getElementById, sessionStorage } from '../browser/browser';
-import { customMetric } from '../analytics/ga';
+import { customMetric, fetchTracker } from '../analytics/ga';
 
 const STORAGE_KEY = 'gu_id_signIn_state';
 const SMART_LOCK_STORAGE_KEY = 'gu_id_smartLock_state';
@@ -12,6 +12,7 @@ class SignInFormModel {
     this.emailFieldElement = emailField;
     this.addBindings();
     this.smartLock();
+    this.saveClientId();
   }
 
   addBindings() {
@@ -87,6 +88,14 @@ class SignInFormModel {
   updateSmartLockStatus(status) {
     this.smartLockStatus = new SmartLockState( status );
     this.smartLockStatus.save();
+  }
+
+  saveClientId() {
+    fetchTracker(function(tracker) {
+      // Save the GA client id to be passed with the form submission
+      const clientIdElem = document.getElementsByClassName('js-ga-client-id')[0];
+      if(clientIdElem) clientIdElem.value = tracker.get('clientId');
+    });
   }
 
   formSubmitted() {

--- a/public/components/signin-form/signin-form.js
+++ b/public/components/signin-form/signin-form.js
@@ -2,6 +2,7 @@
 
 import { getElementById, sessionStorage } from '../browser/browser';
 import { customMetric, fetchTracker } from '../analytics/ga';
+import { init as initOAuthBindings } from '../oauth-cta/_oauth-cta.js';
 
 const STORAGE_KEY = 'gu_id_signIn_state';
 const SMART_LOCK_STORAGE_KEY = 'gu_id_smartLock_state';
@@ -14,6 +15,7 @@ class SignInFormModel {
     this.addBindings();
     this.smartLock();
     this.saveClientId();
+    initOAuthBindings();
   }
 
   addBindings() {

--- a/public/components/signin-form/signin-form.js
+++ b/public/components/signin-form/signin-form.js
@@ -94,7 +94,7 @@ class SignInFormModel {
   saveClientId() {
     fetchTracker((tracker) => {
       // Save the GA client id to be passed with the form submission
-      this.gaClientIdElement.value = tracker.get('clientId');
+      this.gaClientIdElement.setValue(tracker.get('clientId'));
     });
   }
 

--- a/public/components/signin-form/signin-form.js
+++ b/public/components/signin-form/signin-form.js
@@ -7,9 +7,10 @@ const STORAGE_KEY = 'gu_id_signIn_state';
 const SMART_LOCK_STORAGE_KEY = 'gu_id_smartLock_state';
 
 class SignInFormModel {
-  constructor( formElement, emailField ) {
+  constructor( formElement, emailField, gaClientIdElement ) {
     this.formElement = formElement;
     this.emailFieldElement = emailField;
+    this.gaClientIdElement = gaClientIdElement;
     this.addBindings();
     this.smartLock();
     this.saveClientId();
@@ -91,10 +92,9 @@ class SignInFormModel {
   }
 
   saveClientId() {
-    fetchTracker(function(tracker) {
+    fetchTracker((tracker) => {
       // Save the GA client id to be passed with the form submission
-      const clientIdElem = document.getElementsByClassName('js-ga-client-id')[0];
-      if(clientIdElem) clientIdElem.value = tracker.get('clientId');
+      this.gaClientIdElement.value = tracker.get('clientId');
     });
   }
 
@@ -106,9 +106,10 @@ class SignInFormModel {
   static fromDocument() {
     const form = getElementById( 'signin_form' );
     const emailField = getElementById( 'signin_field_email' );
+    const gaClientIdField = getElementById( 'signin_ga_client_id' );
 
     if ( form && emailField ) {
-      return new SignInFormModel( form, emailField );
+      return new SignInFormModel( form, emailField, gaClientIdField );
     }
   }
 }


### PR DESCRIPTION
This PR adds a `gaClientId` querystring parameter to the oauth links for signin and registration.  This client ID will be added to the state parameter sent to social providers in the federation API so that it can be used after successful sign in to send an event to GA.

I've also refactored how the client ID is added to the hidden field that is submitted with regular sign in.  This never belonged in the generic `ga.js` and now resides in `signin-form.js` and `register-form.js`.  It's not as DRY, but then neither are the components.  Wherever possible I have stayed consistent with the existing patterns (unlike before).