### PR TITLE
Email validation

### DIFF
--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -7,6 +7,7 @@ import com.gu.identity.frontend.csrf.CSRFToken
 import com.gu.identity.frontend.models._
 import com.gu.identity.frontend.models.text.RegisterText
 import com.gu.identity.frontend.mvt._
+import com.gu.identity.frontend.request.RegisterActionRequestBody.FormMapping
 import play.api.i18n.Messages
 
 
@@ -36,7 +37,8 @@ case class RegisterViewModel(
                               resources: Seq[PageResource with Product],
                               indirectResources: Seq[PageResource with Product],
                               countryCodes: Option[CountryCodes],
-                              gitCommitId: String
+                              gitCommitId: String,
+                              emailValidationRegex: String
   )
   extends ViewModel with ViewModelResources
 
@@ -86,7 +88,8 @@ object RegisterViewModel {
       indirectResources = layout.indirectResources,
 
       countryCodes = codes,
-      gitCommitId = BuildInfo.gitCommitId
+      gitCommitId = BuildInfo.gitCommitId,
+      emailValidationRegex = "" // FormMapping.dotlessDomainEmailRegex.pattern.toString
     )
   }
 

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -89,7 +89,7 @@ object RegisterViewModel {
 
       countryCodes = codes,
       gitCommitId = BuildInfo.gitCommitId,
-      emailValidationRegex = "" // FormMapping.dotlessDomainEmailRegex.pattern.toString
+      emailValidationRegex = FormMapping.dotlessDomainEmailRegex.pattern.toString
     )
   }
 

--- a/public/components/register-form/_form-fields.hbs
+++ b/public/components/register-form/_form-fields.hbs
@@ -11,7 +11,7 @@
 
 <div class="register-form__control--email">
   <label class="register-form__label--email" for="register_field_email">{{ registerPageText.email }}</label>
-  <input class="register-form__field--email" id="register_field_email" type="email" pattern="^[a-zA-Z0-9!#$%&’*+/=?^_`{|}~.-]+@[a-zA-Z0-9-]+\.([a-zA-Z0-9-]+)*$" name="email" placeholder="{{ registerPageText.emailHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" required />
+  <input class="register-form__field--email" id="register_field_email" type="email" name="email" placeholder="{{ registerPageText.emailHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" required />
 </div>
 
 

--- a/public/components/register-form/_form-fields.hbs
+++ b/public/components/register-form/_form-fields.hbs
@@ -11,7 +11,7 @@
 
 <div class="register-form__control--email">
   <label class="register-form__label--email" for="register_field_email">{{ registerPageText.email }}</label>
-  <input class="register-form__field--email" id="register_field_email" type="email" name="email" placeholder="{{ registerPageText.emailHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" required />
+  <input class="register-form__field--email" id="register_field_email" type="email" pattern="{{ emailValidationRegex }}" name="email" placeholder="{{ registerPageText.emailHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" required />
 </div>
 
 

--- a/public/components/register-form/_form-fields.hbs
+++ b/public/components/register-form/_form-fields.hbs
@@ -11,7 +11,7 @@
 
 <div class="register-form__control--email">
   <label class="register-form__label--email" for="register_field_email">{{ registerPageText.email }}</label>
-  <input class="register-form__field--email" id="register_field_email" type="email" name="email" placeholder="{{ registerPageText.emailHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" required />
+  <input class="register-form__field--email" id="register_field_email" type="email" pattern="^[a-zA-Z0-9!#$%&’*+/=?^_`{|}~.-]+@[a-zA-Z0-9-]+\.([a-zA-Z0-9-]+)*$" name="email" placeholder="{{ registerPageText.emailHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" required />
 </div>
 
 

