### PR TITLE
Cleaner CSS for two step signin

### DIFF
--- a/app/com/gu/identity/frontend/models/Text.scala
+++ b/app/com/gu/identity/frontend/models/Text.scala
@@ -38,7 +38,6 @@ object Text {
         "preludeFaq" -> messages("signin.prelude.faq"),
         "email" -> messages("signin.email"),
         "signInWithEmail" -> messages("signin.signInWithEmail"),
-        "divideText" -> messages("signin.dividetext"),
         "password" -> messages("signin.password"),
         "forgottenPassword" -> messages("signin.forgottenpassword"),
         "rememberMe" -> messages("signin.rememberme"),
@@ -48,7 +47,15 @@ object Text {
         "conditions" -> messages("signin.conditions"),
         "continue" -> messages("signin.continue"),
         "termsOfService" -> messages("signin.termsofservice"),
-        "privacyPolicy" -> messages("signin.privacypolicy")
+        "privacyPolicy" -> messages("signin.privacypolicy"),
+
+        "divideText" -> messages("signinTwoStep.dividetext"),
+        "welcome" -> messages("signinTwoStep.welcome"),
+        "changeEmailLink" -> messages("signinTwoStep.changeEmailLink"),
+        "signInAction" -> messages("signinTwoStep.signInAction"),
+        "continueAction" -> messages("signinTwoStep.continueAction"),
+        "emailFieldTitle" -> messages("signinTwoStep.emailFieldTitle"),
+        "passwordFieldTitle" -> messages("signinTwoStep.passwordFieldTitle")
       )
     }
   }

