### PR TITLE
Bump id-library version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val functionalTests = Project("functional-tests", file("functional-tests"))
 
 resolvers += "Guardian Github Releases" at "https://guardian.github.io/maven/repo-releases"
 
-val identityLibrariesVersion = "3.95"
+val identityLibrariesVersion = "3.96"
 
 libraryDependencies ++= Seq(
   "org.scalatestplus" %% "play" % "1.4.0-M3" % "test",


### PR DESCRIPTION
## What does this change?
Updates the version of `identity-library` to the one with final-ish V2 consent names that can be collected