### PR TITLE
Fix exception on agree journey

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,8 @@ lazy val functionalTests = Project("functional-tests", file("functional-tests"))
 
 resolvers += "Guardian Github Releases" at "https://guardian.github.io/maven/repo-releases"
 
+val identityLibrariesVersion = "3.83"
+
 libraryDependencies ++= Seq(
   "org.scalatestplus" %% "play" % "1.4.0-M3" % "test",
   "org.scalatest" %% "scalatest" % "2.2.5" % "test",
@@ -23,8 +25,8 @@ libraryDependencies ++= Seq(
   filters,
   "jp.co.bizreach" %% "play2-handlebars" % "0.3.0",
   "com.mohiva" %% "play-html-compressor" % "0.5.0",
-  "com.gu.identity" %% "identity-cookie" % "3.51",
-  "com.gu.identity" %% "identity-model" % "3.83",
+  "com.gu.identity" %% "identity-cookie" % identityLibrariesVersion,
+  "com.gu.identity" %% "identity-model" % identityLibrariesVersion,
   "com.typesafe.akka" %% "akka-actor" % "2.4.1",
   "com.typesafe.akka" %% "akka-slf4j" % "2.4.0",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.10.54",


### PR DESCRIPTION
[Sentry issue](https://sentry.io/the-guardian/identity-frontend-prod/issues/400660348/)

identity-cookie was compiled against older version of identity-model 3.51, so it could not pick up the new signature from identity-model 3.83.

```
NoSuchMethodError
com.gu.identity.model.User.<init>(Ljava/lang/String;Ljava/lang/String;Lcom/gu/identity/model/PublicFields;Lcom/gu/identity/model/PrivateFields;Lcom/gu/identity/model/StatusFields;Lcom/gu/identity/model/UserDates;Lscala/Option;Lscala/collection/mutable/Set;Lscala/collection/mutable/Set;Lscala/collection/mutable/Map;)V
com.gu.identity.cookie.GuUDecoder in cookieData2User at line 84
com.gu.identity.cookie.GuUDecoder$$anonfun$getUserDataForScGuU$1 in apply at line 881
com.gu.identity.cookie.GuUDecoder$$anonfun$getDataForScGuU$1 in apply at line 80
com.gu.identity.cookie.GuUDecoder$$anonfun$getDataForScGuU$1 in apply at line 79
scala.Option in map at line 146
com.gu.identity.cookie.GuUDecoder in getDataForScGuU at line 79
com.gu.identity.cookie.GuUDecoder in getUserDataForScGuU at line 88
com.gu.identity.frontend.configuration.ApplicationComponents$$anonfun$thirdPartyTsAndCsController$1 in apply at line 591
com.gu.identity.frontend.authentication.AuthenticationService$$anonfun$authenticatedUserFor$1 in apply at line 27
com.gu.identity.frontend.authentication.AuthenticationService$$anonfun$authenticatedUserFor$1 in apply at line 26
scala.Option in flatMap at line 171
com.gu.identity.frontend.authentication.AuthenticationService$ in authenticatedUserFor at line 26
com.gu.identity.frontend.authentication.UserAuthenticatedActionBuilder$$anon$1 in refine at line 29
com.gu.identity.frontend.authentication.UserAuthenticatedActionBuilder$$anon$1 in refine at line 21
play.api.mvc.ActionRefiner$class in invokeBlock at line 556
com.gu.identity.frontend.authentication.UserAuthenticatedActionBuilder$$anon$1 in invokeBlock at line 21
play.api.mvc.ActionBuilder$$anon$1 in apply at line 493
```