### PR TITLE
Config does not support tilde ~ in includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Web frontend for Sign in and Registration at [theguardian.com](http://theguardia
 Configuration files:
 - Environment-specific configuration (`conf/<ENV>.conf`)
 - Application configuration (`conf/application.conf`)
-- System file with additional properties (`/etc/gu/identity-frontend.conf` or `~/.gu/identity-frontend.conf`)
+- System file with additional properties (`/etc/gu/identity-frontend.conf`)
 
 # Local development
 

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -16,4 +16,3 @@ ga-uid=UA-33592456-10
 
 # Local overrides - include must always be at bottom
 include file("/etc/gu/identity-frontend.conf")
-include file("~/.gu/identity-frontend.conf")


### PR DESCRIPTION
It seems we cannot use tilde ~ or environmental variables in `include file(...)`. Please see:

https://github.com/typesafehub/config/issues/122

To enable local config overrides relative to developer home directory we would need to implement this [in code](https://stackoverflow.com/questions/31570749/typesafe-config-file-in-home-directory) or use [guardian-configuration](https://github.com/guardian/guardian-configuration) library.