### PR TITLE
Add a new valid email case to the validation regex & test

### DIFF
--- a/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
+++ b/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
@@ -1,5 +1,6 @@
 package com.gu.identity.frontend.request
 
+import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.errors._
 import com.gu.identity.frontend.models.{ClientID, GroupCode, ReturnUrl}
 import com.gu.identity.frontend.request.RequestParameters._
@@ -7,7 +8,8 @@ import play.api.data.Forms._
 import play.api.data.validation._
 import play.api.data.{Form, FormError, Mapping}
 import play.api.http.HeaderNames
-import play.api.mvc.{BodyParser, RequestHeader}
+import play.api.mvc.{BodyParser, BodyParsers, RequestHeader, Result}
+import com.gu.identity.model.{Consent, ConsentUnapply}
 
 import scala.util.matching.Regex
 

--- a/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
+++ b/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
@@ -1,6 +1,5 @@
 package com.gu.identity.frontend.request
 
-import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.errors._
 import com.gu.identity.frontend.models.{ClientID, GroupCode, ReturnUrl}
 import com.gu.identity.frontend.request.RequestParameters._
@@ -8,8 +7,7 @@ import play.api.data.Forms._
 import play.api.data.validation._
 import play.api.data.{Form, FormError, Mapping}
 import play.api.http.HeaderNames
-import play.api.mvc.{BodyParser, BodyParsers, RequestHeader, Result}
-import com.gu.identity.model.{Consent, ConsentUnapply}
+import play.api.mvc.{BodyParser, RequestHeader}
 
 import scala.util.matching.Regex
 
@@ -74,7 +72,7 @@ object RegisterActionRequestBody {
     // This regex is based on the one used by WebKit for html email validation, documented here:
     // https://html.spec.whatwg.org/#valid-e-mail-address
     // But with the additional constraint that the domain must not be dotless
-    val dotlessDomainEmailRegex: Regex = """^[a-zA-Z0-9!#$%&’*+\/=?^_`{|}~-][a-zA-Z0-9.!#$%&’*+\/=?^_`{|}~-]*[a-zA-Z0-9!#$%&’*+\/=?^_`{|}~-]@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.(?:[a-zA-Z0-9\.](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$""".r
+    val dotlessDomainEmailRegex: Regex = """^([a-zA-Z0-9!#$%&’*+\/=?^_`{|}~-]|[a-zA-Z0-9!#$%&’*+\/=?^_`{|}~-][a-zA-Z0-9.!#$%&’*+\/=?^_`{|}~-]*[a-zA-Z0-9!#$%&’*+\/=?^_`{|}~-])@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.(?:[a-zA-Z0-9\.](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$""".r
 
     def dotlessDomainEmail: Mapping[String] = email.verifying(
       Constraints.pattern(dotlessDomainEmailRegex)

--- a/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
+++ b/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
@@ -74,7 +74,7 @@ object RegisterActionRequestBody {
     // This regex is based on the one used by WebKit for html email validation, documented here:
     // https://html.spec.whatwg.org/#valid-e-mail-address
     // But with the additional constraint that the domain must not be dotless
-    val dotlessDomainEmailRegex: Regex = """^([a-zA-Z0-9!#$%&’*+\/=?^_`{|}~-]|[a-zA-Z0-9!#$%&’*+\/=?^_`{|}~-][a-zA-Z0-9.!#$%&’*+\/=?^_`{|}~-]*[a-zA-Z0-9!#$%&’*+\/=?^_`{|}~-])@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.(?:[a-zA-Z0-9\.](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$""".r
+    val dotlessDomainEmailRegex: Regex = """^([a-zA-Z0-9!#$%&’'*+\/=?^_`{|}~-]|[a-zA-Z0-9!#$%&’'*+\/=?^_`{|}~-][a-zA-Z0-9.!#$%&’'*+\/=?^_`{|}~-]*[a-zA-Z0-9!#$%&’'*+\/=?^_`{|}~-])@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.(?:[a-zA-Z0-9\.](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$""".r
 
     def dotlessDomainEmail: Mapping[String] = email.verifying(
       Constraints.pattern(dotlessDomainEmailRegex)

--- a/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
+++ b/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
@@ -38,6 +38,7 @@ class EmailValidationSpec extends FlatSpec with Matchers with AppendedClues{
       "email@domain.co.jp", //Dot in Top Level Domain name also considered valid (use co.jp as example here)
       "te44st@gmail.com",
       "f@ggg.fm",
+      "email'withapostrophe@gmail.com",
       "firstname-lastname@domain.com") //Dash in address field is valid
 
     val invalid = List(

--- a/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
+++ b/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
@@ -37,6 +37,7 @@ class EmailValidationSpec extends FlatSpec with Matchers with AppendedClues{
       "email@domain.name", //.name is valid Top Level Domain name
       "email@domain.co.jp", //Dot in Top Level Domain name also considered valid (use co.jp as example here)
       "te44st@gmail.com",
+      "f@ggg.fm",
       "firstname-lastname@domain.com") //Dash in address field is valid
 
     val invalid = List(


### PR DESCRIPTION
Userhelp received an email from a user who couldn't sign up because his email address has a single  letter for the name portion and our validation was failing this even though it is valid.

I've fixed the regex and added a new test case.