### PR TITLE
Parse email from url and use in frontend to pre-populate inputs

### DIFF
--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -6,7 +6,6 @@ import com.gu.identity.frontend.logging.Logging
 import com.gu.identity.frontend.models.{ClientID, GroupCode, ReturnUrl}
 import com.gu.identity.frontend.mvt.MultiVariantTestAction
 import com.gu.identity.frontend.views.ViewRenderer.{renderRegister, renderRegisterConfirmation, renderResetPassword, renderResetPasswordEmailSent, renderSignIn}
-import com.netaporter.uri.Uri
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._
 
@@ -18,7 +17,7 @@ class Application (configuration: Configuration, val messagesApi: MessagesApi, c
     val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"), configuration, clientIdActual)
     val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
     val groupCode = GroupCode(group)
-    val email : Option[String] = getEmailFromUrl(req)
+    val email : Option[String] = req.getQueryString("email")
 
     renderSignIn(configuration, req.activeTests, csrfToken, error, returnUrlActual, skipConfirmation, clientIdActual, groupCode, email)
   }
@@ -28,7 +27,7 @@ class Application (configuration: Configuration, val messagesApi: MessagesApi, c
     val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"), configuration, clientIdActual)
     val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
     val groupCode = GroupCode(group)
-    val email : Option[String] = getEmailFromUrl(req)
+    val email : Option[String] = req.getQueryString("email")
 
     renderRegister(configuration, req.activeTests, error, csrfToken, returnUrlActual, skipConfirmation, clientIdActual, groupCode, email)
   }
@@ -50,18 +49,6 @@ class Application (configuration: Configuration, val messagesApi: MessagesApi, c
   def resetPasswordEmailSent(clientId: Option[String]) = Action {
     val clientIdOpt = ClientID(clientId)
     renderResetPasswordEmailSent(configuration, clientIdOpt)
-  }
-
-  def getEmailFromUrl(req: RequestHeader): Option[String] = {
-    if(req.queryString.contains("email")) {
-      req.getQueryString("email")
-    } else {
-      req.getQueryString("returnUrl")
-        .flatMap(returnUrl => {
-          Uri.parse(returnUrl).query.paramMap.get("email")
-            .flatMap(_.headOption)
-        })
-    }
   }
 }
 

