### PR TITLE
[under flag] hide V1 consent checkboxes

### DIFF
--- a/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
+++ b/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
@@ -61,6 +61,7 @@ class ApplicationComponents(context: Context) extends BuiltInComponentsFromConte
   lazy val registerController = new RegisterAction(identityService, messagesApi, metricsLoggingActor, analyticsEventActor, frontendConfiguration, csrfConfig)
   lazy val thirdPartyTsAndCsController = new ThirdPartyTsAndCs(identityService, frontendConfiguration, messagesApi, httpErrorHandler, identityCookieDecoder.getUserDataForScGuU)
   lazy val resetPasswordController = new ResetPasswordAction(identityService, csrfConfig)
+  lazy val optInController = new OptInController()
   lazy val assets = new controllers.Assets(httpErrorHandler)
   lazy val redirects = new Redirects
 
@@ -90,7 +91,7 @@ class ApplicationComponents(context: Context) extends BuiltInComponentsFromConte
 
   override lazy val router: Router = new Routes(httpErrorHandler, applicationController, signOutController,
     thirdPartyTsAndCsController, consentController,  signinController, registerController, resetPasswordController, cspReporterController,
-    healthcheckController, digitalAssetLinksController, manifestController, assets, redirects)
+    healthcheckController, digitalAssetLinksController, manifestController, optInController, assets, redirects)
 
   val sentryLogging = new SentryLogging(frontendConfiguration) // don't make it lazy
 }

--- a/app/com/gu/identity/frontend/controllers/OptInController.scala
+++ b/app/com/gu/identity/frontend/controllers/OptInController.scala
@@ -1,0 +1,38 @@
+package com.gu.identity.frontend.controllers
+
+import play.api.mvc._
+
+import scala.concurrent.duration._
+
+/*
+ * Opting in a flag: /opt/in/name-of-the-flag
+ * Opting out a flag: /opt/out/name-of-the-flag
+ * Deleting the cookie for a given flag: /opt/delete/name-of-the-flag
+ * Delete all cookies: /opt/reset
+ */
+
+class OptInController() extends Controller {
+
+  private val lifetime: Int = 90.days.toSeconds.toInt
+
+  private def opt(feature: String, choice: String): Result = choice match {
+    case "in" => optIn(feature)
+    case "out" => optOut(feature)
+    case "delete" => optDelete(feature)
+  }
+  def optIn(cookieName: String): Result = SeeOther("/").withCookies(Cookie(cookieName, "true", maxAge = Some(lifetime)))
+  def optOut(cookieName: String): Result = SeeOther("/").discardingCookies(DiscardingCookie(cookieName))
+  def optDelete(cookieName: String): Result = SeeOther("/").discardingCookies(DiscardingCookie(cookieName))
+
+  def reset(): Action[AnyContent] = Action { implicit request =>
+    val discardingCookies = com.gu.identity.frontend.experiments.ActiveExperiments.allExperiments.map(experiment => DiscardingCookie(experiment.headerName())).toSeq
+    SeeOther("/").discardingCookies(discardingCookies:_*)
+  }
+
+  def handle(feature: String, choice: String): Action[AnyContent] = Action { implicit request =>
+    com.gu.identity.frontend.experiments.ActiveExperiments.allExperiments
+      .find(_.name == feature)
+      .map(experiment => opt(experiment.headerName(), choice))
+      .getOrElse(NotFound)
+  }
+}

--- a/app/com/gu/identity/frontend/experiments/Experiment.scala
+++ b/app/com/gu/identity/frontend/experiments/Experiment.scala
@@ -1,0 +1,19 @@
+package com.gu.identity.frontend.experiments
+
+import play.api.mvc.Request
+import play.mvc.Http
+
+abstract case class Experiment(
+  name: String,
+  description: String,
+  defaultStatus: Boolean = false
+) {
+
+  def isActive()(implicit request: Request[Any]) : Boolean = {
+    defaultStatus || request.cookies.get(headerName()).isDefined
+  }
+
+  def headerName(): String = "x-gu-identity-"+name
+
+}
+

--- a/app/com/gu/identity/frontend/experiments/Experiments.scala
+++ b/app/com/gu/identity/frontend/experiments/Experiments.scala
@@ -1,0 +1,14 @@
+package com.gu.identity.frontend.experiments
+
+object ActiveExperiments {
+  val allExperiments: Set[Experiment] = Set(
+    StopConsentCollection
+  )
+}
+
+object StopConsentCollection extends Experiment(
+  name = "stop-consent-collection",
+  description = "Users in this experiment won't get asked for V1 consents at sign up.",
+  defaultStatus = false
+)
+

