### PR TITLE
Remove smart quote from list of valid characters

### DIFF
--- a/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
+++ b/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
@@ -74,7 +74,9 @@ object RegisterActionRequestBody {
     // This regex is based on the one used by WebKit for html email validation, documented here:
     // https://html.spec.whatwg.org/#valid-e-mail-address
     // But with the additional constraint that the domain must not be dotless
-    val dotlessDomainEmailRegex: Regex = """^([a-zA-Z0-9!#$%&’'*+\/=?^_`{|}~-]|[a-zA-Z0-9!#$%&’'*+\/=?^_`{|}~-][a-zA-Z0-9.!#$%&’'*+\/=?^_`{|}~-]*[a-zA-Z0-9!#$%&’'*+\/=?^_`{|}~-])@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.(?:[a-zA-Z0-9\.](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$""".r
+    // RFC spec here: https://tools.ietf.org/html/rfc2822#section-3.4.1
+    val atext = """a-zA-Z0-9!#$%&'*+\/=?^_`{|}~-"""
+    val dotlessDomainEmailRegex: Regex = s"""^([$atext]|[$atext][.$atext]*[$atext])@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.(?:[a-zA-Z0-9\\.](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$$""".r
 
     def dotlessDomainEmail: Mapping[String] = email.verifying(
       Constraints.pattern(dotlessDomainEmailRegex)

--- a/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
+++ b/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
@@ -47,6 +47,7 @@ class EmailValidationSpec extends FlatSpec with Matchers with AppendedClues{
       "#@%^%#$@#$@#.com", //Garbage
       "@domain.com", //Missing username
       "Joe Smith <email@domain.com>", //Encoded html within email is invalid
+      "emailwith’smartquote@gmail.com", //Smart quotes are invalid
       "email.domain.com", //Missing @
       "email@domain@domain.com", //Two @ sign
       ".email@domain.com", //Leading dot in address is not allowed


### PR DESCRIPTION
'Smart quotes' are invalid within an email address name portion