--- a/app/com/gu/identity/frontend/views/models/TwoStepSignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/TwoStepSignInViewModel.scala
@@ -16,7 +16,6 @@ case class TwoStepSignInViewModel private(
   twoStepSignInPageText: Map[String, String],
   terms: TermsViewModel,
 
-  showPrelude: Boolean = false,
   hasErrors: Boolean = false,
   errors: Seq[ErrorViewModel] = Seq.empty,
 
@@ -28,6 +27,7 @@ case class TwoStepSignInViewModel private(
   email:Option[String],
 
   registerUrl: String = "",
+  signinUrl: String = "",
   forgotPasswordUrl: String = "",
 
   signInTypes: Map[String, Boolean],
@@ -84,6 +84,7 @@ object TwoStepSignInViewModel {
       email = email,
 
       registerUrl = UrlBuilder(routes.Application.register(), returnUrl, skipConfirmation, clientId, group.map(_.id)),
+      signinUrl = UrlBuilder(routes.Application.twoStepSignIn(), returnUrl, skipConfirmation, clientId, group.map(_.id)),
       forgotPasswordUrl = UrlBuilder("/reset", returnUrl, skipConfirmation, clientId, group.map(_.id)),
 
       signInTypes = Map(

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -17,6 +17,14 @@ signin.noaccount=Don''t have an account?
 signin.signup=Sign up
 signin.continue=Continue
 
+signinTwoStep.welcome=Welcome
+signinTwoStep.changeEmailLink=Change email
+signinTwoStep.signInAction=Sign In
+signinTwoStep.continueAction=Continue
+signinTwoStep.emailFieldTitle=Enter your email
+signinTwoStep.passwordFieldTitle=Please enter your password
+signinTwoStep.dividetext=or
+
 # com.gu.identity.frontend.models.text.RegisterText
 register.pageTitle=Register
 register.title=Create your Guardian account

--- a/public/_form.css
+++ b/public/_form.css
@@ -1,0 +1,86 @@
+/*
+checkbox
+*/
+.form-checkbox__input {
+  @mixin formCheckbox .form-checkbox__label;
+}
+
+.form-checkbox__label {
+  @extend %form__label--checkbox;
+  font-size: inherit;
+  font-family: inherit;
+}
+
+/*
+button
+*/
+.form-button {
+  @extend %form__button--submit;
+  width: 100%;
+  box-sizing: border-box;
+  justify-content: space-between;
+  &.form-button--secondary {
+    background: transparent;
+    border: 1px solid var(--color-border);
+    &:hover, &:focus {
+      text-decoration: none;
+      border-color: var(--color-border-hover);
+    }
+  }
+}
+
+/*
+input
+*/
+.form-input {
+  @extend %form__text-field;
+}
+
+/*
+prelude
+*/
+.form-prelude {
+  @extend %form__prelude;
+}
+
+/*
+generic input wrapper
+*/
+.form-field-wrap {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.form-field-wrap + .form-field-wrap {
+  margin-top: calc(var(--size-baseline) * 4);
+}
+
+.form-field-wrap > * {
+  margin-bottom: calc(var(--size-baseline) * 2);
+}
+
+.form-field-wrap__title {
+  @extend %font-text-sans-2;
+}
+
+.form-field-wrap__footer {
+  @extend %font-text-sans-1;
+}
+
+/*
+error display
+*/
+.form-input-wrap {
+  .form-input-wrap__info {
+    @extend %font-text-sans-2;
+    margin-bottom: var(--size-baseline);
+  }
+}
+
+.form-input-wrap.form-input-wrap--error {
+  color: var(--color-error);
+  .form-input {
+    border-color: var(--color-error);
+  }
+}

--- a/public/_html.css
+++ b/public/_html.css
@@ -1,0 +1,225 @@
+@import "components/_normalise.css";
+@import "components/_grid.css";
+@import "components/_breakpoints.css";
+@import "components/_typography.css";
+@import "_colors.css";
+
+:root {
+  --size-baseline: 0.425rem;
+  --size-baseline-gutter: calc(var(--size-baseline) * 4);
+  --size-baseline-vertical: calc(var(--size-baseline) * 8);
+}
+
+html {
+  height: 100%;
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+body > section {
+  max-width: 100vw;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+body > section:last-of-type {
+  flex-grow: 1;
+}
+
+.u-h {
+  display: none !important;
+}
+
+.u-flexrow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+%page-block {
+  margin: 0 auto;
+  box-sizing: border-box;
+  padding: 0 1rem;
+
+
+  @media (--viewport-min-mobile-landscape) {
+    padding: 0 2rem;
+    max-width: 58rem;
+  }
+
+  @media (--viewport-min-tablet) {
+    max-width: 74rem;
+  }
+
+  @media (--viewport-min-desktop) {
+    max-width: 98rem;
+  }
+
+}
+
+/**
+ * Off horizontally centred container of a content width of 540px
+ */
+
+%content-container {
+  @extend %page-block;
+  width: 100%;
+  max-width: 58rem;
+}
+
+%page-block--low-margin {
+  margin: 0 1rem;
+  background-color: #fff;
+  box-sizing: border-box;
+
+  @media (--viewport-min-mobile-landscape) {
+    margin: 0 auto;
+    max-width: 44rem;
+  }
+
+  @media (--viewport-min-tablet) {
+    margin: 0 auto;
+    max-width: 46rem;
+  }
+}
+
+%content-container--with-padding {
+  @extend %page-block--low-margin;
+  padding: 0 1rem;
+  width: auto;
+
+  @media (--viewport-min-mobile-landscape) {
+    padding: 0 0.5rem;
+    width: 100%;
+  }
+
+  @media (--viewport-min-tablet) {
+    padding: 0 1rem;
+  }
+}
+
+%content-container--no-padding {
+  @extend %page-block--low-margin;
+  width: auto;
+  padding: 0;
+
+  @media (--viewport-min-mobile-landscape) {
+    width: 100%;
+  }
+}
+
+.page-heading {
+  @extend %font-heading-0;
+  @extend %content-container;
+  font-weight: normal;
+  padding-top: 0.5rem;
+  padding-bottom: 2rem;
+
+  & + .page-standfirst {
+    margin-top: -2rem;
+  }
+
+  @media (--viewport-min-tablet) {
+    @extend %font-heading-1;
+  }
+
+}
+
+/**
+ * Smaller heading
+ */
+.page-heading--small {
+  @extend %font-sub-heading-2;
+  @extend %content-container;
+  padding-bottom: 0.4rem;
+  padding-top: 1.4rem;
+}
+
+/**
+ * Second version of smaller heading
+ */
+.page-heading--small-2 {
+  @extend %font-sub-heading-3;
+  @extend %content-container;
+  margin-top: 0.85rem;
+  padding-bottom: 1.71rem;
+  padding-top: 0.28rem;
+}
+
+/**
+ * Page standfirst - section and paragraph under the page-heading
+ */
+.page-standfirst {
+  @extend %font-sub-heading-2;
+  @extend %content-container;
+  padding-bottom: 2rem;
+  padding-top: 0.5rem;
+  color: var(--color-text-light);
+
+  a {
+    @extend .link;
+    color: var(--color-text);
+    font-weight: 500;
+  }
+
+  & .page-standfirst__paragraph {
+    margin: 0;
+  }
+}
+
+@import "components/header/_header.css";
+@import "components/footer/_footer.css";
+
+.page-content {
+  @extend %content-container;
+}
+
+a {
+  color: var(--color-brand);
+  cursor: pointer;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+/** Global style for links in the body text */
+
+.link {
+  @extend a;
+  border-bottom: 1px solid #dcdcdc;
+  line-height: 1.2;
+  transition: border-color 0.15s ease-out;
+
+  &:hover,
+  &:focus {
+    text-decoration: none;
+    border-color: var(--color-brand);
+  }
+}
+
+.page__footer {
+  display: flex;
+  flex-direction: column;
+  margin-top: 3rem;
+  position: relative;
+
+  > section:last-of-type {
+    flex-grow: 1;
+  }
+
+  & > *:first-child::before {
+    content: "";
+    display: block;
+    width: 100%;
+    background-color: var(--color-border);
+    height: 1px;
+  }
+}

--- a/public/_layout.css
+++ b/public/_layout.css
@@ -1,223 +1,55 @@
-@import "components/_normalise.css";
-@import "components/_grid.css";
-@import "components/_breakpoints.css";
-@import "components/_typography.css";
-@import "_colors.css";
-
-:root {
-  --size-baseline: 0.425rem;
-  --size-baseline-gutter: calc(var(--size-baseline) * 4);
-}
-
-html {
-  height: 100%;
-  background: var(--color-bg);
-  color: var(--color-text);
-}
-
-body {
-  display: flex;
-  flex-direction: column;
-  min-height: 100%;
-}
-
-body > section {
-  max-width: 100vw;
-  max-width: 100%;
-  overflow: hidden;
-}
-
-body > section:last-of-type {
-  flex-grow: 1;
-}
-
-.u-h {
-  display: none !important;
-}
-
-.u-flexrow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-%page-block {
-  margin: 0 auto;
-  box-sizing: border-box;
-  padding: 0 1rem;
-
-
-  @media (--viewport-min-mobile-landscape) {
-    padding: 0 2rem;
-    max-width: 58rem;
-  }
-
-  @media (--viewport-min-tablet) {
-    max-width: 74rem;
-  }
-
-  @media (--viewport-min-desktop) {
-    max-width: 98rem;
-  }
-
-}
-
-/**
- * Off horizontally centred container of a content width of 540px
- */
-
-%content-container {
-  @extend %page-block;
-  width: 100%;
-  max-width: 58rem;
-}
-
-%page-block--low-margin {
-  margin: 0 1rem;
-  background-color: #fff;
-  box-sizing: border-box;
-
-  @media (--viewport-min-mobile-landscape) {
-    margin: 0 auto;
-    max-width: 44rem;
-  }
-
-  @media (--viewport-min-tablet) {
-    margin: 0 auto;
-    max-width: 46rem;
-  }
-}
-
-%content-container--with-padding {
-  @extend %page-block--low-margin;
-  padding: 0 1rem;
-  width: auto;
-
-  @media (--viewport-min-mobile-landscape) {
-    padding: 0 0.5rem;
-    width: 100%;
-  }
-
-  @media (--viewport-min-tablet) {
-    padding: 0 1rem;
-  }
-}
-
-%content-container--no-padding {
-  @extend %page-block--low-margin;
-  width: auto;
-  padding: 0;
-
-  @media (--viewport-min-mobile-landscape) {
-    width: 100%;
-  }
-}
-
-.page-heading {
-  @extend %font-heading-0;
+.layout-wrap-width {
   @extend %content-container;
+  max-width: 48em;
+}
+
+.layout-header {
+  padding: var(--size-baseline) 0 var(--size-baseline-vertical);
+  display: block;
+  &:hover {
+    text-decoration: none;
+  }
+}
+
+.layout-header__title {
+  @extend %font-heading-1;
   font-weight: normal;
-  padding-top: 0.5rem;
-  padding-bottom: 2rem;
-
-  & + .page-standfirst {
-    margin-top: -2rem;
-  }
-
-  @media (--viewport-min-tablet) {
-    @extend %font-heading-1;
-  }
-
-}
-
-/**
- * Smaller heading
- */
-.page-heading--small {
-  @extend %font-sub-heading-2;
-  @extend %content-container;
-  padding-bottom: 0.4rem;
-  padding-top: 1.4rem;
-}
-
-/**
- * Second version of smaller heading
- */
-.page-heading--small-2 {
-  @extend %font-sub-heading-3;
-  @extend %content-container;
-  margin-top: 0.85rem;
-  padding-bottom: 1.71rem;
-  padding-top: 0.28rem;
-}
-
-/**
- * Page standfirst - section and paragraph under the page-heading
- */
-.page-standfirst {
-  @extend %font-sub-heading-2;
-  @extend %content-container;
-  padding-bottom: 2rem;
-  padding-top: 0.5rem;
-  color: var(--color-text-light);
-
+  margin: 0;
+  color: currentColor;
+  text-decoration: none;
   a {
     @extend .link;
-    color: var(--color-text);
-    font-weight: 500;
+    color: currentColor;
   }
-
-  & .page-standfirst__paragraph {
-    margin: 0;
+  &.layout-header__title--standfirst {
+    @extend %font-heading-0;
+    font-weight: 300;
+    color: var(--color-text-light);
   }
-}
-
-@import "components/header/_header.css";
-@import "components/footer/_footer.css";
-
-.page-content {
-  @extend %content-container;
-}
-
-a {
-  color: var(--color-brand);
-  cursor: pointer;
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
+  &.layout-header__title--has-proxy {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    > div:nth-child(1) {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    > .layout-header__title__proxy {
+      flex: 0 0 auto;
+      margin-left: var(--size-baseline);
+    }
   }
 }
 
-/** Global style for links in the body text */
-
-.link {
-  @extend a;
-  border-bottom: 1px solid #dcdcdc;
-  transition: border-color 0.15s ease-out;
-
-  &:hover,
-  &:focus {
-    text-decoration: none;
-    border-color: var(--color-brand);
-  }
+.layout-header__title__proxy {
+  @extend %font-text-sans-1;
+  @extend .link;
+  color: currentColor;
 }
 
-.page__footer {
-  display: flex;
-  flex-direction: column;
-  margin-top: 3rem;
-  position: relative;
-
-  > section:last-of-type {
-    flex-grow: 1;
-  }
-
-  & > *:first-child::before {
-    content: "";
-    display: block;
-    width: 100%;
-    background-color: var(--color-border);
-    height: 1px;
-  }
+.layout-section {
+  margin-top: var(--size-baseline-vertical);
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--size-baseline);
 }

--- a/public/components/terms/_terms-inline.hbs
+++ b/public/components/terms/_terms-inline.hbs
@@ -1,0 +1,11 @@
+<p class="terms__text">
+  {{ terms.conditionsText }}
+  <a class="terms__link" href="{{ terms.termsOfServiceUrl }}">{{ terms.termsOfServiceText }}</a> &amp;
+  <a class="terms__link" href="{{ terms.privacyPolicyUrl }}">{{ terms.privacyPolicyText }}</a>
+  {{#if terms.extendedConditionsText}}
+    {{terms.extendedConditionsText}}
+    <a class="terms__link" href="{{ terms.extendedTermsOfServiceUrl }}">{{ terms.termsOfServiceText }}</a> &amp;
+    <a class="terms__link" href="{{ terms.extendedPrivacyPolicyUrl }}">{{ terms.privacyPolicyText }}</a>
+  {{/if}}
+  .
+</p>

--- a/public/components/terms/_terms.hbs
+++ b/public/components/terms/_terms.hbs
@@ -1,12 +1,3 @@
 <section class="terms">
-  <p class="terms__text">
-    {{ terms.conditionsText }}
-    <a class="terms__link" href="{{ terms.termsOfServiceUrl }}">{{ terms.termsOfServiceText }}</a> &amp;
-    <a class="terms__link" href="{{ terms.privacyPolicyUrl }}">{{ terms.privacyPolicyText }}</a>
-    {{#if terms.extendedConditionsText}}
-      {{terms.extendedConditionsText}}
-      <a class="terms__link" href="{{ terms.extendedTermsOfServiceUrl }}">{{ terms.termsOfServiceText }}</a> &amp;
-      <a class="terms__link" href="{{ terms.extendedPrivacyPolicyUrl }}">{{ terms.privacyPolicyText }}</a>
-    {{/if}}
-  .</p>
+  {{> components/terms/_terms-inline }}
 </section>

--- a/public/components/two-step-signin/_two-step-signin.css
+++ b/public/components/two-step-signin/_two-step-signin.css
@@ -1,34 +1,5 @@
-.two-step-signin-container {
-  @extend %content-container;
-}
-
-.two-step-signin-button {
-  @extend %form__button--submit;
-  width: 100%;
-  box-sizing: border-box;
-  justify-content: space-between;
-  &.two-step-signin-button--secondary {
-    background: transparent;
-    border: 1px solid var(--color-border);
-    &:hover, &:focus {
-      text-decoration: none;
-      border-color: var(--color-border-hover);
-    }
-  }
-}
-
-.two-step-signin-checkbox__input {
-  @mixin formCheckbox .two-step-signin-checkbox__label;
-}
-
-.two-step-signin-checkbox__label {
-  @extend %form__label--checkbox;
-  font-size: inherit;
-  font-family: inherit;
-}
-
 .two-step-signin-form_section {
-  padding: 0.875rem 0 0;
+  padding: calc(var(--size-baseline) * 2) 0 0;
   margin-top: 3rem;
   position: relative;
   &::before {
@@ -39,55 +10,6 @@
     left: -100%;
     right: -100%;
     top: 0;
-  }
-}
-
-.two-step-signin-field-wrap {
-  margin: 0;
-  padding: 0;
-  border: 0;
-}
-
-.two-step-signin-field-wrap + .two-step-signin-field-wrap {
-  margin-top: calc(var(--size-baseline) * 4);
-}
-
-.two-step-signin-field-wrap > * {
-  margin-bottom: calc(var(--size-baseline) * 2);
-}
-.two-step-signin-field-wrap__title {
-  @extend %font-text-sans-2;
-}
-
-.two-step-signin-field-wrap__footer {
-  @extend %font-text-sans-1;
-}
-
-.two-step-signin-field-wrap__field {
-  @media (--viewport-min-mobile-landscape) {
-    @supports(height: calc(2px + 2px)) {
-      margin-left: calc(var(--size-baseline-gutter) * -1);
-      margin-right: calc(var(--size-baseline-gutter) * -1);
-      width: calc(100% + calc(var(--size-baseline-gutter) * 2));
-    }
-  }
-}
-
-.two-step-signin-input {
-  @extend %form__text-field;
-}
-
-.two-step-signin-input-wrap {
-  .two-step-signin-input-wrap__info {
-    @extend %font-text-sans-2;
-    margin-bottom: var(--size-baseline);
-  }
-}
-
-.two-step-signin-input-wrap.two-step-signin-input-wrap--error {
-  color: var(--color-error);
-  .two-step-signin-input {
-    border-color: var(--color-error);
   }
 }
 

--- a/public/components/two-step-signin/two-step-signin-email.hbs
+++ b/public/components/two-step-signin/two-step-signin-email.hbs
@@ -1,17 +1,17 @@
 <form class="two-step-signin-form" action="{{ actions.signInWithEmail }}" method="POST">
   {{> components/two-step-signin/_helpers }}
-  <fieldset class="two-step-signin-field-wrap">
-    <div class="two-step-signin-field-wrap__field">
+  <fieldset class="form-field-wrap">
+    <div class="form-field-wrap__field">
       {{> components/oauth-cta/_oauth-cta-content }}
     </div>
   </fieldset>
 
-  <p class="signin-form__prelude"> <span>or</span> </p>
+  <p class="form-prelude"> <span>{{twoStepSignInPageText.divideText}}</span> </p>
 
-  <fieldset class="two-step-signin-field-wrap">
-    <label class="two-step-signin-field-wrap__title">{{twoStepSignInPageText.email}}</label>
-    <input class="two-step-signin-input two-step-signin-field-wrap__field" type="email" name="email" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{email}}" />
-    <input class="two-step-signin-input two-step-signin-field-wrap__field u-h" type="password" name="password" autocomplete="password" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{password}}" />
-    <button class="two-step-signin-button two-step-signin-field-wrap__field" type="submit">Continue {{> components/icon/arrow-inline }}</button>
+  <fieldset class="form-field-wrap">
+    <label class="form-field-wrap__title">{{twoStepSignInPageText.emailFieldTitle}}</label>
+    <input class="form-input form-field-wrap__field" type="email" name="email" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{email}}" />
+    <input class="form-input form-field-wrap__field u-h" type="password" name="password" autocomplete="password" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{password}}" />
+    <button class="form-button form-field-wrap__field" type="submit">{{twoStepSignInPageText.continueAction}} {{> components/icon/arrow-inline }}</button>
   </fieldset>
 </form>

--- a/public/components/two-step-signin/two-step-signin-existing.hbs
+++ b/public/components/two-step-signin/two-step-signin-existing.hbs
@@ -2,27 +2,20 @@
 
     {{> components/two-step-signin/_helpers }}
 
-    <div class="two-step-signin-field-wrap">
+    <div class="form-field-wrap">
       <input class="u-h" type="email" name="email" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{email}}" />
-      <label class="two-step-signin-field-wrap__title" for="signin_field_email">Please enter your password</label>
-      <input class="two-step-signin-input two-step-signin-field-wrap__field" type="password" name="password" autocomplete="password" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{password}}" />
-      <div class="u-flexrow two-step-signin-field-wrap__footer">
-        <label class="two-step-signin-checkbox">
-          <input class="two-step-signin-checkbox__input" type="checkbox" name="rememberMe" checked="checked" value="true"/>
-          <span class="two-step-signin-checkbox__label">{{twoStepSignInPageText.rememberMe}}</span>
+      <label class="form-field-wrap__title" for="signin_field_email">{{twoStepSignInPageText.passwordFieldTitle}}</label>
+      <input class="form-input form-field-wrap__field" type="password" name="password" autocomplete="password" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{password}}" />
+      <div class="u-flexrow form-field-wrap__footer">
+        <label class="form-checkbox">
+          <input class="form-checkbox__input" type="checkbox" name="rememberMe" checked="checked" value="true"/>
+          <span class="form-checkbox__label">{{twoStepSignInPageText.rememberMe}}</span>
         </label>
         <a class="link" href="{{forgotPasswordUrl}}">{{twoStepSignInPageText.forgottenPassword}}</a>
       </div>
     </div>
-    <div class="two-step-signin-field-wrap">
-      <button class="two-step-signin-button two-step-signin-field-wrap__field" type="submit">Sign In {{> components/icon/arrow-inline }}</button>
+    <div class="form-field-wrap">
+      <button class="form-button form-field-wrap__field" type="submit">{{twoStepSignInPageText.signInAction}} {{> components/icon/arrow-inline }}</button>
     </div>
-
-    <aside class="two-step-signin-form_section">
-      <div class="two-step-signin-field-wrap">
-        <p class="two-step-signin-field-wrap__title">You are signing in as {{email}}</p>
-        <a href="/signin" class="two-step-signin-button two-step-signin-button--secondary two-step-signin-field-wrap__field" type>Change email address {{> components/icon/arrow-inline }}</a>
-      </div>
-    </aside>
 
 </form>

--- a/public/main.css
+++ b/public/main.css
@@ -1,5 +1,10 @@
-@import "_layout.css";
+@import "_html.css";
 @import "components/form-foundations/_form_foundations.css";
+
+/** Layout **/
+
+@import "_layout.css";
+@import "_form.css";
 
 /** Error pages **/
 

--- a/public/two-step-signin-choices-page.hbs
+++ b/public/two-step-signin-choices-page.hbs
@@ -4,7 +4,7 @@
 
   <section class="layout-wrap-width">
 
-    <a class="layout-header" href="{{signInUrl}}" >
+    <a class="layout-header" href="{{signinUrl}}" >
       <h1 class="layout-header__title">{{ twoStepSignInPageText.welcome }}</h1>
       <div class="layout-header__title layout-header__title--has-proxy layout-header__title--standfirst">
         <div>{{email}}</div>

--- a/public/two-step-signin-choices-page.hbs
+++ b/public/two-step-signin-choices-page.hbs
@@ -2,35 +2,33 @@
 
 {{# partial "content" }}
 
-  {{#showPrelude}}
-    <div class="signin__prelude ">
-      <p>{{twoStepSignInPageText.prelude}}</p>
-      <p> {{twoStepSignInPageText.preludeMoreInfo}} <a href="https://www.theguardian.com/help/identity-faq"> {{twoStepSignInPageText.preludeFaq}} </a>.</p>
-    </div>
-  {{/showPrelude}}
+  <section class="layout-wrap-width">
 
-  <h1 class="page-heading">{{ twoStepSignInPageText.title }}</h1>
+    <a class="layout-header" href="{{signInUrl}}" >
+      <h1 class="layout-header__title">{{ twoStepSignInPageText.welcome }}</h1>
+      <div class="layout-header__title layout-header__title--has-proxy layout-header__title--standfirst">
+        <div>{{email}}</div>
+        <div class="layout-header__title__proxy">{{twoStepSignInPageText.changeEmailLink}}</div>
+      </div>
+    </a>
 
-  <section class="page-standfirst">
-    <p class="page-standfirst__paragraph">{{twoStepSignInPageText.noAccount}} <a href="{{registerUrl}}" >{{twoStepSignInPageText.signUp}}</a>.</p>
+    <section class="two-step-signin-container">
+      {{#signInTypes.isExisting}}
+        {{> components/two-step-signin/two-step-signin-existing }}
+      {{/signInTypes.isExisting}}
+      {{#signInTypes.isNew}}
+        <h1 class="page-heading">Register for The Guardian</h1>
+      {{/signInTypes.isNew}}
+      {{#signInTypes.isGuest}}
+        <h1 class="page-heading">Set a password</h1>
+      {{/signInTypes.isGuest}}
+    </section>
+
+    <section class="layout-section">
+      {{> components/terms/_terms-inline }}
+    </section>
+
   </section>
-
-  <section class="two-step-signin-container">
-    {{#signInTypes.isExisting}}
-      {{> components/two-step-signin/two-step-signin-existing }}
-    {{/signInTypes.isExisting}}
-    {{#signInTypes.isNew}}
-      <h1 class="page-heading">Register for The Guardian</h1>
-    {{/signInTypes.isNew}}
-    {{#signInTypes.isGuest}}
-      <h1 class="page-heading">Set a password</h1>
-    {{/signInTypes.isGuest}}
-  </section>
-
-  <section class="page__footer">
-    {{> components/terms/_terms }}
-  </section>
-
 {{/partial}}
 
 {{> layout}}

--- a/public/two-step-signin-start-page.hbs
+++ b/public/two-step-signin-start-page.hbs
@@ -2,25 +2,21 @@
 
 {{# partial "content" }}
 
-  {{#showPrelude}}
-    <div class="signin__prelude">
-      <p>{{twoStepSignInPageText.prelude}}</p>
-      <p> {{twoStepSignInPageText.preludeMoreInfo}} <a href="https://www.theguardian.com/help/identity-faq"> {{twoStepSignInPageText.preludeFaq}} </a>.</p>
-    </div>
-  {{/showPrelude}}
+  <section class="layout-wrap-width">
 
-  <h1 class="page-heading">{{ twoStepSignInPageText.title }}</h1>
+    <section class="layout-header">
+      <h1 class="layout-header__title">{{ twoStepSignInPageText.title }}</h1>
+      <p class="layout-header__title layout-header__title--standfirst">{{twoStepSignInPageText.noAccount}} <a href="{{registerUrl}}" >{{twoStepSignInPageText.signUp}}</a>.</p>
+    </section>
 
-  <section class="page-standfirst">
-    <p class="page-standfirst__paragraph">{{twoStepSignInPageText.noAccount}} <a href="{{registerUrl}}" >{{twoStepSignInPageText.signUp}}</a>.</p>
-  </section>
+    <section class="two-step-signin-container">
+      {{> components/two-step-signin/two-step-signin-email }}
+    </section>
 
-  <section class="two-step-signin-container">
-    {{> components/two-step-signin/two-step-signin-email }}
-  </section>
+    <section class="layout-section">
+      {{> components/terms/_terms-inline }}
+    </section>
 
-  <section class="page__footer">
-    {{> components/terms/_terms }}
   </section>
 
 {{/partial}}


### PR DESCRIPTION
While we are here I'm taking this opportunity to clean up the css and normalize it a bit, having global classes we can work with without needing extra boilerplate, so stuff like `.signin-page-remember-me__checkbox` becomes `.form-checkbox` and so on (example. not an actual change).

The new format also better acknowledges the reality of this design. The previous one had a quite complex wrapper structure since it had side borders and coloured sections while this one is rather plain.

This only applies to the css on the new two step signin but the eventual goal is to move all css (meaning the signup page if there's still a signup page; and third party terms) to this format after we assess what the rest of pages are and how they fit in this new flow.