### PR TITLE
Endpoint to deal with repermission tokens

### DIFF
--- a/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
+++ b/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
@@ -62,6 +62,7 @@ class ApplicationComponents(context: Context) extends BuiltInComponentsFromConte
   lazy val thirdPartyTsAndCsController = new ThirdPartyTsAndCs(identityService, frontendConfiguration, messagesApi, httpErrorHandler, identityCookieDecoder.getUserDataForScGuU)
   lazy val resetPasswordController = new ResetPasswordAction(identityService, csrfConfig)
   lazy val resendConsentTokenController = new ResendConsentTokenAction(identityService, csrfConfig)
+  lazy val repermissionController = new RepermissionController(frontendConfiguration, identityService, messagesApi, ExecutionContext.Implicits.global)
   lazy val optInController = new OptInController()
   lazy val assets = new controllers.Assets(httpErrorHandler)
   lazy val redirects = new Redirects
@@ -91,7 +92,7 @@ class ApplicationComponents(context: Context) extends BuiltInComponentsFromConte
 
 
   override lazy val router: Router = new Routes(httpErrorHandler, applicationController, signOutController,
-    thirdPartyTsAndCsController,  signinController, registerController, consentController,resendConsentTokenController, resetPasswordController, cspReporterController,
+    thirdPartyTsAndCsController,  signinController, registerController, consentController,resendConsentTokenController, repermissionController, resetPasswordController, cspReporterController,
     healthcheckController, digitalAssetLinksController, manifestController, optInController, assets, redirects)
 
   val sentryLogging = new SentryLogging(frontendConfiguration) // don't make it lazy

--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -56,6 +56,7 @@ class Application (configuration: Configuration, val messagesApi: MessagesApi, c
     renderResendConsentTokenSent(configuration, csrfToken, error)
   }
 
+  //TODO: This is a placeholder until a generic invalid-token page is made for general token use
   def invalidRepermissioningToken(error: Seq[String]) = CSRFAddToken(csrfConfig)  { req =>
     val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
     renderResendConsentTokenSent(configuration, csrfToken, error)

--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -55,4 +55,9 @@ class Application (configuration: Configuration, val messagesApi: MessagesApi, c
     val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
     renderResendConsentTokenSent(configuration, csrfToken, error)
   }
+
+  def invalidRepermissioningToken(error: Seq[String]) = CSRFAddToken(csrfConfig)  { req =>
+    val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
+    renderResendConsentTokenSent(configuration, csrfToken, error)
+  }
 }

--- a/app/com/gu/identity/frontend/controllers/RepermissionController.scala
+++ b/app/com/gu/identity/frontend/controllers/RepermissionController.scala
@@ -1,8 +1,8 @@
 package com.gu.identity.frontend.controllers
 
 import com.gu.identity.frontend.configuration.Configuration
-import com.gu.identity.frontend.errors.ErrorIDs.UnauthorizedConsentTokenErrorID
-import com.gu.identity.frontend.errors.{NotFoundError, UnauthorizedError}
+import com.gu.identity.frontend.errors.ErrorIDs.RepermissionConsentTokenErrorID
+import com.gu.identity.frontend.errors.NotFoundError
 import com.gu.identity.frontend.logging.Logging
 import com.gu.identity.frontend.services.IdentityService
 import com.gu.identity.frontend.views.ViewRenderer._
