### PR TITLE
Check the correct URI for adding GA client ID

### DIFF
--- a/public/components/oauth-cta/_oauth-cta.js
+++ b/public/components/oauth-cta/_oauth-cta.js
@@ -12,7 +12,7 @@ export default class OAuthCtaModel {
       const clientId = encodeURI(tracker.get( 'clientId' ));
 
       for ( let elem of this.oAuthCtaAnchors ) {
-        const connector = window.location.search.length ? '&' : '?';
+        const connector = elem.search.length ? '&' : '?';
         elem.setAttribute( 'href', `${elem.getAttribute( 'href' )}${connector}gaClientId=${clientId}` );
       }
     });


### PR DESCRIPTION
Was checking the wrong URI for a the query string length.  This works most of the time because the oauth and profile URIs happen to share similar query strings - but there are edge cases where this breaks e.g. signing in with a deleted account.