### PR TITLE
Update teachers Ts&Cs

### DIFF
--- a/app/com/gu/identity/frontend/models/text/ThirdPartyTsAndCsText.scala
+++ b/app/com/gu/identity/frontend/models/text/ThirdPartyTsAndCsText.scala
@@ -44,10 +44,15 @@ object TeachersTsAndCsText {
     ThirdPartyTsAndCsText(
       pageTitle = messages("thirdPartyTerms.teachersPageTitle"),
       title = title,
-      features = Seq(messages("thirdPartyTerms.teachersFeatures")),
+      featureIntro = Some(messages("thirdPartyTerms.teachersFeaturesIntro")),
+      features = Seq(
+        messages("thirdPartyTerms.teachersFeatures1"),
+        messages("thirdPartyTerms.teachersFeatures2"),
+        messages("thirdPartyTerms.teachersFeatures3")
+      ),
       serviceName = serviceName,
-      termsOfServiceLink = "http://teachers.theguardian.com/Terms.htm",
-      privacyPolicyLink = "http://teachers.theguardian.com/privacypolicy.htm",
+      termsOfServiceLink = "https://teachers.theguardian.com/guardian-teacher-network-terms-and-conditions",
+      privacyPolicyLink = "https://teachers.theguardian.com/guardian-teacher-network-privacy-policy",
       baseText = BaseTsAndCsText(title, serviceName)
     )
   }

--- a/app/com/gu/identity/frontend/views/models/TermsViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/TermsViewModel.scala
@@ -70,8 +70,8 @@ object TeachersTermsViewModel {
       privacyPolicyText = text.basicTermsText.privacyPolicyText,
       privacyPolicyUrl = text.basicTermsText.privacyPolicyUrl,
       extendedConditionsText = text.conditionsText,
-      extendedTermsOfServiceUrl = "http://teachers.theguardian.com/Terms.htm",
-      extendedPrivacyPolicyUrl = "http://teachers.theguardian.com/privacypolicy.htm"
+      extendedTermsOfServiceUrl = "https://teachers.theguardian.com/guardian-teacher-network-terms-and-conditions",
+      extendedPrivacyPolicyUrl = "https://teachers.theguardian.com/guardian-teacher-network-privacy-policy"
     )
   }
 }
@@ -95,7 +95,7 @@ object JobsTermsViewModel {
 object Terms {
   def getTermsModel(group: Option[GroupCode])(implicit messages: Messages): TermsViewModel = {
     group match {
-      case Some(GuardianTeachersNetwork) => {TeachersTermsViewModel()}
+      case Some(GuardianTeachersNetwork) => TeachersTermsViewModel()
       case Some(GuardianJobs) => JobsTermsViewModel()
       case _ => BasicTermsViewModel()
     }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -130,10 +130,15 @@ thirdPartyTerms.continueButton=Continue
 thirdPartyTerms.terms=By proceeding, you agree to Guardian {0}
 thirdPartyTerms.termsOfService=Terms of Service
 thirdPartyTerms.privacyPolicy=Privacy Policy
+
 thirdPartyTerms.teachersPageTitle=Teacher''s Network
 thirdPartyTerms.teachersTitle=Teacher''s Network
 thirdPartyTerms.teachersServiceName=Teacher Network''s
-thirdPartyTerms.teachersFeatures=Download teaching resources
+thirdPartyTerms.teachersFeaturesIntro=By activating your Guardian Teacher''s Network account you will be able to do the following:
+thirdPartyTerms.teachersFeatures1=Download teaching assets
+thirdPartyTerms.teachersFeatures2=Contribute new resources
+thirdPartyTerms.teachersFeatures3=Rate the quality of published resources
+
 thirdPartyTerms.jobsPageTitle=Jobs
 thirdPartyTerms.jobsTitle=Jobs
 thirdPartyTerms.jobsServiceName=Jobs''


### PR DESCRIPTION
The teacher's network has been updated and will now be using the 'use my existing account' page at `/agree/GTNF` for users who have an account but have not yet agreed to the additional teacher's network Ts&Cs.  This updates the wording on that page, and also the Ts&Cs/privacy links there and on the sign in page.