@@ -25,7 +25,7 @@ class RepermissionController(
     identityService.processRepermissionToken(repermissionToken).map {
       case Right(playCookies) =>
         Redirect("/consents").withCookies(playCookies: _*)
-      case Left(err) if err.id == UnauthorizedConsentTokenErrorID => Redirect(routes.Application.invalidConsentToken(consentToken = repermissionToken))
+      case Left(err) if err.id == RepermissionConsentTokenErrorID => renderErrorPage(configuration, NotFoundError("This link has expired."), NotFound.apply)
       case Left(_) => renderErrorPage(configuration, NotFoundError("The requested page was not found."), NotFound.apply)
     }.recover {
       case NonFatal(e) =>

--- a/app/com/gu/identity/frontend/controllers/RepermissionController.scala
+++ b/app/com/gu/identity/frontend/controllers/RepermissionController.scala
@@ -1,0 +1,35 @@
+package com.gu.identity.frontend.controllers
+
+import com.gu.identity.frontend.configuration.Configuration
+import com.gu.identity.frontend.errors.ErrorIDs.UnauthorizedConsentTokenErrorID
+import com.gu.identity.frontend.errors.{NotFoundError, UnauthorizedError}
+import com.gu.identity.frontend.logging.Logging
+import com.gu.identity.frontend.services.IdentityService
+import com.gu.identity.frontend.views.ViewRenderer._
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, Controller}
+
+import scala.concurrent.ExecutionContext
+import scala.util.control.NonFatal
+
+class RepermissionController(
+                         configuration: Configuration,
+                         identityService: IdentityService,
+                         val messagesApi: MessagesApi,
+                         implicit val executionContext: ExecutionContext
+                       ) extends Controller
+  with Logging
+  with I18nSupport {
+
+  def acceptToken(repermissionToken: String) = Action.async {
+    identityService.processRepermissionToken(repermissionToken).map {
+      case Right(playCookies) =>
+        Redirect("/consents").withCookies(playCookies: _*)
+      case Left(err) if err.id == UnauthorizedConsentTokenErrorID => Redirect(routes.Application.invalidConsentToken(consentToken = repermissionToken))
+      case Left(_) => renderErrorPage(configuration, NotFoundError("The requested page was not found."), NotFound.apply)
+    }.recover {
+      case NonFatal(e) =>
+        logger.error("Failed to process consent token", e)
+        renderErrorPage(configuration, NotFoundError("The requested page was not found."), NotFound.apply)}
+  }
+}

--- a/app/com/gu/identity/frontend/controllers/RepermissionController.scala
+++ b/app/com/gu/identity/frontend/controllers/RepermissionController.scala
@@ -1,8 +1,8 @@
 package com.gu.identity.frontend.controllers
 
 import com.gu.identity.frontend.configuration.Configuration
-import com.gu.identity.frontend.errors.ErrorIDs.RepermissionConsentTokenErrorID
-import com.gu.identity.frontend.errors.NotFoundError
+import com.gu.identity.frontend.errors.ErrorIDs.{RepermissionConsentTokenErrorID, UnauthorizedRepermissionTokenErrorID}
+import com.gu.identity.frontend.errors.{NotFoundError, RepermissionTokenUnauthorizedException}
 import com.gu.identity.frontend.logging.Logging
 import com.gu.identity.frontend.services.IdentityService
 import com.gu.identity.frontend.views.ViewRenderer._
@@ -25,7 +25,7 @@ class RepermissionController(
     identityService.processRepermissionToken(repermissionToken).map {
       case Right(playCookies) =>
         Redirect("/consents").withCookies(playCookies: _*)
-      case Left(err) if err.id == RepermissionConsentTokenErrorID => Redirect(routes.Application.resendConsentTokenSent(List("error-unexpected")))
+      case Left(err) if err.id == UnauthorizedRepermissionTokenErrorID => Redirect(routes.Application.invalidRepermissioningToken(List("error-unexpected")))
       case Left(_) => renderErrorPage(configuration, NotFoundError("The requested page was not found."), NotFound.apply)
     }.recover {
       case NonFatal(e) =>

--- a/app/com/gu/identity/frontend/controllers/RepermissionController.scala
+++ b/app/com/gu/identity/frontend/controllers/RepermissionController.scala
@@ -25,7 +25,7 @@ class RepermissionController(
     identityService.processRepermissionToken(repermissionToken).map {
       case Right(playCookies) =>
         Redirect("/consents").withCookies(playCookies: _*)
-      case Left(err) if err.id == RepermissionConsentTokenErrorID => renderErrorPage(configuration, NotFoundError("This link has expired."), NotFound.apply)
+      case Left(err) if err.id == RepermissionConsentTokenErrorID => Redirect(routes.Application.resendConsentTokenSent(List("error-unexpected")))
       case Left(_) => renderErrorPage(configuration, NotFoundError("The requested page was not found."), NotFound.apply)
     }.recover {
       case NonFatal(e) =>

--- a/app/com/gu/identity/frontend/errors/DeauthenticateAppException.scala
+++ b/app/com/gu/identity/frontend/errors/DeauthenticateAppException.scala
@@ -34,6 +34,18 @@ case class ConsentTokenUnauthorizedException(
   override val id = UnauthorizedConsentTokenErrorID
 }
 
+case class RepermissionTokenUnauthorizedException(
+ clientError: IdentityClientError
+ ) extends ServiceGatewayAppException(clientError) {
+  override val id = UnauthorizedRepermissionTokenErrorID
+}
+
+case class RepermissionTokenAppException(
+ clientError: IdentityClientError
+) extends ServiceGatewayAppException(clientError) {
+  override val id = RepermissionTokenGatewayErrorID
+}
+
 
 case class DeauthenticateServiceBadRequestException(
     clientError: IdentityClientError)

--- a/app/com/gu/identity/frontend/errors/ErrorID.scala
+++ b/app/com/gu/identity/frontend/errors/ErrorID.scala
@@ -122,6 +122,13 @@ object ErrorIDs {
     val key = "deauthenticate-error-bad-request"
   }
 
+  case object RepermissionTokenGatewayErrorID extends ErrorID {
+    val key = "repermission-token-error-gateway"
+  }
+
+  case object UnauthorizedRepermissionTokenErrorID extends ErrorID {
+    val key = "unauthorized-repermission-token-error-gateway"
+  }
 
   case object GetUserGatewayErrorID extends ErrorID {
     val key = "getuser-error-gateway"

--- a/app/com/gu/identity/frontend/errors/ErrorID.scala
+++ b/app/com/gu/identity/frontend/errors/ErrorID.scala
@@ -126,6 +126,10 @@ object ErrorIDs {
     val key = "repermission-token-error-gateway"
   }
 
+  case object RepermissionConsentTokenErrorID extends ErrorID {
+    val key = "unauthorized-consent-token-error-gateway"
+  }
+
   case object UnauthorizedRepermissionTokenErrorID extends ErrorID {
     val key = "unauthorized-repermission-token-error-gateway"
   }

--- a/app/com/gu/identity/frontend/services/IdentityServiceRequestHandler.scala
+++ b/app/com/gu/identity/frontend/services/IdentityServiceRequestHandler.scala
@@ -155,6 +155,13 @@ class IdentityServiceRequestHandler (ws: WSClient) extends IdentityClientRequest
         handleUnexpectedResponse(response)
       }
 
+    case r: UserRepermissionTokenRequest =>
+      if (response.status == 200) {
+        Right(response.json.as[AuthenticationCookiesResponse])
+      } else {
+        handleUnexpectedResponse(response)
+      }
+
     case _ => Left(Seq(ClientGatewayError("Unsupported request")))
   }
 

--- a/app/com/gu/identity/service/client/IdentityClient.scala
+++ b/app/com/gu/identity/service/client/IdentityClient.scala
@@ -99,4 +99,8 @@ class IdentityClient extends Logging {
     configuration.requestHandler.handleRequest(UseConsentTokenRequest(token, configuration))
   }
 
+  def postRepermissionToken(token: String)(implicit configuration: IdentityClientConfiguration, ec: ExecutionContext): Future[Either[IdentityClientErrors, ApiResponse]] = {
+    configuration.requestHandler.handleRequest(UserRepermissionTokenRequest(token, configuration))
+  }
+
 }

--- a/app/com/gu/identity/service/client/request/UserRepermissionTokenRequest.scala
+++ b/app/com/gu/identity/service/client/request/UserRepermissionTokenRequest.scala
@@ -9,7 +9,7 @@ case class UserRepermissionTokenRequest private(override val url: String) extend
 
 object UserRepermissionTokenRequest {
   def apply(token: String, config: IdentityClientConfiguration): UserRepermissionTokenRequest = {
-    val pathComponents = Seq("repermission")
+    val pathComponents = Seq("repermission/auth")
     new UserRepermissionTokenRequest(ApiRequest.apiEndpoint(pathComponents: _*)(config)) {
       override val headers = List(ApiRequest.apiKeyHeader(config))
       override val parameters: HttpParameters = List("scopedToken" -> token)

--- a/app/com/gu/identity/service/client/request/UserRepermissionTokenRequest.scala
+++ b/app/com/gu/identity/service/client/request/UserRepermissionTokenRequest.scala
@@ -1,0 +1,18 @@
+package com.gu.identity.service.client.request
+
+import com.gu.identity.service.client.{ApiRequest, HttpParameters, IdentityClientConfiguration, POST}
+
+case class UserRepermissionTokenRequest private(override val url: String) extends ApiRequest {
+  override val method = POST
+}
+
+
+object UserRepermissionTokenRequest {
+  def apply(token: String, config: IdentityClientConfiguration): UserRepermissionTokenRequest = {
+    val pathComponents = Seq("repermission")
+    new UserRepermissionTokenRequest(ApiRequest.apiEndpoint(pathComponents: _*)(config)) {
+      override val headers = List(ApiRequest.apiKeyHeader(config))
+      override val parameters: HttpParameters = List("scopedToken" -> token)
+    }
+  }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -37,6 +37,8 @@ GET        /consent-token/resent                        com.gu.identity.frontend
 
 GET        /repermission-token/:repermissionToken/accept com.gu.identity.frontend.controllers.RepermissionController.acceptToken(repermissionToken: String)
 
+GET        /repermission-token/invalid                  com.gu.identity.frontend.controllers.Application.invalidRepermissioningToken(error: Seq[String] ?= Seq.empty)
+
 POST       /actions/reset                               com.gu.identity.frontend.controllers.ResetPasswordAction.reset
 
 POST       /actions/csp/report                          com.gu.identity.frontend.controllers.CSPViolationReporter.cspReport

--- a/conf/routes
+++ b/conf/routes
@@ -35,6 +35,8 @@ GET       /consent-token/resend                         com.gu.identity.frontend
 
 GET        /consent-token/resent                        com.gu.identity.frontend.controllers.Application.resendConsentTokenSent(error: Seq[String] ?= Seq.empty)
 
+GET        /repermission-token/:repermissionToken/accept com.gu.identity.frontend.controllers.RepermissionController.acceptToken(repermissionToken: String)
+
 POST       /actions/reset                               com.gu.identity.frontend.controllers.ResetPasswordAction.reset
 
 POST       /actions/csp/report                          com.gu.identity.frontend.controllers.CSPViolationReporter.cspReport


### PR DESCRIPTION
- Add endpoint /repermission-token/:token/accept 
- This will make a request to Identity api /repermission with a parameter of scopeToken=[token]
- If successful Identity will return a RP cookie
- If an RP cookie is received we will redirect the user to /consents (this may change if we get a specific repermisioning end point)

Currently using error page for invalid token until we make a dedicated expired token page.

![image](https://user-images.githubusercontent.com/14179210/35633374-f920193c-06a0-11e8-8fef-c7c317d60302.png)



Related ID PR = https://github.com/guardian/identity/pull/836