### PR TITLE
New style for the membership/support header.

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -61,7 +61,7 @@
       "always-multi-line",
       { ignore: ["after-comment"] }
     ],
-    "rule-trailing-semicolon": "always",
+    "declaration-block-trailing-semicolon": "always",
     "selector-combinator-space-after": "always",
     "selector-combinator-space-before": "always",
     "selector-list-comma-newline-after": "always",

--- a/public/components/_breakpoints.css
+++ b/public/components/_breakpoints.css
@@ -17,6 +17,7 @@
 
 /* Viewports */
 @custom-media --viewport-mobile-wide (--viewport-min-mobile-landscape) and (--viewport-max-tablet);
+@custom-media --viewport-phablet (--viewport-min-phablet) and (--viewport-max-tablet);
 @custom-media --viewport-tablet (--viewport-min-tablet) and (--viewport-max-desktop);
 @custom-media --viewport-desktop (--viewport-min-desktop) and (--viewport-max-leftCol);
 @custom-media --viewport-wide (--viewport-min-leftCol);

--- a/public/components/membership/_membership.css
+++ b/public/components/membership/_membership.css
@@ -10,8 +10,8 @@
   }
 
   @media (--viewport-phablet) {
-    width: 66rem;
-    max-width: 66rem;
+    width: 660px;
+    max-width: 660px;
     padding-right: 0;
   }
 
@@ -20,15 +20,15 @@
   }
 
   @media (--viewport-min-desktop) {
-    max-width: 98rem;
+    max-width: 980px;
   }
 
   @media (--viewport-min-leftCol) {
-    max-width: 114rem;
+    max-width: 1140px;
   }
 
   @media (--viewport-min-wide) {
-    max-width: 130rem;
+    max-width: 1300px;
   }
 }
 

--- a/public/components/membership/_membership.css
+++ b/public/components/membership/_membership.css
@@ -1,13 +1,58 @@
 .skin-members {
   .header__logo-link {
-    background-image: inline("guardian-members-logo.svg");
-    height: height("guardian-members-logo.svg");
-    width: width("guardian-members-logo.svg");
     margin: 1rem 0 1.4rem;
+    height: 42px;
+    width: 224px;
+
+    @media (--viewport-min-mobile-landscape) {
+      height: 49px;
+      width: 261px;
+    }
+
+    @media (--viewport-min-tablet) {
+      height: 68px;
+      width:362px;
+    }
+
+  }
+
+  .header__back-link {
+    display: none;
+  }
+
+  .header__inner {
+    width: 100%;
+
+    @media (--viewport-min-mobile-landscape) {
+      width: 480px;
+    }
+
+    @media (--viewport-min-phablet) {
+      width: 660px;
+      max-width: 660px;
+      padding-right:0;
+    }
+
+    @media(--viewport-min-tablet) {
+      width: 100%;
+    }
+
+    @media(--viewport-min-desktop) {
+      max-width: 980px;
+    }
+
+    @media(--viewport-min-leftCol) {
+      max-width: 1140px;
+    }
+
+    @media(--viewport-min-wide) {
+      max-width: 1300px;
+    }
+
   }
 
   .header {
-    background-image: inline("bg-masthead-72px.png");
+
     background-position: center top;
 
     @media (--viewport-max-tablet) {

--- a/public/components/membership/_membership.css
+++ b/public/components/membership/_membership.css
@@ -6,17 +6,16 @@
   width: 100%;
 
   @media (--viewport-min-mobile-landscape) {
-    width: 480px;
+    max-width: 480px;
   }
 
   @media (--viewport-phablet) {
-    width: 660px;
     max-width: 660px;
     padding-right: 0;
   }
 
   @media (--viewport-min-tablet) {
-    width:100%;
+    max-width: 740px;
   }
 
   @media (--viewport-min-desktop) {

--- a/public/components/membership/_membership.css
+++ b/public/components/membership/_membership.css
@@ -56,7 +56,6 @@
   }
 
   .header {
-
     background-position: center top;
 
     @media (--viewport-max-tablet) {

--- a/public/components/membership/_membership.css
+++ b/public/components/membership/_membership.css
@@ -1,3 +1,7 @@
+/* The membership header should use the membership/support layout.
+ * This layout can be found in
+ * https://github.com/guardian/support-frontend/blob/master/assets/stylesheets/gu-sass/layout.scss */
+
 %membership-header-container {
   width: 100%;
 

--- a/public/components/membership/_membership.css
+++ b/public/components/membership/_membership.css
@@ -1,3 +1,34 @@
+%membership-header-container {
+  width: 100%;
+
+  @media (--viewport-min-mobile-landscape) {
+    width: 480px;
+  }
+
+  @media (--viewport-phablet) {
+    width: 66rem;
+    max-width: 66rem;
+    padding-right: 0;
+  }
+
+  @media (--viewport-min-tablet) {
+    width:100%;
+  }
+
+  @media (--viewport-min-desktop) {
+    max-width: 98rem;
+  }
+
+  @media (--viewport-min-leftCol) {
+    max-width: 114rem;
+  }
+
+  @media (--viewport-min-wide) {
+    max-width: 130rem;
+  }
+}
+
+
 .skin-members {
   .header__logo-link {
     margin: 1rem 0 1.4rem;
@@ -21,34 +52,7 @@
   }
 
   .header__inner {
-    width: 100%;
-
-    @media (--viewport-min-mobile-landscape) {
-      width: 480px;
-    }
-
-    @media (--viewport-min-phablet) {
-      width: 660px;
-      max-width: 660px;
-      padding-right:0;
-    }
-
-    @media(--viewport-min-tablet) {
-      width: 100%;
-    }
-
-    @media(--viewport-min-desktop) {
-      max-width: 980px;
-    }
-
-    @media(--viewport-min-leftCol) {
-      max-width: 1140px;
-    }
-
-    @media(--viewport-min-wide) {
-      max-width: 1300px;
-    }
-
+    @extend %membership-header-container;
   }
 
   .header {


### PR DESCRIPTION
New design for the membership skin. We get rid of the Guardian Members logo.


| Mobile | Mobile Landscape | Phablet | Tablet | Desktop | Wide |
|--------|------------------|---------|--------|---------|------|
|  ![identity-mobile](https://user-images.githubusercontent.com/825398/28276543-29eb574e-6b0f-11e7-9e1f-ccacff514b49.png)    | ![identity-mobile-landscape](https://user-images.githubusercontent.com/825398/28276401-b86187ba-6b0e-11e7-909c-a808824fdd8a.png)  |![identity-phablet](https://user-images.githubusercontent.com/825398/28276418-c97ed78c-6b0e-11e7-9e1c-8bfa0080d7c5.png) | ![identity-tablet](https://user-images.githubusercontent.com/825398/28276448-df9d78c0-6b0e-11e7-8f34-02eab05fc35a.png) | ![identity-desktop](https://user-images.githubusercontent.com/825398/28276391-b3005e54-6b0e-11e7-8d1f-06fc8be6984d.png)  |  ![identity-wide](https://user-images.githubusercontent.com/825398/28276530-1ebb7a84-6b0f-11e7-8e66-2b7abdfd8b11.png)   |











During this PR a new css class was created in order the with to be compatible with the header style in support-frontend. https://github.com/guardian/support-frontend/blob/master/assets/stylesheets/gu-sass/layout.scss#L16




