### PR TITLE
Make resend consent token a get endpoint

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -33,7 +33,7 @@ GET        /consent-token/:consentToken/accept          com.gu.identity.frontend
 
 GET        /consent-token/:consentToken/invalid         com.gu.identity.frontend.controllers.Application.invalidConsentToken(error: Seq[String] ?= Seq.empty, consentToken: String)
 
-POST       /consent-token/resend                        com.gu.identity.frontend.controllers.ResendConsentTokenAction.resend
+GET       /consent-token/resend                         com.gu.identity.frontend.controllers.ResendConsentTokenAction.resend
 
 GET        /consent-token/resent                        com.gu.identity.frontend.controllers.Application.resendConsentTokenSent(error: Seq[String] ?= Seq.empty)
 

--- a/public/invalid-consent-token-page.hbs
+++ b/public/invalid-consent-token-page.hbs
@@ -11,7 +11,7 @@
       {{else}}
       <p class="resend-consent__text">{{ text.description }}</p>
 
-      <form id="resend-token-form" class="resend-consent-form" action="/consent-token/resend" method="POST">
+      <form id="resend-token-form" class="resend-consent-form" action="/consent-token/resend" method="GET">
         <input type="hidden" name="token" value="{{ token }}">
         <input type="hidden" name="{{ csrfToken.fieldName }}" value="{{ csrfToken.value }}">
 


### PR DESCRIPTION
- Make the resend consentToken endpoint consistent with reset password by making it a GET endpoint.
- Consistent with endpoints setup in Fastly