### PR TITLE
Revert "Add /email-prefs as registration return url"

### DIFF
--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -24,8 +24,7 @@ class Application (configuration: Configuration, val messagesApi: MessagesApi, c
 
   def register(error: Seq[String], returnUrl: Option[String], skipConfirmation: Option[Boolean],  clientId: Option[String], group: Option[String]) = (CSRFAddToken(csrfConfig) andThen MultiVariantTestAction) { implicit req =>
     val clientIdActual = ClientID(clientId)
-    val emailPrefsReturnUrl = Some(s"${configuration.identityProfileBaseUrl}/email-prefs")
-    val returnUrlActual = ReturnUrl(returnUrl.orElse(emailPrefsReturnUrl), req.headers.get("Referer"), configuration, clientIdActual)
+    val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"), configuration, clientIdActual)
     val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
     val groupCode = GroupCode(group)
     val email : Option[String] = req.getQueryString("email")


### PR DESCRIPTION
Reverts guardian/identity-frontend#302

This redirect is now implemented in identity-federation-api: https://github.com/guardian/identity-federation-api/pull/240