### PR TITLE
Update smart lock to avoid using deprecated features

### DIFF
--- a/public/components/register-form/register-form.js
+++ b/public/components/register-form/register-form.js
@@ -183,14 +183,16 @@ export function init() {
 }
 
 function checkForCredentials() {
-  if (navigator.credentials) {
+  if (navigator.credentials && navigator.credentials.preventSilentAccess) {
     navigator.credentials.get({
-      password: true,
+      password: true
     })
       .then(c => {
         if (c instanceof PasswordCredential) {
           const link = getElementById("sign_in_page_link");
-          window.location.replace(link.elem.href);
+          if(link && link.elem.href) {
+            window.location.replace(link.elem.href);
+          }
         }
       });
   }

--- a/public/components/register-form/register-form.js
+++ b/public/components/register-form/register-form.js
@@ -185,7 +185,7 @@ export function init() {
 function checkForCredentials() {
   if (navigator.credentials && navigator.credentials.preventSilentAccess) {
     navigator.credentials.get({
-      password: true
+      password: true,
     })
       .then(c => {
         if (c instanceof PasswordCredential) {

--- a/public/components/signin-form/signin-form.js
+++ b/public/components/signin-form/signin-form.js
@@ -73,7 +73,7 @@ class SignInFormModel {
 
   smartLockSignIn(c) {
     if (this.smartLockStatus.status) {
-      let form = new FormData(document.querySelector('#signin_form'));
+      const form = new FormData(document.querySelector('#signin_form'));
       form.set('email', c.id);
       form.set('password', c.password);
 

--- a/public/components/signin-form/signin-form.js
+++ b/public/components/signin-form/signin-form.js
@@ -8,9 +8,10 @@ const STORAGE_KEY = 'gu_id_signIn_state';
 const SMART_LOCK_STORAGE_KEY = 'gu_id_smartLock_state';
 
 class SignInFormModel {
-  constructor( formElement, emailField, gaClientIdElement ) {
+  constructor( formElement, emailField, passwordField, gaClientIdElement ) {
     this.formElement = formElement;
     this.emailFieldElement = emailField;
+    this.passwordFieldElement = passwordField;
     this.gaClientIdElement = gaClientIdElement;
     this.addBindings();
     this.smartLock();
@@ -41,26 +42,25 @@ class SignInFormModel {
 
   smartLockSetupOnSubmit() {
 
-    if (navigator.credentials) {
-      const formElement = this.formElement.elem;
-
-      const c = new PasswordCredential(formElement);
+    if (navigator.credentials && navigator.credentials.preventSilentAccess) {
+      const c = new PasswordCredential({
+        id: this.emailFieldElement.value(),
+        password: this.passwordFieldElement.value()
+      });
       this.updateSmartLockStatus(true);
       this.smartLockSignIn(c);
     }
   }
 
   smartLock() {
-    if (navigator.credentials) {
+    if (navigator.credentials && navigator.credentials.preventSilentAccess) {
       navigator.credentials.get({
           password: true,
         })
         .then(c => {
           if (c instanceof PasswordCredential) {
-            c.additionalData = new FormData(document.querySelector('#signin_form'));
-            c.idName = "email";
             this.smartLockSignIn(c);
-          };
+          }
         });
     }
   }
@@ -73,22 +73,27 @@ class SignInFormModel {
 
   smartLockSignIn(c) {
     if (this.smartLockStatus.status) {
-        fetch("/actions/signin/smartlock", {credentials: c, method: 'POST'})
-          .then(r => {
-            if (r.status == 200) {
-              this.updateSmartLockStatus(true);
-              customMetric({ name: 'SigninSuccessful', type: 'SmartLockSignin'});
-              this.storeRedirect(c);
-              return;
-            }
-            else {
-             r.json().then(j => {
-               this.updateSmartLockStatus(false);
-               window.location = j.url;
-               return;
-             });
+      let form = new FormData(document.querySelector('#signin_form'));
+      form.set('email', c.id);
+      form.set('password', c.password);
+
+      fetch("/actions/signin/smartlock", {
+        credentials: 'same-origin',
+        method: 'POST',
+        body: form
+      })
+        .then(r => {
+          if (r.status == 200) {
+            this.updateSmartLockStatus(true);
+            customMetric({ name: 'SigninSuccessful', type: 'SmartLockSignin'});
+            this.storeRedirect(c);
+          } else {
+           r.json().then(j => {
+             this.updateSmartLockStatus(false);
+             window.location = j.url;
+           });
           }
-      });
+        });
     }
   }
 
@@ -114,10 +119,11 @@ class SignInFormModel {
   static fromDocument() {
     const form = getElementById( 'signin_form' );
     const emailField = getElementById( 'signin_field_email' );
+    const passwordField = getElementById( 'signin_field_password' );
     const gaClientIdField = getElementById( 'signin_ga_client_id' );
 
     if ( form && emailField ) {
-      return new SignInFormModel( form, emailField, gaClientIdField );
+      return new SignInFormModel( form, emailField, passwordField, gaClientIdField );
     }
   }
 }


### PR DESCRIPTION
Some features of the credential management API (available in Chrome for smartlock) have being deprecated and we must migrate before Jan 23rd.

Notably I have decided to only support Chrome 60+. Users of older Chrome and other browsers will just not be able to use smartlock, normal sign in should work as usual though.  Will test this on CODE briefly and check in browser stack with older browsers.

Migration guide is here for reference: https://docs.google.com/document/d/154cO-0d5paDFfhN79GNdet1VeMUmELKhNv3YHvVSOh8/edit#heading=h.p0s1hn49u2f%E2%80%9D%20with%20%E2%80%9Chttps://docs.google.com/document/d/154cO-0d5paDFfhN79GNdet1VeMUmELKhNv3YHvVSOh8/edit%23