### PR TITLE
Move consent collection to prefs

### DIFF
--- a/app/com/gu/identity/frontend/configuration/Configuration.scala
+++ b/app/com/gu/identity/frontend/configuration/Configuration.scala
@@ -37,6 +37,8 @@ case class Configuration(
 
   useSnow: Boolean,
 
+  collectSignupConsents: Boolean,
+
   underlying: PlayConfiguration)
 
 
@@ -82,6 +84,8 @@ object Configuration {
 
       useSnow = false,
 
+      collectSignupConsents = true,
+
       underlying = appConfiguration
     )
   }
@@ -116,6 +120,8 @@ object Configuration {
     gaUID = "UA-78705427-123123",
 
     useSnow = false,
+
+    collectSignupConsents = true,
 
     underlying = PlayConfiguration.empty
   )

--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -2,7 +2,6 @@ package com.gu.identity.frontend.controllers
 
 import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.csrf.{CSRFAddToken, CSRFConfig, CSRFToken}
-import com.gu.identity.frontend.experiments.StopConsentCollection
 import com.gu.identity.frontend.logging.Logging
 import com.gu.identity.frontend.models.{ClientID, GroupCode, ReturnUrl}
 import com.gu.identity.frontend.mvt.MultiVariantTestAction
@@ -29,7 +28,7 @@ class Application (configuration: Configuration, val messagesApi: MessagesApi, c
     val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
     val groupCode = GroupCode(group)
     val email : Option[String] = req.getQueryString("email")
-    val shouldCollectConsents = !StopConsentCollection.isActive
+    val shouldCollectConsents = configuration.collectSignupConsents
 
     renderRegister(configuration, req.activeTests, error, csrfToken, returnUrlActual, skipConfirmation, clientIdActual, groupCode, email, shouldCollectConsents)
   }

--- a/app/com/gu/identity/frontend/experiments/Experiments.scala
+++ b/app/com/gu/identity/frontend/experiments/Experiments.scala
@@ -2,13 +2,7 @@ package com.gu.identity.frontend.experiments
 
 object ActiveExperiments {
   val allExperiments: Set[Experiment] = Set(
-    StopConsentCollection
+
   )
 }
-
-object StopConsentCollection extends Experiment(
-  name = "stop-consent-collection",
-  description = "Users in this experiment won't get asked for V1 consents at sign up.",
-  defaultStatus = false
-)
 


### PR DESCRIPTION
Changes the "show consent checkboxes on signup" switch to a config parameter so it's easier to flip it on launch day