--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -28,7 +28,8 @@ object ViewRenderer {
       returnUrl: ReturnUrl,
       skipConfirmation: Option[Boolean],
       clientId: Option[ClientID],
-      group: Option[GroupCode])
+      group: Option[GroupCode],
+      email: Option[String])
       (implicit messages: Messages) = {
 
     val model = SignInViewModel(
@@ -39,7 +40,8 @@ object ViewRenderer {
       returnUrl = returnUrl,
       skipConfirmation = skipConfirmation,
       clientId = clientId,
-      group = group
+      group = group,
+      email = email
     )
 
     val view = clientId match {
@@ -58,7 +60,8 @@ object ViewRenderer {
       returnUrl: ReturnUrl,
       skipConfirmation: Option[Boolean],
       clientId: Option[ClientID],
-      group: Option[GroupCode])
+      group: Option[GroupCode],
+      email: Option[String])
       (implicit messages: Messages) = {
 
     val model = RegisterViewModel(
@@ -69,7 +72,8 @@ object ViewRenderer {
       returnUrl = returnUrl,
       skipConfirmation = skipConfirmation,
       clientId = clientId,
-      group = group)
+      group = group,
+      email = email)
 
     clientId match {
       case Some(GuardianMembersClientID) => renderViewModel("register-page-membership", model)

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -30,7 +30,7 @@ case class RegisterViewModel(
                               skipConfirmation: Boolean,
                               clientId: Option[ClientID],
                               group: Option[GroupCode],
-
+                              email: Option[String],
                               actions: RegisterActions,
                               links: RegisterLinks,
 
@@ -53,7 +53,8 @@ object RegisterViewModel {
       returnUrl: ReturnUrl,
       skipConfirmation: Option[Boolean],
       clientId: Option[ClientID],
-      group: Option[GroupCode])
+      group: Option[GroupCode],
+      email: Option[String])
       (implicit messages: Messages): RegisterViewModel = {
 
     val layout = LayoutViewModel(configuration, activeTests, clientId, Some(returnUrl))
@@ -80,6 +81,7 @@ object RegisterViewModel {
       skipConfirmation = skipConfirmation.getOrElse(false),
       clientId = clientId,
       group = group,
+      email = email,
 
       actions = RegisterActions(),
       links = RegisterLinks(returnUrl, skipConfirmation, clientId),

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -25,6 +25,7 @@ case class SignInViewModel private(
     skipConfirmation: Boolean = false,
     clientId: Option[ClientID],
     group: Option[GroupCode],
+    email:Option[String],
 
     registerUrl: String = "",
     forgotPasswordUrl: String = "",
@@ -47,7 +48,8 @@ object SignInViewModel {
    returnUrl: ReturnUrl,
    skipConfirmation: Option[Boolean],
    clientId: Option[ClientID],
-   group: Option[GroupCode])(implicit messages: Messages): SignInViewModel = {
+   group: Option[GroupCode],
+   email: Option[String])(implicit messages: Messages): SignInViewModel = {
 
     val layout = LayoutViewModel(configuration, activeTests, clientId, Some(returnUrl))
     val recaptchaModel : Option[GoogleRecaptchaViewModel] =
@@ -73,6 +75,7 @@ object SignInViewModel {
       skipConfirmation = skipConfirmation.getOrElse(false),
       clientId = clientId,
       group = group,
+      email = email,
 
       registerUrl = UrlBuilder(routes.Application.register(), returnUrl, skipConfirmation, clientId, group.map(_.id)),
       forgotPasswordUrl = UrlBuilder("/reset", returnUrl, skipConfirmation, clientId, group.map(_.id)),

--- a/build.sbt
+++ b/build.sbt
@@ -32,8 +32,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.10.54",
   "com.getsentry.raven" % "raven-logback" % "7.2.1",
   "com.googlecode.libphonenumber" % "libphonenumber" % "7.2.4",
-  "com.gu" %% "tip" % "0.3.2",
-  "io.lemonlabs" %% "scala-uri" % "0.5.0"
+  "com.gu" %% "tip" % "0.3.2"
 )
 
 // Set logs options and default local resource for running locally (run and test)

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,8 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.10.54",
   "com.getsentry.raven" % "raven-logback" % "7.2.1",
   "com.googlecode.libphonenumber" % "libphonenumber" % "7.2.4",
-  "com.gu" %% "tip" % "0.3.2"
+  "com.gu" %% "tip" % "0.3.2",
+  "io.lemonlabs" %% "scala-uri" % "0.5.0"
 )
 
 // Set logs options and default local resource for running locally (run and test)

--- a/public/components/register-form/_form-fields.hbs
+++ b/public/components/register-form/_form-fields.hbs
@@ -11,7 +11,8 @@
 
 <div class="register-form__control--email">
   <label class="register-form__label--email" for="register_field_email">{{ registerPageText.email }}</label>
-  <input class="register-form__field--email" id="register_field_email" type="email" pattern="{{ emailValidationRegex }}" name="email" placeholder="{{ registerPageText.emailHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" required />
+  <input class="register-form__field--email" id="register_field_email" type="email" pattern="{{ emailValidationRegex }}" name="email" placeholder="{{ registerPageText.emailHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off"
+         spellcheck="false" value="{{email}}" required />
 </div>
 
 

--- a/public/components/register-form/register-form.js
+++ b/public/components/register-form/register-form.js
@@ -27,7 +27,10 @@ class RegisterFormFields {
   setValues( { firstName, lastName, email, displayName, optionalCountryCode, optionalCountryIsoName, optionalPhoneNumber } = {} ) {
     this.firstName.setValue( firstName );
     this.lastName.setValue( lastName );
-    this.email.setValue( email );
+    // If we don't receive an email from the backend model use local storage
+    if(this.email.value().length === 0){
+      this.email.setValue( email );
+    }
     this.displayName.setValue( displayName );
     if (this.optionalPhoneNumber) {
       this.optionalPhoneNumber.setValue(optionalPhoneNumber);

--- a/public/components/signin-form/_signin-form.hbs
+++ b/public/components/signin-form/_signin-form.hbs
@@ -20,10 +20,9 @@
   {{/each}}
 
   <fieldset class="signin-form__fieldset">
-
     <div class="signin-form__control--email">
       <label class="signin-form__label--email" for="signin_field_email">{{signInPageText.email}}</label>
-      <input class="signin-form__field--email" id="signin_field_email" type="email" name="email" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{email}}"/>
+      <input class="signin-form__field--email" id="signin_field_email" type="email" name="email" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{email}}" />
     </div>
 
     <div class="signin-form__control--password">

--- a/public/components/signin-form/signin-form.js
+++ b/public/components/signin-form/signin-form.js
@@ -25,7 +25,11 @@ class SignInFormModel {
   loadState() {
     this.state = SignInFormState.fromStorage();
     this.smartLockStatus = SmartLockState.fromStorage();
-    this.emailFieldElement.setValue( this.state.email );
+    // If we don't receive an email from the backend model use local storage
+    if(this.emailFieldElement.value().length === 0){
+      this.emailFieldElement.setValue( this.state.email );
+    }
+
   }
 
   saveState() {


### PR DESCRIPTION
We want to populate email address input boxes when users land /signin or /register pages with certain query params. 
#### In this PR
- Parse the email from the url in the Applications.scala
- Pass the email from the backend to the handlebars template model and use this to prepopulate the email inputs.
-  Stop the javascript getting the email value from local storage if one has been passed in the model.
#### Valid Url's handled : 
- Landing directly: `https://profile.theguardian.com/register?email=foo@bar.com`

- When redirected from another identity page e.g `https://profile.theguardian.com/public/edit?email=foo@bar.com` : `https://profile.thegulocal.com/signin?returnUrl=https%3A%2F%2Fprofile.thegulocal.com%2Fpublic%2Fedit%3Femailasd%3Dfoo%40bar.com` 

Relies on https://github.com/guardian/frontend/pull/18247