### PR TITLE
Garnett touches

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -65,12 +65,12 @@ oauth.google=Google
 header.backtext=Back to The Guardian
 header.logo=The Guardian
 
-footer.help=help
-footer.terms=terms & conditions
-footer.contact=contact us
-footer.privacy=privacy policy
-footer.techfeedback=report technical issue
-footer.cookies=cookie policy
+footer.help=Help
+footer.terms=Terms & Conditions
+footer.contact=Contact us
+footer.privacy=Privacy Policy
+footer.techfeedback=Report technical issue
+footer.cookies=Cookie Policy
 footer.copyright=© {0} Guardian News and Media Limited or its affiliated companies. All rights reserved.
 
 # com.gu.identity.frontend.models.text.RegisterConfirmationText

--- a/public/_colors.css
+++ b/public/_colors.css
@@ -3,7 +3,7 @@
   --color-cta: #ffe500;
   --color-card: #f7f6f5;
   --color-border: #dcdcdc;
-  --color-border-hover: #ccc;
+  --color-border-hover: #a4a3a5;
 
   --color-text: #121212;
   --color-text-light: #444;

--- a/public/_colors.css
+++ b/public/_colors.css
@@ -1,10 +1,9 @@
 :root {
-  --color-page-bg: #fff;
-  --color-bg: #fff;
   --color-brand: #121212;
-  --color-brand-alt: #567681;
-  --color-card: #e7edef;
+  --color-cta: #ffe500;
+  --color-card: #f7f6f5;
   --color-border: #dcdcdc;
+  --color-border-hover: #ccc;
 
   --color-text: #121212;
   --color-text-light: #444;

--- a/public/_colors.css
+++ b/public/_colors.css
@@ -7,4 +7,6 @@
 
   --color-text: #121212;
   --color-text-light: #444;
+
+  --color-bg: var(--color-card);
 }