--- a/public/components/register-form/register-form.js
+++ b/public/components/register-form/register-form.js
@@ -66,6 +66,11 @@ class RegisterFormModel {
     this.formElement.on( 'submit', this.formSubmitted.bind( this ) );
     this.fields.firstName.on('blur', this.updateDisplayName.bind( this ));
     this.fields.lastName.on('blur', this.updateDisplayName.bind( this ));
+    this.fields.email.on('invalid', this.validateEmail.bind( event ));
+  }
+
+  validateEmail(event) {
+    event.target.setCustomValidity('Please enter a valid email address');
   }
 
   updateDisplayName(){

--- a/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
+++ b/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
@@ -1,11 +1,10 @@
 package com.gu.identity.frontend.models
 
-import com.gu.identity.frontend.request.RegisterActionRequestBody.FormMapping
 import com.gu.identity.frontend.logging.Logging
 import com.gu.identity.frontend.request.RegisterActionRequestBody.FormMapping.dotlessDomainEmail
 import org.scalatest.{FlatSpec, Matchers}
-import play.api.data._
 import play.api.data.Forms._
+import play.api.data._
 
 class EmailValidationSpec extends FlatSpec with Matchers with Logging {
   it should "work" in {

--- a/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
+++ b/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
@@ -6,7 +6,7 @@ import play.api.data.Forms._
 import play.api.data._
 
 class EmailValidationSpec extends FlatSpec with Matchers with AppendedClues{
-  it should "work" in {
+  it should "correctly detect valid and invalid email addresses" in {
     /*
       The regex used to validate email addresses is based on the one used by WebKit for html email validation
       and comes from here: https://html.spec.whatwg.org/#valid-e-mail-address

--- a/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
+++ b/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
@@ -37,6 +37,7 @@ class EmailValidationSpec extends FlatSpec with Matchers with Logging {
       "_______@domain.com", //Underscore in the address field is valid
       "email@domain.name", //.name is valid Top Level Domain name
       "email@domain.co.jp", //Dot in Top Level Domain name also considered valid (use co.jp as example here)
+      "te44st@gmail.com",
       "firstname-lastname@domain.com") //Dash in address field is valid
 
     val invalid = List(

--- a/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
+++ b/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
@@ -1,0 +1,81 @@
+package com.gu.identity.frontend.models
+
+import com.gu.identity.frontend.request.RegisterActionRequestBody.FormMapping
+import com.gu.identity.frontend.logging.Logging
+import com.gu.identity.frontend.request.RegisterActionRequestBody.FormMapping.dotlessDomainEmail
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.data._
+import play.api.data.Forms._
+
+class EmailValidationSpec extends FlatSpec with Matchers with Logging {
+  it should "work" in {
+    /*
+      The regex used to validate email addresses is based on the one used by WebKit for html email validation
+      and comes from here: https://html.spec.whatwg.org/#valid-e-mail-address
+      However it has the additional constraint that the domain must not be dotless
+
+      There are a few patterns which it doesn't match correctly, but these are the same as all the
+      major browsers so do not represent a regression.
+
+      Unsupported valid patterns:
+        email@[123.123.123.123] //Square bracket around IP address is considered valid
+        "email"@domain.com //Quotes around email is considered valid
+
+      Unsupported Invalid patterns;
+        email..email@domain.com //Multiple dots in the first part of the email
+        email@domain.web //Invalid top level domains
+        email@111.222.333.44444 //Invalid IP format
+    */
+
+    val valid = List(
+      "email@domain.com", //Valid email
+      "firstname.lastname@domain.com", //Email contains dot in the address field
+      "email@subdomain.domain.com", //Email contains dot with subdomain
+      "firstname+lastname@domain.com", //Plus sign is considered valid character
+      "email@123.123.123.123", //Domain is valid IP address
+      "1234567890@domain.com", //Digits in address are valid
+      "email@domain-one.com", //Dash in domain name is valid
+      "_______@domain.com", //Underscore in the address field is valid
+      "email@domain.name", //.name is valid Top Level Domain name
+      "email@domain.co.jp", //Dot in Top Level Domain name also considered valid (use co.jp as example here)
+      "firstname-lastname@domain.com") //Dash in address field is valid
+
+    val invalid = List(
+      "blah@gmail", //dotless domain
+      "plainaddress", //Missing @ sign and domain
+      "#@%^%#$@#$@#.com", //Garbage
+      "@domain.com", //Missing username
+      "Joe Smith <email@domain.com>", //Encoded html within email is invalid
+      "email.domain.com", //Missing @
+      "email@domain@domain.com", //Two @ sign
+      ".email@domain.com", //Leading dot in address is not allowed
+      "email.@domain.com", //Trailing dot in address is not allowed
+
+      "あいうえお@domain.com", //Unicode char as address
+      "email@domain.com (Joe Smith)", //Text followed email is not allowed
+      "email@domain", //Missing top level domain (.com/.net/.org/etc)
+      "email@-domain.com", //Leading dash in front of domain is invalid
+      "email@domain..com") //Multiple dot in the domain portion is invalid
+
+    val singleForm = Form(
+      single(
+        "email" -> dotlessDomainEmail
+      )
+    )
+
+    System.out.println("\nValid emails\n----------------------------")
+    valid.foreach {
+      email =>
+        System.out.println(s"Trying to bind valid email $email")
+        singleForm.bind(Map("email" -> email)).get shouldBe email
+    }
+
+    System.out.println("\nInvalid emails\n----------------------------")
+    invalid.foreach {
+      email =>
+        System.out.println(s"Trying to bind invalid email $email")
+        singleForm.bind(Map("email" -> email)).errors.nonEmpty shouldBe true
+    }
+
+  }
+}

--- a/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
+++ b/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
@@ -1,12 +1,11 @@
 package com.gu.identity.frontend.models
 
-import com.gu.identity.frontend.logging.Logging
 import com.gu.identity.frontend.request.RegisterActionRequestBody.FormMapping.dotlessDomainEmail
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{AppendedClues, FlatSpec, Matchers}
 import play.api.data.Forms._
 import play.api.data._
 
-class EmailValidationSpec extends FlatSpec with Matchers with Logging {
+class EmailValidationSpec extends FlatSpec with Matchers with AppendedClues{
   it should "work" in {
     /*
       The regex used to validate email addresses is based on the one used by WebKit for html email validation
@@ -50,7 +49,6 @@ class EmailValidationSpec extends FlatSpec with Matchers with Logging {
       "email@domain@domain.com", //Two @ sign
       ".email@domain.com", //Leading dot in address is not allowed
       "email.@domain.com", //Trailing dot in address is not allowed
-
       "あいうえお@domain.com", //Unicode char as address
       "email@domain.com (Joe Smith)", //Text followed email is not allowed
       "email@domain", //Missing top level domain (.com/.net/.org/etc)
@@ -63,18 +61,14 @@ class EmailValidationSpec extends FlatSpec with Matchers with Logging {
       )
     )
 
-    System.out.println("\nValid emails\n----------------------------")
     valid.foreach {
       email =>
-        System.out.println(s"Trying to bind valid email $email")
-        singleForm.bind(Map("email" -> email)).get shouldBe email
+        singleForm.bind(Map("email" -> email)).errors shouldBe Nil withClue s"$email failed to validate but is a valid email"
     }
 
-    System.out.println("\nInvalid emails\n----------------------------")
     invalid.foreach {
       email =>
-        System.out.println(s"Trying to bind invalid email $email")
-        singleForm.bind(Map("email" -> email)).errors.nonEmpty shouldBe true
+        singleForm.bind(Map("email" -> email)).errors.nonEmpty shouldBe true withClue s"$email validated but is an invalid email"
     }
 
   }


### PR DESCRIPTION
Our email validation currently uses the standard Html 5 input validation and the Play email constraint. However both of these allow dotless domains on email addresses eg. test@gmail

These are now [prohibited by ICANN](https://www.icann.org/news/announcement-2013-08-30-en) and the likelihood is that anyone registering with one has actually just made a mistake. Dotless domains also cause problems when we try to use them to create user accounts in Salesforce.

A bit of research by @jfsoul reveals that we have 1,984 accounts with dotless domains of which none are actually valid.

This PR makes out email validation stricter to disallow dotless domains (see [EmailValidationSpec](https://github.com/guardian/identity-frontend/pull/231/files#diff-ffc2d94f9a4c37dd928a56af5bf4aab0) for a more in depth discussion of what is and isn't valid)

