### PR TITLE
Disallow links in names

### DIFF
--- a/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
+++ b/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
@@ -2,12 +2,13 @@ package com.gu.identity.frontend.request
 
 import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.errors._
-import com.gu.identity.frontend.models.{ReturnUrl, ClientID, GroupCode}
+import com.gu.identity.frontend.models.{ClientID, GroupCode, ReturnUrl}
 import com.gu.identity.frontend.request.RequestParameters._
 import play.api.data.Forms._
-import play.api.data.{FormError, Mapping, Form}
+import play.api.data.validation.Constraints
+import play.api.data.{Form, FormError, Mapping}
 import play.api.http.HeaderNames
-import play.api.mvc.{RequestHeader, Result, BodyParsers, BodyParser}
+import play.api.mvc.{BodyParser, BodyParsers, RequestHeader, Result}
 
 
 case class RegisterActionRequestBody private(
@@ -67,20 +68,22 @@ object RegisterActionRequestBody {
     import GroupCode.FormMappings.groupCode
     import ReturnUrl.FormMapping.returnUrl
 
-    def minMaxLength(min : Int, max: Int): Mapping[String] = text.verifying(
-      "error.displayName", name => name.length >= min && name.length <= max
+    def validNameText(min : Int, max: Int): Mapping[String] = text.verifying(
+      Constraints.minLength(min),
+      Constraints.maxLength(max),
+      Constraints.pattern("^[^/:]*$".r)
     )
 
     private val password: Mapping[String] = text.verifying(
-      "error.password", name => name.length > 5 && name.length < 73
+      "error.password", pwd => pwd.length > 5 && pwd.length < 73
     )
 
     def registerFormMapping(refererHeader: Option[String]): Mapping[RegisterActionRequestBody] =
       mapping(
-        "firstName" -> minMaxLength(1, 25),
-        "lastName" -> minMaxLength(1, 25),
+        "firstName" -> validNameText(1, 25),
+        "lastName" -> validNameText(1, 25),
         "email" -> email,
-        "displayName" -> minMaxLength(2, 50),
+        "displayName" -> validNameText(2, 50),
         "password" -> password,
         "countryCode" -> optional(text),
         "localNumber" -> optional(text),

--- a/app/com/gu/identity/frontend/views/models/ErrorViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/ErrorViewModel.scala
@@ -24,10 +24,10 @@ object ErrorViewModel {
     RegisterActionBadRequestErrorID -> "One or more inputs was not valid; please try again.",
     RegisterEmailConflictErrorID -> "You already have a Guardian account. Please sign in or use another email address.",
     RegisterEmailReservedErrorID -> "This email is not available. Please use another email address.",
-    RegisterActionInvalidFirstNameErrorID -> minMaxLength("First name", 1, 25),
-    RegisterActionInvalidLastNameErrorID -> minMaxLength("Last name", 1, 25),
+    RegisterActionInvalidFirstNameErrorID -> (minMaxLength("First name", 1, 25) + " " + invalidNameCharacters("First name")),
+    RegisterActionInvalidLastNameErrorID ->(minMaxLength("Last name", 1, 25) + " " + invalidNameCharacters("Last name"),
     RegisterActionInvalidEmailErrorID -> "Invalid email address; please try again.",
-    RegisterActionInvalidDisplayNameErrorID -> minMaxLength("Display name", 2, 50),
+    RegisterActionInvalidDisplayNameErrorID -> (minMaxLength("Display name", 2, 50) + " " + invalidNameCharacters("Display name")),
     RegisterActionInvalidPasswordErrorID -> "Invalid password; your password must be between 6 and 72 characters long.",
 
     SocialRegistrationFacebookEmailErrorID -> "We need your email address when you sign in with Facebook so that we can keep in touch (you can choose which emails you receive in your account settings). Try again and allow access to your email address or provide it manually below.",
@@ -50,6 +50,8 @@ object ErrorViewModel {
   private def nonEmptyField(fieldName: String) = s"${fieldName.capitalize} field must not be blank."
 
   private def minMaxLength(fieldName: String, min: Int, max: Int) = s"${fieldName.capitalize} field must be between $min and $max characters long."
+
+  private def invalidNameCharacters(fieldName: String) = s"${fieldName.capitalize} field may not the characters : or /."
 
   val default: String = "There was an unexpected problem; please try again."
 

--- a/app/com/gu/identity/frontend/views/models/ErrorViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/ErrorViewModel.scala
@@ -51,7 +51,7 @@ object ErrorViewModel {
 
   private def minMaxLength(fieldName: String, min: Int, max: Int) = s"${fieldName.capitalize} field must be between $min and $max characters long."
 
-  private def invalidNameCharacters(fieldName: String) = s"${fieldName.capitalize} field may not the characters : or /."
+  private def invalidNameCharacters(fieldName: String) = s"${fieldName.capitalize} field may not contain the characters : or /."
 
   val default: String = "There was an unexpected problem; please try again."
 

--- a/app/com/gu/identity/frontend/views/models/ErrorViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/ErrorViewModel.scala
@@ -25,7 +25,7 @@ object ErrorViewModel {
     RegisterEmailConflictErrorID -> "You already have a Guardian account. Please sign in or use another email address.",
     RegisterEmailReservedErrorID -> "This email is not available. Please use another email address.",
     RegisterActionInvalidFirstNameErrorID -> (minMaxLength("First name", 1, 25) + " " + invalidNameCharacters("First name")),
-    RegisterActionInvalidLastNameErrorID ->(minMaxLength("Last name", 1, 25) + " " + invalidNameCharacters("Last name"),
+    RegisterActionInvalidLastNameErrorID ->(minMaxLength("Last name", 1, 25) + " " + invalidNameCharacters("Last name")),
     RegisterActionInvalidEmailErrorID -> "Invalid email address; please try again.",
     RegisterActionInvalidDisplayNameErrorID -> (minMaxLength("Display name", 2, 50) + " " + invalidNameCharacters("Display name")),
     RegisterActionInvalidPasswordErrorID -> "Invalid password; your password must be between 6 and 72 characters long.",

--- a/public/components/register-form/_form-fields.hbs
+++ b/public/components/register-form/_form-fields.hbs
@@ -2,10 +2,10 @@
   <label class="register-form__label--name" for="register_field_firstname">{{ registerPageText.name }}</label>
 
   <div class="register-form__control-column--firstname">
-    <input class="register-form__field--firstname" id="register_field_firstname" type="text" name="firstName" placeholder="{{ registerPageText.firstName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" />
+    <input class="register-form__field--firstname" id="register_field_firstname" type="text" name="firstName" placeholder="{{ registerPageText.firstName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="^[^:/]*$" />
   </div>
   <div class="register-form__control-column--lastname">
-    <input class="register-form__field--lastname" id="register_field_lastname" type="text" name="lastName" placeholder="{{ registerPageText.lastName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" />
+    <input class="register-form__field--lastname" id="register_field_lastname" type="text" name="lastName" placeholder="{{ registerPageText.lastName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="^[^:/]*$" />
   </div>
 </div>
 


### PR DESCRIPTION
This removes the ability to create an account with the `:` or `/` characters in the first name or last name field.  We have seen an influx of accounts created like this.  Hopefully this change should mitigate that - although the ultimate goal would be to stop automated methods of creating accounts.