### PR TITLE
link to /complete-registration

### DIFF
--- a/app/com/gu/identity/frontend/controllers/RegisterAction.scala
+++ b/app/com/gu/identity/frontend/controllers/RegisterAction.scala
@@ -62,7 +62,7 @@ class RegisterAction(
       clientId: Option[ClientID])(implicit request: Request[RegisterActionRequestBody]) = {
 
     val returnUrl = returnUrlOpt.getOrElse(ReturnUrl.defaultForClient(config, clientId))
-    val registrationConfirmUrl = config.identityProfileBaseUrl+"/verify-email?isSignupFlow=true"
+    val registrationConfirmUrl = config.identityProfileBaseUrl+"/complete-registration"
 
     (group, skipConfirmation.getOrElse(false)) match {
       case(Some(group), false) => {

--- a/functional-tests/src/test/scala/pages/RegisterConfirm.scala
+++ b/functional-tests/src/test/scala/pages/RegisterConfirm.scala
@@ -5,9 +5,7 @@ import test.util.{LoadablePage, Browser, Config}
 class RegisterConfirm extends LoadablePage with Browser {
   val url = s"${Config.baseUrl}/register/confirm?returnUrl=${Config.baseUrl}/test-return-test"
 
-  def hasLoaded(): Boolean = pageHasUrl("verify-email")
-
-  def isSignupFlow(): Boolean = pageHasUrl("isSignupFlow")
+  def isCompleteRegistration(): Boolean = pageHasUrl("complete-registration")
 
   def hasPassedReturnUrl(): Boolean = pageHasUrl("test-return-test")
 

--- a/test/com/gu/identity/frontend/controllers/RegisterActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/RegisterActionSpec.scala
@@ -128,7 +128,7 @@ class RegisterActionSpec extends PlaySpec with MockitoSugar {
       val result = call(controller.register, fakeRegisterRequest(skipConfirmation = skipConfirmation))
 
       status(result) mustEqual SEE_OTHER
-      redirectLocation(result).get must startWith (s"${config.identityProfileBaseUrl}/verify-email?isSignupFlow=true")
+      redirectLocation(result).get must startWith (s"${config.identityProfileBaseUrl}/complete-registration")
     }
 
     "have a sign in cookie when registration is successful skipConfirmation is false and no group code" in new WithControllerMockedDependencies {


### PR DESCRIPTION
Link to `/complete-registration `, A more specifically-worded endpoint that replaces `/verify-email?isSignupFlow=true`. [See #frontend/19218](https://github.com/guardian/frontend/pull/19218)