--- a/public/_layout.css
+++ b/public/_layout.css
@@ -7,6 +7,7 @@
 html {
   height: 100%;
   background: var(--color-card);
+  color: var(--color-text);
 }
 
 body {
@@ -113,7 +114,6 @@ body > section:last-of-type {
 .page-heading {
   @extend %font-heading-0;
   @extend %content-container;
-  color: #333;
   font-weight: normal;
   padding-top: 0.5rem;
   padding-bottom: 0 !important;
@@ -220,7 +220,6 @@ a {
   display: flex;
   flex-direction: column;
   margin-top: 3rem;
-  color: #333;
   position: relative;
 
   > section:last-of-type {

--- a/public/_layout.css
+++ b/public/_layout.css
@@ -26,21 +26,17 @@ body > section:last-of-type {
   padding: 0 1rem;
 
 
-  @media (--viewport-mobile-wide) {
+  @media (--viewport-min-mobile-wide) {
     padding: 0 2rem;
     max-width: 58rem;
   }
 
-  @media (--viewport-tablet) {
+  @media (--viewport-min-tablet) {
     max-width: 74rem;
   }
 
-  @media (--viewport-desktop) {
+  @media (--viewport-min-desktop) {
     max-width: 98rem;
-  }
-
-  @media (--viewport-wide) {
-    max-width: 114rem;
   }
 
 }
@@ -51,23 +47,8 @@ body > section:last-of-type {
 
 %content-container {
   @extend %page-block;
-
   width: 100%;
-
-  @media (--viewport-tablet) {
-    padding-right: 10rem;
-    padding-left: 10rem;
-  }
-
-  @media (--viewport-desktop) {
-    padding-right: 26rem;
-    padding-left: 18rem;
-  }
-
-  @media (--viewport-wide) {
-    padding-right: 34rem;
-    padding-left: 26rem;
-  }
+  max-width: 58rem;
 }
 
 %page-block--low-margin {

--- a/public/_layout.css
+++ b/public/_layout.css
@@ -6,7 +6,7 @@
 
 html {
   height: 100%;
-  background: var(--color-card);
+  background: var(--color-bg);
   color: var(--color-text);
 }
 
@@ -147,15 +147,6 @@ body > section:last-of-type {
   margin-top: 0.85rem;
   padding-bottom: 1.71rem;
   padding-top: 0.28rem;
-}
-
-.page-heading--with-standfirst {
-  @extend .page-heading;
-  padding-bottom: 0;
-
-  &::after {
-    display: none;
-  }
 }
 
 /**

--- a/public/_layout.css
+++ b/public/_layout.css
@@ -116,20 +116,14 @@ body > section:last-of-type {
   @extend %content-container;
   font-weight: normal;
   padding-top: 0.5rem;
-  padding-bottom: 0 !important;
+  padding-bottom: 2rem;
 
-  &::after {
-    content: "";
-    display: block;
-    width: 100%;
-    margin-top: 2.4rem;
-    background-color: var(--color-border);
-    height: 1px;
+  & + .page-standfirst {
+    margin-top: -2rem;
   }
 
   @media (--viewport-min-tablet) {
     @extend %font-heading-1;
-    padding-bottom: 3.6rem;
   }
 
 }
@@ -170,8 +164,8 @@ body > section:last-of-type {
 .page-standfirst {
   @extend %font-sub-heading-2;
   @extend %content-container;
-  padding-bottom: 2.4rem;
-  padding-top: 0.25rem;
+  padding-bottom: 2rem;
+  padding-top: 0.5rem;
   color: var(--color-text-light);
 
   a {

--- a/public/_layout.css
+++ b/public/_layout.css
@@ -6,10 +6,10 @@
 
 html {
   height: 100%;
+  background: var(--color-card);
 }
 
 body {
-  background-color: var(--color-page-bg);
   display: flex;
   flex-direction: column;
   min-height: 100%;

--- a/public/components/footer/_footer.css
+++ b/public/components/footer/_footer.css
@@ -32,10 +32,6 @@
     @mixin footer-columns 3;
   }
 
-  @media all and (min-width: 980px) {
-    @mixin footer-columns 4;
-  }
-
   margin: 2.5rem 0 0.6rem;
   padding: 0;
   list-style: none;

--- a/public/components/footer/_footer.css
+++ b/public/components/footer/_footer.css
@@ -4,7 +4,7 @@
 
 .footer {
   @extend %font-sans-serif;
-  background-color: #333;
+  background-color: var(--color-brand);
   color: #dcdcdc;
 }
 

--- a/public/components/footer/_footer.css
+++ b/public/components/footer/_footer.css
@@ -5,7 +5,7 @@
 .footer {
   @extend %font-sans-serif;
   background-color: var(--color-brand);
-  color: #dcdcdc;
+  color: color(var(--color-brand) lightness(100%));
 }
 
 .footer__inner {
@@ -14,11 +14,11 @@
 
 .footer__copyright {
   @extend %font-text-sans-0;
-
-  border-top: 1px solid #666;
+  border-top: 1px solid color(var(--color-brand) lightness(25%));
   clear: both;
   margin: 0;
   padding: 0.6rem 0 2.5rem;
+  opacity: 0.75;
 }
 
 @define-mixin footer-columns $cols: 1, $gap: 0 {
@@ -45,7 +45,6 @@
   a {
     display: inline-block;
     margin: 0 0 0.6rem;
-    text-transform: lowercase;
-    color: #dcdcdc;
+    color: currentColor;
   }
 }

--- a/public/components/footer/_footer.css
+++ b/public/components/footer/_footer.css
@@ -3,9 +3,9 @@
  */
 
 .footer {
-  @extend %font-sans-serif;
+  @extend %font-text-sans-0;
   background-color: var(--color-brand);
-  color: color(var(--color-brand) lightness(100%));
+  color: color(var(--color-brand) lightness(80%));
 }
 
 .footer__inner {
@@ -13,7 +13,6 @@
 }
 
 .footer__copyright {
-  @extend %font-text-sans-0;
   border-top: 1px solid color(var(--color-brand) lightness(25%));
   clear: both;
   margin: 0;
@@ -27,7 +26,6 @@
 }
 
 .colophon__list {
-  @extend %font-text-sans-2;
   @mixin footer-columns 2;
 
   @media all and (min-width: 600px) {
@@ -46,5 +44,9 @@
     display: inline-block;
     margin: 0 0 0.6rem;
     color: currentColor;
+
+    &:hover {
+      color: #fff;
+    }
   }
 }

--- a/public/components/form-foundations/_form_foundations.css
+++ b/public/components/form-foundations/_form_foundations.css
@@ -19,14 +19,17 @@
 /** Form prelude - the "or" text before a form **/
 
 %form__prelude {
-  @extend %font-text-1;
-  color: var(--color-text-light);
-  font-weight: bold;
+  @extend %font-text-sans-3;
   margin: 0;
-  padding: 1.2rem 0;
+  padding: 2.5rem 0;
   text-align: center;
-  color: #666;
   font-weight: 300;
+  background: linear-gradient(to bottom, transparent calc(50% - 1px), var(--color-border) calc(50% - 1px), var(--color-border) calc(50%), transparent calc(50%));
+
+  > * {
+    background: var(--color-bg);
+    padding: 0 1rem;
+  }
 }
 
 

--- a/public/components/form-foundations/_form_foundations.css
+++ b/public/components/form-foundations/_form_foundations.css
@@ -65,8 +65,7 @@
 /** Form labels **/
 
 %form__label {
-  @extend %font-text-2;
-  color: #333;
+  @extend %font-text-sans-3;
   display: block;
   font-weight: normal;
   cursor: pointer;
@@ -84,15 +83,15 @@
 /** Form buttons **/
 %form__button--submit {
   @extend %font-text-sans-3;
-  background: var(--c-form-button--submit);
+  background: var(--color-cta);
   border: 0;
   border-radius: 9999px;
-  color: white;
+  color: var(--color-brand);
   text-align: left;
   transition: 0.15s;
   padding: 0 1.8rem;
-  line-height: 3.6rem;
-  height: 3.6rem;
+  line-height: 4.2rem;
+  height: 4.2rem;
   display: block;
   display: flex;
   align-items: center;
@@ -102,11 +101,15 @@
     transition: 0.15s;
     margin-left: 2rem;
     margin-right: -1rem;
+
+    * {
+      fill: currentColor;
+    }
   }
 
   &:focus,
   &:hover {
-    background-color: color(var(--c-form-button--submit) lightness(30%));
+    background-color: color(var(--color-cta) lightness(-2.5%));
     outline: none;
 
     svg {
@@ -115,7 +118,7 @@
   }
 
   &:focus {
-    box-shadow: 0 0 2px 2px color(var(--c-form-button--submit) alpha(50%));
+    box-shadow: 0 0 2px 0 var(--color-border);
   }
 
 }
@@ -128,29 +131,28 @@
   box-sizing: border-box;
   display: block;
   background-color: #fff;
-  border: 1px solid var(--c-form-field-border);
+  border: 1px solid var(--color-border);
   color: #000;
-  padding: 7px 15px;
-  border-radius: 18px;
+  padding: 0 1.8rem;
+  line-height: 4.2rem;
+  height: 4.2rem;
+  border-radius: 99999px;
   margin: 0.2rem 0;
   width: 100%;
 
+  &:hover {
+    border-color: var(--color-border-hover);
+  }
+
   &:focus {
-    box-shadow: 0 0 2px 2px color(var(--c-form-field-border) alpha(50%) lightness(- 10%));
-    border-color: color(var(--c-form-field-border) lightness(- 10%));
+    border-color: color(var(--color-border-hover) lightness(- 10%));
     outline: none;
   }
 
   /* override default invalid field styles, only show on focus */
 
-  &:invalid {
-    border-color: var(--c-form-field-border);
-    box-shadow: none;
-
-    &:focus {
-      border-color: var(--c-form-error);
-      box-shadow: 0 0 2px 2px color(var(--c-form-error) alpha(50%) lightness(+ 20%));
-    }
+  &:invalid:focus {
+    border-color: #e00914;
   }
 }
 

--- a/public/components/form-foundations/_form_foundations.css
+++ b/public/components/form-foundations/_form_foundations.css
@@ -8,7 +8,6 @@
 /** Form colours **/
 
 :root {
-  --c-form-prelude: #333;
   --c-form-fieldset-border: #eee;
   --c-form-error: #d61d00;
   --c-form-field-border: #ddd;
@@ -21,7 +20,7 @@
 
 %form__prelude {
   @extend %font-text-1;
-  color: var(--c-form-prelude);
+  color: var(--color-text-light);
   font-weight: bold;
   margin: 0;
   padding: 1.2rem 0;
@@ -145,7 +144,7 @@
   }
 
   &:focus {
-    border-color: color(var(--color-border-hover) lightness(- 10%));
+    border-color: color(var(--color-border-hover) lightness(-20%));
     outline: none;
   }
 

--- a/public/components/form-foundations/_form_foundations.css
+++ b/public/components/form-foundations/_form_foundations.css
@@ -141,6 +141,7 @@
   border-radius: 99999px;
   margin: 0.2rem 0;
   width: 100%;
+  transition: 0.15s;
 
   &:hover {
     border-color: var(--color-border-hover);

--- a/public/components/form-foundations/arrow-right.svg
+++ b/public/components/form-foundations/arrow-right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30"><path fill="#000" d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"/></svg>

--- a/public/components/form-foundations/arrow-white-right.svg
+++ b/public/components/form-foundations/arrow-white-right.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30"><path fill="#fff" d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"/></svg>

--- a/public/components/header/_header.css
+++ b/public/components/header/_header.css
@@ -35,7 +35,6 @@
 
 .header {
   background: var(--color-card);
-  color: #333;
   border-bottom: 1px solid var(--color-border);
   padding: 5px 0;
 

--- a/public/components/header/_header.css
+++ b/public/components/header/_header.css
@@ -36,14 +36,14 @@
 .header {
   background: var(--color-card);
   color: #333;
-  border-bottom: 1px solid #aabfc6;
+  border-bottom: 1px solid var(--color-border);
   padding: 5px 0;
 
   &::after {
     @mixin multiline 4, var(--color-border), top;
     @mixin multiline-height 4;
     content: "";
-    background-color: #fff;
+    background-color: var(--color-card);
     margin-bottom: calc((5px + 1px) * -1);
     margin-top: 5px;
     width: 100%;
@@ -120,7 +120,7 @@
 
   &:hover {
     text-decoration: none;
-    color: var(--color-brand-alt);
+    opacity: 0.75;
 
     &::before {
       transform: translateY(-1px) translateX(-2px) rotate(135deg);

--- a/public/components/oauth-cta/_oauth-cta.css
+++ b/public/components/oauth-cta/_oauth-cta.css
@@ -20,6 +20,7 @@
   border-radius: 9999px;
   background-repeat: no-repeat;
   background-position: 1.6rem center;
+  transition: 0.15s;
 
   &:hover,
   &:focus {

--- a/public/components/oauth-cta/_oauth-cta.css
+++ b/public/components/oauth-cta/_oauth-cta.css
@@ -4,30 +4,27 @@
 
 .oauth {
   @extend %content-container;
-  background: var(--color-page-bg);
   padding-top: 2rem;
   padding-bottom: 0.6rem;
 }
 
 %oauth__cta {
   @extend %font-text-sans-3;
-  color: #333;
   display: block;
   text-decoration: none;
-  line-height: 3.4rem;
-  height: 3.4rem;
+  line-height: 4.2rem;
+  height: 4.2rem;
   padding: 0 1.8rem 0 4.8rem;
   margin: 0 0 1.2rem;
   border: 1px solid var(--color-border);
   border-radius: 9999px;
-  background-color: white;
   background-repeat: no-repeat;
   background-position: 1.6rem center;
 
   &:hover,
   &:focus {
     text-decoration: none;
-    border-color: color(var(--color-border) lightness(- 10%));
+    border-color: var(--color-border-hover);
   }
 }
 

--- a/public/components/register-form/_register-form.css
+++ b/public/components/register-form/_register-form.css
@@ -187,7 +187,6 @@
   right: 0;
   z-index: 1;
   padding: 2rem;
-  color: #333;
   border: 2px solid #eaeaea;
   max-width: 36rem;
 }
@@ -236,7 +235,6 @@
 .register-form__label--gnm-marketing {
   @extend %form__label--checkbox;
   @extend %font-text-sans-1;
-  color: #333;
 }
 
 
@@ -253,7 +251,6 @@
 .register-form__label--3rd-party-marketing {
   @extend %form__label--checkbox;
   @extend %font-text-sans-1;
-  color: #333;
 }
 
 
@@ -276,7 +273,6 @@
 
 .register__cta--sign-in {
   @extend %font-text-sans-1;
-  color: #333;
   margin: 1.2rem 0;
 }
 

--- a/public/components/register-form/_register-form.css
+++ b/public/components/register-form/_register-form.css
@@ -1,6 +1,5 @@
 .register-form {
   @extend %content-container;
-  background: var(--color-page-bg);
 }
 
 .register-form__prelude {
@@ -190,7 +189,6 @@
   padding: 2rem;
   color: #333;
   border: 2px solid #eaeaea;
-  background: #fff;
   max-width: 36rem;
 }
 

--- a/public/components/register-form/_register-form.hbs
+++ b/public/components/register-form/_register-form.hbs
@@ -18,7 +18,9 @@
 
   <input id="register_ga_client_id" type="hidden" name="gaClientId" value="">
 
-  <p class="register-form__prelude">{{ registerPageText.divideText }}</p>
+  <p class="register-form__prelude">
+    <span>{{ registerPageText.divideText }}</span>
+  </p>
 
   {{#each errors.otherErrors }}
     <p id="{{ id }}" class="register-form__error">{{ message }}</p>

--- a/public/components/reset-password/_reset-password.css
+++ b/public/components/reset-password/_reset-password.css
@@ -12,12 +12,6 @@
   margin-bottom: 1.5rem;
 }
 
-.reset-password__section {
-  .page-content {
-    background: var(--color-page-bg);
-  }
-}
-
 .reset-password__text {
   @extend %font-text-1;
 

--- a/public/components/signin-form/_signin-form.css
+++ b/public/components/signin-form/_signin-form.css
@@ -15,7 +15,6 @@
 
 .signin-form {
   @extend %content-container;
-  background: var(--color-page-bg);
 }
 
 .signin-form--with-errors {

--- a/public/components/signin-form/_signin-form.css
+++ b/public/components/signin-form/_signin-form.css
@@ -2,7 +2,6 @@
 .signin__prelude {
   @extend %font-text-1;
   @extend %content-container;
-  color: #333;
   background-color: #ddd;
   padding: 10px 20px;
   margin-top: 20px;
@@ -82,7 +81,6 @@
 .signin-form__label--remember-me {
   @extend %form__label--checkbox;
   @extend %font-text-sans-1;
-  color: #333;
   float: left;
 }
 
@@ -106,7 +104,6 @@
 
 .signin__cta--signup {
   @extend %font-text-sans-1;
-  color: #333;
   margin: 1.2rem 0;
 }
 
@@ -119,7 +116,6 @@
 
 .signin-form__cta--reset {
   @extend %font-text-sans-1;
-  color: #333;
   position: absolute;
   right: 0;
   margin: 0;

--- a/public/components/signin-form/_signin-form.hbs
+++ b/public/components/signin-form/_signin-form.hbs
@@ -13,7 +13,9 @@
 
   <input id="signin_ga_client_id" type="hidden" name="gaClientId" value="">
 
-  <p class="signin-form__prelude">{{signInPageText.divideText}}</p>
+  <p class="signin-form__prelude">
+    <span>{{signInPageText.divideText}}</span>
+  </p>
 
   {{#each errors }}
     <p id="{{ id }}" class="signin-form__error">{{ message }}</p>

--- a/public/components/third-party-ts-and-cs/_third-party-ts-and-cs.css
+++ b/public/components/third-party-ts-and-cs/_third-party-ts-and-cs.css
@@ -16,7 +16,6 @@
 
 .third-party-terms__features-list-item {
   @extend %font-text-1;
-  color: #333;
 }
 
 .third-party-ts-and-cs__confirm-agree {
@@ -27,7 +26,6 @@
 .third-party-terms__text {
   @extend %font-text-sans-1;
   border-top: 1px solid #eee;
-  color: #333;
   margin: 0 0 2.4rem;
   padding-top: 0.6rem;
 }

--- a/public/register-confirmation-page.hbs
+++ b/public/register-confirmation-page.hbs
@@ -2,7 +2,7 @@
 
 {{# partial "content" }}
 
-    <h1 class="page-heading--with-standfirst">{{ registerConfirmationPageText.title }}</h1>
+    <h1 class="page-heading">{{ registerConfirmationPageText.title }}</h1>
     <section class="page-standfirst">
       <p class="page-standfirst__paragraph">{{ registerConfirmationPageText.titleStandfirst }}</p>
     </section>

--- a/public/register-page.hbs
+++ b/public/register-page.hbs
@@ -1,7 +1,7 @@
 {{# partial "pageTitle" }}{{ registerPageText.pageTitle }}{{/ partial }}
 
 {{# partial "content" }}
-  <h1 class="page-heading{{# showStandfirst }}--with-standfirst{{/ showStandfirst }} commitId="{{ gitCommitId }}">{{ registerPageText.title }}</h1>
+  <h1 class="page-heading" data-commitId="{{ gitCommitId }}">{{ registerPageText.title }}</h1>
 
   {{# showStandfirst }}
     <section class="page-standfirst">

--- a/public/third-party-ts-and-cs-page.hbs
+++ b/public/third-party-ts-and-cs-page.hbs
@@ -2,7 +2,7 @@
 
 {{# partial "content" }}
 
-  <h1 class="page-heading--with-standfirst">{{tsAndCsPageText.baseText.title}}</h1>
+  <h1 class="page-heading">{{tsAndCsPageText.baseText.title}}</h1>
 
   <section class="page-standfirst">
       <p class="page-standfirst__paragraph">{{tsAndCsPageText.baseText.explanationText}}</p>


### PR DESCRIPTION
Implement a couple of visual changes to clean up the CSS + align with [Zef's mockup](https://www.figma.com/file/LkeSGB4PTbyNe6PSNCFnP7yM/Sign-in-page)

- Same height for inputs, & CTA's
- Footer now has capitalised authoritative looking links
- Fonts are less over the place in terms of sizing & classnames
- The max width is now a tad tinier so the logo doesn't go floating over the page on large screens
- The -or- thingy now has a divider running through it
- The background is grey, the cta's are yellow

## Screenshots
![screen shot 2018-01-19 at 13 58 29](https://user-images.githubusercontent.com/11539094/35154418-208a3e5e-fd22-11e7-95ed-264d256b9161.png)
![screen shot 2018-01-19 at 14 00 34](https://user-images.githubusercontent.com/11539094/35154422-22d808b2-fd22-11e7-92b8-7fdeb58e3a62.png)
