### PR TITLE
Re-add cache control parameter

### DIFF
--- a/provisioning/riff-raff.yaml
+++ b/provisioning/riff-raff.yaml
@@ -8,3 +8,4 @@ deployments:
     parameters:
       bucket: gu-identity-frontend-dist
       prefixPackage: false
+      cacheControl: max-age=600


### PR DESCRIPTION
Turns out is is a required parameter and we may as well use the previous 10 minute value.