### PR TITLE
Add Recurring Contributor Cookie

### DIFF
--- a/app/com/gu/identity/frontend/authentication/AuthenticationService.scala
+++ b/app/com/gu/identity/frontend/authentication/AuthenticationService.scala
@@ -13,6 +13,7 @@ object AuthenticationService {
   val knownCookies: Seq[GuardianCookie] = Seq(
     DotComCookie(CookieName.gu_user_features_expiry),
     DotComCookie(CookieName.gu_paying_member),
+    DotComCookie(CookieName.gu_recurring_contributor),
     IdentityCookie(CookieName.GU_U),
     IdentityCookie(CookieName.GU_ID_CSRF),
     IdentityCookie(CookieName.GU_PROFILE_CSRF),

--- a/app/com/gu/identity/frontend/authentication/CookieName.scala
+++ b/app/com/gu/identity/frontend/authentication/CookieName.scala
@@ -4,7 +4,7 @@ package com.gu.identity.frontend.authentication
 object CookieName extends Enumeration {
 
   type Name = Value
-  val GU_U, SC_GU_U, SC_GU_LA, GU_SO, GU_ID_CSRF, GU_PROFILE_CSRF, gu_user_features_expiry, gu_paying_member = Value
+  val GU_U, SC_GU_U, SC_GU_LA, GU_SO, GU_ID_CSRF, GU_PROFILE_CSRF, gu_user_features_expiry, gu_paying_member, gu_recurring_contributor = Value
 
   val SECURE_COOKIE_PREFIX = "SC"
   def isHttpOnly(cookieName: String) = cookieName.startsWith(SECURE_COOKIE_PREFIX)

--- a/test/com/gu/identity/frontend/authentication/AuthenticationServiceSpec.scala
+++ b/test/com/gu/identity/frontend/authentication/AuthenticationServiceSpec.scala
@@ -52,6 +52,7 @@ class AuthenticationServiceSpec extends PlaySpec {
       val resultCookies = cookies(Future.successful(result))
       resultCookies.get(CookieName.gu_user_features_expiry).value.value.isEmpty mustBe true
       resultCookies.get(CookieName.gu_paying_member).value.value.isEmpty mustBe true
+      resultCookies.get(CookieName.gu_recurring_contributor).value.value.isEmpty mustBe true
       resultCookies.get(CookieName.GU_U).value.value.isEmpty mustBe true
       resultCookies.get(CookieName.SC_GU_U).value.value.isEmpty mustBe true
       resultCookies.get(CookieName.GU_ID_CSRF).value.value.isEmpty mustBe true
@@ -64,6 +65,7 @@ class AuthenticationServiceSpec extends PlaySpec {
       val resultCookies = cookies(Future.successful(result))
       resultCookies.get(CookieName.gu_user_features_expiry).value.value.isEmpty mustBe true
       resultCookies.get(CookieName.gu_paying_member).value.value.isEmpty mustBe true
+      resultCookies.get(CookieName.gu_recurring_contributor).value.value.isEmpty mustBe true
       resultCookies.get(CookieName.GU_U).value.value.isEmpty mustBe true
       resultCookies.get(CookieName.SC_GU_U).value.value.isEmpty mustBe true
       resultCookies.get(CookieName.GU_ID_CSRF).value.value.isEmpty mustBe true

--- a/test/com/gu/identity/frontend/controllers/SignOutActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/SignOutActionSpec.scala
@@ -65,7 +65,7 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
       status(result) mustEqual SEE_OTHER
       redirectLocation(result) mustEqual returnUrl
 
-      resultCookies.size mustEqual 7
+      resultCookies.size mustEqual 8
     }
 
     "redirect to returnUrl when Identity API call fails" in new WithControllerMockedDependencies {
@@ -84,7 +84,7 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
       status(result) mustEqual SEE_OTHER
       redirectLocation(result) mustEqual returnUrl
 
-      resultCookies.size mustEqual 6
+      resultCookies.size mustEqual 7
     }
 
     "redirect to returnUrl despite lack of SC_GU_U cookie" in new WithControllerMockedDependencies {
@@ -96,7 +96,7 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
       status(result) mustEqual SEE_OTHER
       redirectLocation(result) mustEqual returnUrl
 
-      resultCookies.size mustEqual 6
+      resultCookies.size mustEqual 7
     }
 
     "set GU_SO cookie when user has SC_GU_U cookie" in new WithControllerMockedDependencies {
@@ -117,7 +117,7 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
       captor.getValue.name mustEqual secureCookie.name
       captor.getValue.value mustEqual secureCookie.value
 
-      resultCookies.size mustEqual 7
+      resultCookies.size mustEqual 8
       resultCookies.get("GU_SO").get.name == "GU_SO"
       resultCookies.get("GU_SO").get.value == "data_for_GU_SO"
     }
@@ -144,6 +144,6 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
     status(result) mustEqual SEE_OTHER
     redirectLocation(result) mustEqual Some(referer)
 
-    resultCookies.size mustEqual 7
+    resultCookies.size mustEqual 8
   }
 }


### PR DESCRIPTION
## Why?

To include support for a new cookie being introduced on dotcom: `gu_recurring_contributor`. This is being used to mark someone as a recurring contributor, and to therefore hide supporter messaging for them. This cookie needs to be deleted on sign-out along with the other user cookies.

The corresponding branch (soon to become a PR in frontend) is [here](https://github.com/guardian/frontend/compare/stop-showing-messaging-for-recurring-contributors). Another corresponding PR in the members-data-api was merged today, and is [here](https://github.com/guardian/members-data-api/pull/230).

cc: @JustinPinner

## Changes

- Added `gu_recurring_contributor` to the list of known cookies.
- Updated tests to include this new cookie.