--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -62,7 +62,8 @@ object ViewRenderer {
       skipConfirmation: Option[Boolean],
       clientId: Option[ClientID],
       group: Option[GroupCode],
-      email: Option[String])
+      email: Option[String],
+      shouldCollectConsents: Boolean)
       (implicit messages: Messages) = {
 
     val model = RegisterViewModel(
@@ -74,7 +75,8 @@ object ViewRenderer {
       skipConfirmation = skipConfirmation,
       clientId = clientId,
       group = group,
-      email = email)
+      email = email,
+      shouldCollectConsents = shouldCollectConsents)
 
     clientId match {
       case Some(GuardianMembersClientID) => renderViewModel("register-page-membership", model)

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -31,6 +31,9 @@ case class RegisterViewModel(
                               clientId: Option[ClientID],
                               group: Option[GroupCode],
                               email: Option[String],
+
+                              shouldCollectConsents: Boolean,
+
                               actions: RegisterActions,
                               links: RegisterLinks,
 
@@ -54,7 +57,8 @@ object RegisterViewModel {
       skipConfirmation: Option[Boolean],
       clientId: Option[ClientID],
       group: Option[GroupCode],
-      email: Option[String])
+      email: Option[String],
+      shouldCollectConsents: Boolean)
       (implicit messages: Messages): RegisterViewModel = {
 
     val layout = LayoutViewModel(configuration, activeTests, clientId, Some(returnUrl))
@@ -82,6 +86,8 @@ object RegisterViewModel {
       clientId = clientId,
       group = group,
       email = email,
+
+      shouldCollectConsents = shouldCollectConsents,
 
       actions = RegisterActions(),
       links = RegisterLinks(returnUrl, skipConfirmation, clientId),

--- a/conf/routes
+++ b/conf/routes
@@ -39,6 +39,9 @@ GET        /.well-known/assetlinks.json     com.gu.identity.frontend.controllers
 
 GET        /management/manifest             com.gu.identity.frontend.controllers.Manifest.manifest
 
+GET        /opt/:choice/:feature            com.gu.identity.frontend.controllers.OptInController.handle(feature: String, choice: String)
+GET        /opt/reset                       com.gu.identity.frontend.controllers.OptInController.reset()
+
 GET        /static/*file                    controllers.Assets.versioned(path="/public", file: Asset)
 
 GET        /robots.txt                      controllers.Assets.at(path="/public", file="robots.txt")

--- a/public/components/register-form/_form-fields.hbs
+++ b/public/components/register-form/_form-fields.hbs
@@ -75,17 +75,20 @@
   <p id="{{ id }}" class="register-form__error">{{ message }}</p>
 {{/ each }}
 
-<div class="register-form__control--gnm-marketing">
-    <input type="hidden" id="consents_0_actor" name="consents[0].actor" value="user">
-    <input type="hidden" id="consents_0_id" name="consents[0].id" value={{ registerPageText.consent.1stPartyConsentIdentifier }}>
-    <input class="register-form__checkbox--gnm-marketing" id="register_field_gnm_marketing" type="checkbox" name="consents[0].consented" value="true"/>
-    <label class="register-form__label--gnm-marketing" for="register_field_gnm_marketing">{{ registerPageText.consent.1stPartyConsentText }}</label>
-</div>
+{{#if shouldCollectConsents }}
 
-<div class="register-form__control--3rd-party-marketing">
-    <input type="hidden" id="consents_1_actor" name="consents[1].actor" value="user">
-    <input type="hidden" id="consents_1_id" name="consents[1].id" value={{ registerPageText.consent.3rdPartyConsentIdentifier }}>
-    <input class="register-form__checkbox--3rd-party-marketing" id="register_field_3rd-party_marketing" type="checkbox" name="consents[1].consented" value="true"/>
-    <label class="register-form__label--3rd-party-marketing" for="register_field_3rd-party_marketing">{{ registerPageText.consent.3rdPartyConsentText }}</label>
-</div>
+  <div class="register-form__control--gnm-marketing">
+      <input type="hidden" id="consents_0_actor" name="consents[0].actor" value="user">
+      <input type="hidden" id="consents_0_id" name="consents[0].id" value={{ registerPageText.consent.1stPartyConsentIdentifier }}>
+      <input class="register-form__checkbox--gnm-marketing" id="register_field_gnm_marketing" type="checkbox" name="consents[0].consented" value="true"/>
+      <label class="register-form__label--gnm-marketing" for="register_field_gnm_marketing">{{ registerPageText.consent.1stPartyConsentText }}</label>
+  </div>
 
+  <div class="register-form__control--3rd-party-marketing">
+      <input type="hidden" id="consents_1_actor" name="consents[1].actor" value="user">
+      <input type="hidden" id="consents_1_id" name="consents[1].id" value={{ registerPageText.consent.3rdPartyConsentIdentifier }}>
+      <input class="register-form__checkbox--3rd-party-marketing" id="register_field_3rd-party_marketing" type="checkbox" name="consents[1].consented" value="true"/>
+      <label class="register-form__label--3rd-party-marketing" for="register_field_3rd-party_marketing">{{ registerPageText.consent.3rdPartyConsentText }}</label>
+  </div>
+
+{{/if}}


### PR DESCRIPTION
Copies over a slim version of `frontend`'s experiment tooling and adds a flag to hide the V1 consent checkboxes that can be set as true for the gdpr launch

## How do i set flags?

    https://profile.thegulocal.com/opt/in/stop-consent-collection

This merely sets a cookie (`x-gu-identity-$(consentName}`) which you can also set manually

## How does the signup page look under it?
![screen shot 2017-12-11 at 14 29 24](https://user-images.githubusercontent.com/11539094/33835888-bf584dee-de7f-11e7-8255-64aff630833c.png)
