### PR TITLE
Add permissions to fix SSH key fetching

### DIFF
--- a/cloudformation/identity-frontend.yaml
+++ b/cloudformation/identity-frontend.yaml
@@ -98,6 +98,10 @@ Resources:
             Resource:
             - !Sub arn:aws:s3:::identity-artifacts/${Stage}/${App}/*
             - !Sub arn:aws:s3:::identity-private-config/${Stage}/${App}/*
+            - arn:aws:s3:::github-public-keys/*
+          - Effect: Allow
+            Action: s3:ListBucket
+            Resource: arn:aws:s3:::github-public-keys
           - Effect: Allow
             Action: ec2:DescribeTags
             Resource: '*'


### PR DESCRIPTION
The fetching of SSH keys was not working after AMI creation due to this missing s3 permission.