### PR TITLE
Pass journey parameter in token url

### DIFF
--- a/app/com/gu/identity/frontend/controllers/SigninAction.scala
+++ b/app/com/gu/identity/frontend/controllers/SigninAction.scala
@@ -90,16 +90,17 @@ class SigninAction(
       RedirectOnError(redirectRoute) andThen
       LogOnErrorAction(logger)
 
-  def permissionAuth(token:String) = {
+  def permissionAuth(token:String, journey: Option[String]) = {
     TokenFromServiceAction {
-      permissionAuthAction(successfulSignInResponse, token)
+      permissionAuthAction(successfulSignInResponse, token, journey)
     }
   }
 
 
-  def permissionAuthAction(successResponse: (ReturnUrl, Seq[Cookie]) => Result, token:String) = { implicit req: RequestHeader =>
+  def permissionAuthAction(successResponse: (ReturnUrl, Seq[Cookie]) => Result, token:String, journeyOpt: Option[String]) = { implicit req: RequestHeader =>
 
-    val permissionRedirectString =  s"${config.identityProfileBaseUrl}/consent"
+    val journey = journeyOpt.getOrElse("repermission")
+    val permissionRedirectString =  s"${config.identityProfileBaseUrl}/consent?journey=${journey}"
     val returnUrl = ReturnUrl(Some(permissionRedirectString), config)
 
     val trackingData = TrackingData(req, returnUrl.toStringOpt)

--- a/conf/routes
+++ b/conf/routes
@@ -25,7 +25,7 @@ POST       /actions/signin                  com.gu.identity.frontend.controllers
 
 POST       /actions/signin/smartlock        com.gu.identity.frontend.controllers.SigninAction.signInWithSmartLock
 
-GET        /actions/signin/consents/:token  com.gu.identity.frontend.controllers.SigninAction.permissionAuth(token:String)
+GET        /actions/signin/consents/:token  com.gu.identity.frontend.controllers.SigninAction.permissionAuth(token:String, journey: Option[String])
 
 POST       /actions/register                com.gu.identity.frontend.controllers.RegisterAction.register
 


### PR DESCRIPTION
- Pass a "journey" parameter in the token login endpoint.
- This will be passed to the successful redirect to as profile.theguardian/consent?journey=[repermission, signin,...]
- link will look something like _https://profile.thegulocal.com/actions/signin/consents/25FlkCgqELR8jObFLWepB3CyMZvTbs%2Fgqk7a3cqgCPJZhjlE60z2go%%3D%3D.z15GIEVc1x6HTxqA?journey=signup_
- This determines the consent mentioned in this pr : https://github.com/guardian/frontend/pull/18407