### PR TITLE
Use HTTPS links to theguardian.com

### DIFF
--- a/app/com/gu/identity/frontend/configuration/Configuration.scala
+++ b/app/com/gu/identity/frontend/configuration/Configuration.scala
@@ -93,7 +93,7 @@ object Configuration {
 
     identityProfileBaseUrl = "https://profile.code.dev-theguardian.com",
 
-    dotcomBaseUrl = "http://www.theguardian.com",
+    dotcomBaseUrl = "https://www.theguardian.com",
     preferredMembershipUrl = "https://membership.theguardian.com/supporter",
     jobsBaseUrl = "https://jobs.theguardian.com",
 

--- a/app/com/gu/identity/frontend/views/models/RegisterConfirmationViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterConfirmationViewModel.scala
@@ -9,7 +9,7 @@ case class RegisterConfirmationViewModel private(
     layout: LayoutViewModel,
     returnUrl: String,
     registerConfirmationPageText: RegisterConfirmationText,
-    faqUrl: String = "http://www.theguardian.com/help/identity-faq",
+    faqUrl: String = "https://www.theguardian.com/help/identity-faq",
     emailUserHelpUrl: String = "mailto:userhelp@theguardian.com?subject=Account help",
     resetPasswordUrl: String,
     signOutUrl: String,

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -50,9 +50,9 @@ register.countryCode=Country code
 # com.gu.identity.frontend.models.text.TermsText
 terms.conditions=By proceeding, you agree to the Guardian''s
 terms.termsOfService=Terms of Service
-terms.termsOfServiceUrl=http://www.theguardian.com/help/terms-of-service
+terms.termsOfServiceUrl=https://www.theguardian.com/help/terms-of-service
 terms.privacyPolicy=Privacy Policy
-terms.privacyPolicyUrl=http://www.theguardian.com/help/privacy-policy
+terms.privacyPolicyUrl=https://www.theguardian.com/help/privacy-policy
 terms.teachersConditions=and Guardian Teacher Network''s
 terms.jobsConditions=and Guardian Jobs''
 

--- a/public/signin-page-membership.hbs
+++ b/public/signin-page-membership.hbs
@@ -5,7 +5,7 @@
   {{#showPrelude}}
       <div class="signin__prelude">
           <p>{{signInPageText.prelude}}</p>
-          <p> {{signInPageText.preludeMoreInfo}} <a href="http://www.theguardian.com/help/identity-faq"> {{signInPageText.preludeFaq}} </a>.</p>
+          <p> {{signInPageText.preludeMoreInfo}} <a href="https://www.theguardian.com/help/identity-faq"> {{signInPageText.preludeFaq}} </a>.</p>
       </div>
   {{/showPrelude}}
 

--- a/public/signin-page.hbs
+++ b/public/signin-page.hbs
@@ -5,7 +5,7 @@
   {{#showPrelude}}
     <div class="signin__prelude">
       <p>{{signInPageText.prelude}}</p>
-      <p> {{signInPageText.preludeMoreInfo}} <a href="http://www.theguardian.com/help/identity-faq"> {{signInPageText.preludeFaq}} </a>.</p>
+      <p> {{signInPageText.preludeMoreInfo}} <a href="https://www.theguardian.com/help/identity-faq"> {{signInPageText.preludeFaq}} </a>.</p>
     </div>
   {{/showPrelude}}
 

--- a/test/com/gu/identity/frontend/controllers/RegisterActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/RegisterActionSpec.scala
@@ -42,7 +42,7 @@ class RegisterActionSpec extends PlaySpec with MockitoSugar {
      password: String = "password",
      receiveGnmMarketing: Boolean = true,
      receive3rdPartyMarketing: Boolean = true,
-     returnUrl: Option[String] = Some("http://www.theguardian.com"),
+     returnUrl: Option[String] = Some("https://www.theguardian.com"),
      skipConfirmation: Option[Boolean] = None,
      groupCode: Option[String] = None) = {
     val bodyParams = Seq(
@@ -77,7 +77,7 @@ class RegisterActionSpec extends PlaySpec with MockitoSugar {
   //Registration Success Skip Confirmation is true, no group code
 
     "redirect to theguardian.com and sign user in when registration is successful skipConfirmation is true and no group code" in new WithControllerMockedDependencies {
-      val returnUrl = Some("http://www.theguardian.com/test")
+      val returnUrl = Some("https://www.theguardian.com/test")
       val testCookie = Cookie("SC_GU_U", "##hash##")
       val skipConfirmation = Some(true)
 
@@ -150,7 +150,7 @@ class RegisterActionSpec extends PlaySpec with MockitoSugar {
     }
 
     "include a return url when registration is successful skipConfirmation is false and no group code" in new WithControllerMockedDependencies {
-      val returnUrl = "http://www.theguardian.com/test?returnUrl=www.theguardian.com"
+      val returnUrl = "https://www.theguardian.com/test?returnUrl=www.theguardian.com"
       val testCookie = Cookie("SC_GU_U", "##hash##")
       val skipConfirmation = Some(false)
 
@@ -207,7 +207,7 @@ class RegisterActionSpec extends PlaySpec with MockitoSugar {
     }
 
     "include a return url when registration is successful skipConfirmation is true and group code is valid" in new WithControllerMockedDependencies {
-      val returnUrl = "http://www.theguardian.com/test?returnUrl=www.theguardian.com"
+      val returnUrl = "https://www.theguardian.com/test?returnUrl=www.theguardian.com"
       val skipConfirmation = Some(true)
       val group = Some("GRS")
       val testCookie = Cookie("SC_GU_U", "##hash##")
@@ -226,7 +226,7 @@ class RegisterActionSpec extends PlaySpec with MockitoSugar {
     }
 
     "include skipConfirmation param when registration is successful skipConfirmation is true and group code is valid" in new WithControllerMockedDependencies {
-      val returnUrl = Some("http://www.theguardian.com/test")
+      val returnUrl = Some("https://www.theguardian.com/test")
       val skipConfirmation = Some(true)
       val group = Some("GRS")
       val testCookie = Cookie("SC_GU_U", "##hash##")
@@ -246,7 +246,7 @@ class RegisterActionSpec extends PlaySpec with MockitoSugar {
     }
 
     "include skipThirdPartyLandingPage param when registration is successful skipConfirmation is true and group code is valid" in new WithControllerMockedDependencies {
-      val returnUrl = Some("http://www.theguardian.com/test")
+      val returnUrl = Some("https://www.theguardian.com/test")
       val skipConfirmation = Some(true)
       val group = Some("GRS")
       val testCookie = Cookie("SC_GU_U", "##hash##")
@@ -305,7 +305,7 @@ class RegisterActionSpec extends PlaySpec with MockitoSugar {
     }
 
     "include a return url when registration is successful skipConfirmation is false and group code is valid" in new WithControllerMockedDependencies {
-      val returnUrl = Some("http://www.theguardian.com/test")
+      val returnUrl = Some("https://www.theguardian.com/test")
       val skipConfirmation = Some(false)
       val group = Some("GRS")
       val testCookie = Cookie("SC_GU_U", "##hash##")

--- a/test/com/gu/identity/frontend/controllers/SignOutActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/SignOutActionSpec.scala
@@ -35,7 +35,7 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
     Cookie(name = CookieName.GU_U.toString, value = "GU_U", maxAge = None, path = "/", domain = Some("dev-theguardian.com"), secure = true, httpOnly = false)
   )
 
-  val referer = "http://www.theguardian.com/refs"
+  val referer = "https://www.theguardian.com/refs"
   val signOutCookie = Cookie(name = CookieName.GU_SO.toString, value = "data_for_GU_SO")
 
   def fakeSignOutRequest(cookies: Seq[Cookie] = Seq.empty) = FakeRequest("GET", "/signout")
@@ -45,7 +45,7 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
   "GET /signout" should {
 
     "redirect to returnUrl when user has SC_GU_U cookie" in new WithControllerMockedDependencies {
-      val returnUrl = Some("http://www.theguardian.com/yeah")
+      val returnUrl = Some("https://www.theguardian.com/yeah")
 
       val captor = ArgumentCaptor.forClass(classOf[Cookie])
 
@@ -69,7 +69,7 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
     }
 
     "redirect to returnUrl when Identity API call fails" in new WithControllerMockedDependencies {
-      val returnUrl = Some("http://www.theguardian.com/yeah")
+      val returnUrl = Some("https://www.theguardian.com/yeah")
 
       when(mockIdentityService.deauthenticate(argAny[Cookie], argAny[TrackingData])(argAny[ExecutionContext]))
         .thenReturn {
@@ -88,7 +88,7 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
     }
 
     "redirect to returnUrl despite lack of SC_GU_U cookie" in new WithControllerMockedDependencies {
-      val returnUrl = Some("http://www.theguardian.com/yeah")
+      val returnUrl = Some("https://www.theguardian.com/yeah")
 
       val result = call(controller.signOut(returnUrl), fakeSignOutRequest(Seq.empty))
       val resultCookies = cookies(result)
@@ -100,7 +100,7 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
     }
 
     "set GU_SO cookie when user has SC_GU_U cookie" in new WithControllerMockedDependencies {
-      val returnUrl = Some("http://www.theguardian.com/yeah")
+      val returnUrl = Some("https://www.theguardian.com/yeah")
 
       val captor = ArgumentCaptor.forClass(classOf[Cookie])
 

--- a/test/com/gu/identity/frontend/controllers/SigninActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/SigninActionSpec.scala
@@ -97,7 +97,7 @@ class SigninActionSpec extends PlaySpec with MockitoSugar {
     "redirect to returnUrl when passed authentication" in new WithControllerMockedDependencies {
       val email = "me@me.com"
       val password = "password"
-      val returnUrl = Some("http://www.theguardian.com/yeah")
+      val returnUrl = Some("https://www.theguardian.com/yeah")
 
       val testCookie = Cookie("SC_GU_U", "##hash##")
 
@@ -121,7 +121,7 @@ class SigninActionSpec extends PlaySpec with MockitoSugar {
     "redirect to sign in page when failed authentication" in new WithControllerMockedDependencies {
       val email = "me@me.com"
       val password = "password"
-      val returnUrl = Some("http://www.theguardian.com/yeah")
+      val returnUrl = Some("https://www.theguardian.com/yeah")
 
       when(mockAuthenticate(email, password))
         .thenReturn {
@@ -140,7 +140,7 @@ class SigninActionSpec extends PlaySpec with MockitoSugar {
     "redirect to sign in page when service error" in new WithControllerMockedDependencies {
       val email = "me@me.com"
       val password = "password"
-      val returnUrl = Some("http://www.theguardian.com/yeah")
+      val returnUrl = Some("https://www.theguardian.com/yeah")
 
       when(mockAuthenticate(email, password))
         .thenReturn {
@@ -160,7 +160,7 @@ class SigninActionSpec extends PlaySpec with MockitoSugar {
     "redirect to sign in page when error from future" in new WithControllerMockedDependencies {
       val email = "me@me.com"
       val password = "password"
-      val returnUrl = Some("http://www.theguardian.com/yeah")
+      val returnUrl = Some("https://www.theguardian.com/yeah")
 
       when(mockAuthenticate(email, password))
         .thenReturn {

--- a/test/com/gu/identity/frontend/controllers/ThirdPartyTsAndCsSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/ThirdPartyTsAndCsSpec.scala
@@ -149,7 +149,7 @@ class ThirdPartyTsAndCsSpec extends PlaySpec with MockitoSugar{
       val userGroup = UserGroup(groupCode, "Group/GTNF")
       val userGroups = List(userGroup)
       val user = User(userGroups = userGroups)
-      val url = Some("http://www.theguardian.com/sport")
+      val url = Some("https://www.theguardian.com/sport")
       val returnUrl = ReturnUrl(url, Configuration.testConfiguration)
       val cookie = Cookie("Name", "Value")
       val timeout = Timeout(5 seconds)
@@ -174,7 +174,7 @@ class ThirdPartyTsAndCsSpec extends PlaySpec with MockitoSugar{
       val userGroup = UserGroup("ABC", "Group/ABC")
       val userGroups = List(userGroup)
       val user = User(userGroups = userGroups)
-      val url = Some("http://www.theguardian.com/sport")
+      val url = Some("https://www.theguardian.com/sport")
       val returnUrl = ReturnUrl(url, Configuration.testConfiguration)
       val cookie = Cookie("Name", "Value")
       val timeout = Timeout(5 seconds)
@@ -206,7 +206,7 @@ class ThirdPartyTsAndCsSpec extends PlaySpec with MockitoSugar{
       val userGroup = UserGroup("ABC", "Group/ABC")
       val userGroups = List(userGroup)
       val user = User(userGroups = userGroups)
-      val url = Some("http://www.theguardian.com/sport")
+      val url = Some("https://www.theguardian.com/sport")
       val returnUrl = ReturnUrl(url, Configuration.testConfiguration)
       val cookie = Cookie("Name", "Value")
       val timeout = Timeout(5 seconds)
@@ -242,7 +242,7 @@ class ThirdPartyTsAndCsSpec extends PlaySpec with MockitoSugar{
 
     "return a result of the return url when user has successfully been added to the group" in new WithControllerMockedDependencies {
       val groupCode = "GTNF"
-      val returnUrl = "http://www.theguardian.com/sport"
+      val returnUrl = "https://www.theguardian.com/sport"
       val cookie = validCookie
       val fakeRequest = successfulFakeRequest(groupCode, returnUrl, cookie)
 
@@ -260,7 +260,7 @@ class ThirdPartyTsAndCsSpec extends PlaySpec with MockitoSugar{
 
     "return bad request when it is not possible to add the user to group" in new WithControllerMockedDependencies {
       val groupCode = "GTNF"
-      val returnUrl = "http://www.theguardian.com/sport"
+      val returnUrl = "https://www.theguardian.com/sport"
       val cookie = validCookie
       val fakeRequest = successfulFakeRequest(groupCode, returnUrl, cookie)
 
@@ -280,7 +280,7 @@ class ThirdPartyTsAndCsSpec extends PlaySpec with MockitoSugar{
 
     "return a not found error if group code is invalid" in new WithControllerMockedDependencies {
       val groupCode = "ABC"
-      val returnUrl = "http://www.theguardian.com/sport"
+      val returnUrl = "https://www.theguardian.com/sport"
       val cookie = validCookie
       val fakeRequest = successfulFakeRequest(groupCode, returnUrl, cookie)
 
@@ -300,7 +300,7 @@ class ThirdPartyTsAndCsSpec extends PlaySpec with MockitoSugar{
 
     "return bad request when the form submission to add to group action is invalid" in new WithControllerMockedDependencies {
       val groupCode = "GTNF"
-      val returnUrl = "http://www.theguardian.com/sport"
+      val returnUrl = "https://www.theguardian.com/sport"
       val cookie = validCookie
       val fakeRequest = FakeRequest("POST", "/actions/GTNF")
         .withFormUrlEncodedBody("group" -> groupCode, "returnUrl" -> returnUrl)

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -13,7 +13,7 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
 
   it should "determine valid domain" in {
 
-    validDomain(new URI("http://www.theguardian.com")) should be(true)
+    validDomain(new URI("https://www.theguardian.com")) should be(true)
     validDomain(new URI("http://jobs.theguardian.com")) should be(true)
     validDomain(new URI("http://code.dev-theguardian.com")) should be(true)
     validDomain(new URI("http://thegulocal.com")) should be(true)
@@ -22,8 +22,8 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
 
   it should "construct return url" in {
 
-    ReturnUrl(Some("http://www.theguardian.com/uk"), None, config, None) should be(ReturnUrl(new URI("http://www.theguardian.com/uk")))
-    ReturnUrl(None, Some("http://www.theguardian.com/uk"), config, None) should be(ReturnUrl(new URI("http://www.theguardian.com/uk")))
+    ReturnUrl(Some("https://www.theguardian.com/uk"), None, config, None) should be(ReturnUrl(new URI("https://www.theguardian.com/uk")))
+    ReturnUrl(None, Some("https://www.theguardian.com/uk"), config, None) should be(ReturnUrl(new URI("https://www.theguardian.com/uk")))
 
     ReturnUrl(Some("http://jobs.theguardian.com/apply"), None, config, None) should be(ReturnUrl(new URI("http://jobs.theguardian.com/apply")))
     ReturnUrl(None, Some("http://jobs.theguardian.com/apply"), config, None) should be(ReturnUrl(new URI("http://jobs.theguardian.com/apply")))
@@ -34,7 +34,7 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
 
     ReturnUrl(None, Some("sso.com.theguardian.jobs://ssologoutsuccess"), config, None) should be(ReturnUrl(new URI("sso.com.theguardian.jobs://ssologoutsuccess")))
 
-    ReturnUrl(None, Some("sso.com.theguardian.teachers://hello"), config, None) should be(ReturnUrl(new URI("http://www.theguardian.com"), isDefault = true))
+    ReturnUrl(None, Some("sso.com.theguardian.teachers://hello"), config, None) should be(ReturnUrl(new URI("https://www.theguardian.com"), isDefault = true))
 
     ReturnUrl(Some("https://profile.theguardian.com/register"), None, config, None, List("/signin")) should be(ReturnUrl(new URI("https://profile.theguardian.com/register")))
 
@@ -69,7 +69,7 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
 
     ReturnUrl(None, None, codeConfig, None) should be(ReturnUrl(new URI("http://m.code.dev-theguardian.com"), isDefault = true))
 
-    ReturnUrl(None, None, config, None) should be(ReturnUrl(new URI("http://www.theguardian.com"), isDefault = true))
+    ReturnUrl(None, None, config, None) should be(ReturnUrl(new URI("https://www.theguardian.com"), isDefault = true))
   }
 
   it should "Use the membership return url for clientId=members as the default fallback" in {

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -14,8 +14,8 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
   it should "determine valid domain" in {
 
     validDomain(new URI("https://www.theguardian.com")) should be(true)
-    validDomain(new URI("http://jobs.theguardian.com")) should be(true)
-    validDomain(new URI("http://code.dev-theguardian.com")) should be(true)
+    validDomain(new URI("https://jobs.theguardian.com")) should be(true)
+    validDomain(new URI("https://code.dev-theguardian.com")) should be(true)
     validDomain(new URI("http://thegulocal.com")) should be(true)
     validDomain(new URI("http://baddomain.com")) should be(false)
   }
@@ -25,8 +25,8 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
     ReturnUrl(Some("https://www.theguardian.com/uk"), None, config, None) should be(ReturnUrl(new URI("https://www.theguardian.com/uk")))
     ReturnUrl(None, Some("https://www.theguardian.com/uk"), config, None) should be(ReturnUrl(new URI("https://www.theguardian.com/uk")))
 
-    ReturnUrl(Some("http://jobs.theguardian.com/apply"), None, config, None) should be(ReturnUrl(new URI("http://jobs.theguardian.com/apply")))
-    ReturnUrl(None, Some("http://jobs.theguardian.com/apply"), config, None) should be(ReturnUrl(new URI("http://jobs.theguardian.com/apply")))
+    ReturnUrl(Some("https://jobs.theguardian.com/apply"), None, config, None) should be(ReturnUrl(new URI("https://jobs.theguardian.com/apply")))
+    ReturnUrl(None, Some("https://jobs.theguardian.com/apply"), config, None) should be(ReturnUrl(new URI("https://jobs.theguardian.com/apply")))
 
     ReturnUrl(None, Some("http://www.thegulocal.com/"), config, None) should be(ReturnUrl(new URI("http://www.thegulocal.com/")))
 

--- a/test/com/gu/identity/frontend/models/UrlBuilderSpec.scala
+++ b/test/com/gu/identity/frontend/models/UrlBuilderSpec.scala
@@ -32,9 +32,9 @@ class UrlBuilderSpec extends FlatSpec with Matchers{
   }
 
   it should "create valid url when provided a valid returnUrl object" in {
-    val returnUrl = ReturnUrl(Some("http://www.theguardian.com/uk"), Configuration.testConfiguration)
+    val returnUrl = ReturnUrl(Some("https://www.theguardian.com/uk"), Configuration.testConfiguration)
 
-    UrlBuilder("/register/confirm", returnUrl) should be("/register/confirm?returnUrl=http%3A%2F%2Fwww.theguardian.com%2Fuk")
+    UrlBuilder("/register/confirm", returnUrl) should be("/register/confirm?returnUrl=https%3A%2F%2Fwww.theguardian.com%2Fuk")
   }
 
   it should "create valid url without any returnUrl when provided the default returnUrl" in {
@@ -45,14 +45,14 @@ class UrlBuilderSpec extends FlatSpec with Matchers{
 
   it should "Include group code in return url when one is provided" in {
     val baseUrl = "/register/confirm"
-    val returnUrl = ReturnUrl(Some("http://www.theguardian.com/uk"), Configuration.testConfiguration)
+    val returnUrl = ReturnUrl(Some("https://www.theguardian.com/uk"), Configuration.testConfiguration)
     val group = Some("ABC")
 
     val result = UrlBuilder(baseUrl, returnUrl, skipConfirmation = None, clientId = None, group = group, skipThirdPartyLandingPage = None)
-    result should be("/register/confirm?returnUrl=http%3A%2F%2Fwww.theguardian.com%2Fuk&group=ABC")
+    result should be("/register/confirm?returnUrl=https%3A%2F%2Fwww.theguardian.com%2Fuk&group=ABC")
   }
 
-  private def getThirdPartyUri(baseDomain: String = "oauth.thegulocal.com", url: String = "http://www.profile.theguardian.com/agree/GRS"): URI = {
+  private def getThirdPartyUri(baseDomain: String = "oauth.thegulocal.com", url: String = "https://www.profile.theguardian.com/agree/GRS"): URI = {
     val baseDomain = "oauth.thegulocal.com"
     val baseUrl = s"http://$baseDomain"
     val returnUrl = ReturnUrl(Some(url), Configuration.testConfiguration)
@@ -62,7 +62,7 @@ class UrlBuilderSpec extends FlatSpec with Matchers{
   }
 
   it should "return a url including a reference to the third party additional ts and cs page" in {
-    val returnUrl = "http://www.profile.theguardian.com/agree/GRS"
+    val returnUrl = "https://www.profile.theguardian.com/agree/GRS"
     val encodedUrl = URLEncoder.encode(returnUrl, "UTF-8")
     val validUri = getThirdPartyUri(returnUrl)
     val query = validUri.getQuery

--- a/test/com/gu/identity/frontend/utils/UrlDecoderSpec.scala
+++ b/test/com/gu/identity/frontend/utils/UrlDecoderSpec.scala
@@ -6,17 +6,17 @@ class UrlDecoder$Test extends PlaySpec {
 
   "getQueryParams" should {
     "return a map containing a return url" in {
-      val queryParams = UrlDecoder.getQueryParams("/register?returnUrl=http://www.theguardian.com/test")
+      val queryParams = UrlDecoder.getQueryParams("/register?returnUrl=https://www.theguardian.com/test")
 
       queryParams.contains("returnUrl") mustEqual true
-      queryParams.get("returnUrl") mustEqual Some("http://www.theguardian.com/test")
+      queryParams.get("returnUrl") mustEqual Some("https://www.theguardian.com/test")
     }
 
     "return a map containing a return url and an error" in {
-      val queryParams = UrlDecoder.getQueryParams("/register?error=error-bad-gateway&returnUrl=http://www.theguardian.com/test")
+      val queryParams = UrlDecoder.getQueryParams("/register?error=error-bad-gateway&returnUrl=https://www.theguardian.com/test")
 
       queryParams.contains("returnUrl") mustEqual true
-      queryParams.get("returnUrl") mustEqual Some("http://www.theguardian.com/test")
+      queryParams.get("returnUrl") mustEqual Some("https://www.theguardian.com/test")
       queryParams.contains("error") mustEqual true
       queryParams.get("error") mustEqual Some("error-bad-gateway")
     }

--- a/test/com/gu/identity/service/client/request/AuthenticateCookiesApiRequestSpec.scala
+++ b/test/com/gu/identity/service/client/request/AuthenticateCookiesApiRequestSpec.scala
@@ -17,7 +17,7 @@ class AuthenticateCookiesApiRequestSpec extends WordSpec with Matchers with Mock
     trackingReturnUrl = Some("https://profile.theguardian.com"),
     registrationType = Some("facebook"),
     ipAddress = Some("127.0.0.1"),
-    referrer = Some("http://www.theguardian.com"),
+    referrer = Some("https://www.theguardian.com"),
     userAgent = Some("chrome")
   )
 

--- a/test/com/gu/identity/service/client/request/DeauthenticateApiRequestSpec.scala
+++ b/test/com/gu/identity/service/client/request/DeauthenticateApiRequestSpec.scala
@@ -19,7 +19,7 @@ class DeauthenticateApiRequestSpec extends WordSpec with Matchers with MockitoSu
     trackingReturnUrl = Some("https://profile.theguardian.com"),
     registrationType = Some("facebook"),
     ipAddress = Some("127.0.0.1"),
-    referrer = Some("http://www.theguardian.com"),
+    referrer = Some("https://www.theguardian.com"),
     userAgent = Some("chrome")
   )
 


### PR DESCRIPTION
These pages are now served directly on https so we can link to the https site directly.

