### PR TITLE
Add templates for all 3 signin types

### DIFF
--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -48,7 +48,7 @@ class Application (configuration: Configuration, val messagesApi: MessagesApi, c
     val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"), configuration, clientIdActual)
     val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
     val groupCode = GroupCode(group)
-    val email : Option[String] = req.getQueryString("email").orElse(req.cookies.get("GU_SIGNIN_EMAIL").map(_.value))
+    val email : Option[String] = req.cookies.get("GU_SIGNIN_EMAIL").map(_.value)
     val shouldCollectConsents = configuration.collectSignupConsents
     val shouldCollectV2Consents = configuration.collectV2Consents
 

--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -58,8 +58,9 @@ class Application (configuration: Configuration, val messagesApi: MessagesApi, c
   def reset(error: Seq[String], clientId: Option[String]) = CSRFAddToken(csrfConfig) { req =>
     val clientIdOpt = ClientID(clientId)
     val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
+    val email : Option[String] = req.cookies.get("GU_SIGNIN_EMAIL").map(_.value)
 
-    renderResetPassword(configuration, error, csrfToken, clientIdOpt)
+    renderResetPassword(configuration, error, csrfToken, email, clientIdOpt)
   }
 
   def resetPasswordEmailSent(clientId: Option[String]) = Action {

--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -58,9 +58,8 @@ class Application (configuration: Configuration, val messagesApi: MessagesApi, c
   def reset(error: Seq[String], clientId: Option[String]) = CSRFAddToken(csrfConfig) { req =>
     val clientIdOpt = ClientID(clientId)
     val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
-    val email : Option[String] = req.cookies.get("GU_SIGNIN_EMAIL").map(_.value)
 
-    renderResetPassword(configuration, error, csrfToken, email, clientIdOpt)
+    renderResetPassword(configuration, error, csrfToken, clientIdOpt)
   }
 
   def resetPasswordEmailSent(clientId: Option[String]) = Action {

--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -48,7 +48,7 @@ class Application (configuration: Configuration, val messagesApi: MessagesApi, c
     val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"), configuration, clientIdActual)
     val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
     val groupCode = GroupCode(group)
-    val email : Option[String] = req.getQueryString("email")
+    val email : Option[String] = req.getQueryString("email").orElse(req.cookies.get("GU_SIGNIN_EMAIL").map(_.value))
     val shouldCollectConsents = configuration.collectSignupConsents
     val shouldCollectV2Consents = configuration.collectV2Consents
 

--- a/app/com/gu/identity/frontend/models/Text.scala
+++ b/app/com/gu/identity/frontend/models/Text.scala
@@ -49,12 +49,16 @@ object Text {
         "termsOfService" -> messages("signin.termsofservice"),
         "privacyPolicy" -> messages("signin.privacypolicy"),
 
+        "emailFieldTitle" -> messages("signinTwoStep.emailFieldTitle"),
+        "setPasswordTitle" -> messages("signinTwoStep.setPasswordTitle"),
+        "setPasswordAction" -> messages("signinTwoStep.setPasswordAction"),
         "divideText" -> messages("signinTwoStep.dividetext"),
         "welcome" -> messages("signinTwoStep.welcome"),
         "changeEmailLink" -> messages("signinTwoStep.changeEmailLink"),
         "signInAction" -> messages("signinTwoStep.signInAction"),
         "continueAction" -> messages("signinTwoStep.continueAction"),
-        "emailFieldTitle" -> messages("signinTwoStep.emailFieldTitle"),
+        "unknownEmailTitle" -> messages("signinTwoStep.unknownEmailTitle"),
+        "registerAction" -> messages("signinTwoStep.registerAction"),
         "passwordFieldTitle" -> messages("signinTwoStep.passwordFieldTitle")
       )
     }

--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -151,14 +151,12 @@ object ViewRenderer {
     configuration: Configuration,
     errorIds: Seq[String],
     csrfToken: Option[CSRFToken],
-    email: Option[String],
     clientId: Option[ClientID])
     (implicit messages: Messages) = {
     val model = ResetPasswordViewModel(
       configuration = configuration,
       errors = errorIds.map(ErrorViewModel.apply),
       csrfToken = csrfToken,
-      email = email,
       clientId = clientId
     )
     renderViewModel("reset-password-page", model)

--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -151,12 +151,14 @@ object ViewRenderer {
     configuration: Configuration,
     errorIds: Seq[String],
     csrfToken: Option[CSRFToken],
+    email: Option[String],
     clientId: Option[ClientID])
     (implicit messages: Messages) = {
     val model = ResetPasswordViewModel(
       configuration = configuration,
       errors = errorIds.map(ErrorViewModel.apply),
       csrfToken = csrfToken,
+      email = email,
       clientId = clientId
     )
     renderViewModel("reset-password-page", model)

--- a/app/com/gu/identity/frontend/views/models/ResetPasswordViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/ResetPasswordViewModel.scala
@@ -15,6 +15,7 @@ case class ResetPasswordViewModel private(
     actions: Map[String, String] = Map("reset" -> routes.ResetPasswordAction.reset().url),
     errors: Seq[ErrorViewModel] = Seq.empty,
     csrfToken: Option[CSRFToken],
+    email: Option[String],
     resources: Seq[PageResource with Product],
     indirectResources: Seq[PageResource with Product]
   )
@@ -29,6 +30,7 @@ object ResetPasswordViewModel {
     configuration: Configuration,
     errors: Seq[ErrorViewModel],
     csrfToken: Option[CSRFToken],
+    email: Option[String],
     clientId: Option[ClientID])
     (implicit messages: Messages): ResetPasswordViewModel = {
     val layout = LayoutViewModel(configuration, clientId = clientId, returnUrl = None)
@@ -38,6 +40,7 @@ object ResetPasswordViewModel {
       resetPasswordText = ResetPasswordText(),
       errors = errors,
       csrfToken = csrfToken,
+      email = email,
       resources = layout.resources,
       indirectResources = layout.indirectResources
     )

--- a/app/com/gu/identity/frontend/views/models/ResetPasswordViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/ResetPasswordViewModel.scala
@@ -15,7 +15,6 @@ case class ResetPasswordViewModel private(
     actions: Map[String, String] = Map("reset" -> routes.ResetPasswordAction.reset().url),
     errors: Seq[ErrorViewModel] = Seq.empty,
     csrfToken: Option[CSRFToken],
-    email: Option[String],
     resources: Seq[PageResource with Product],
     indirectResources: Seq[PageResource with Product]
   )
@@ -30,7 +29,6 @@ object ResetPasswordViewModel {
     configuration: Configuration,
     errors: Seq[ErrorViewModel],
     csrfToken: Option[CSRFToken],
-    email: Option[String],
     clientId: Option[ClientID])
     (implicit messages: Messages): ResetPasswordViewModel = {
     val layout = LayoutViewModel(configuration, clientId = clientId, returnUrl = None)
@@ -40,7 +38,6 @@ object ResetPasswordViewModel {
       resetPasswordText = ResetPasswordText(),
       errors = errors,
       csrfToken = csrfToken,
-      email = email,
       resources = layout.resources,
       indirectResources = layout.indirectResources
     )

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -24,6 +24,10 @@ signinTwoStep.continueAction=Continue
 signinTwoStep.emailFieldTitle=Enter your email
 signinTwoStep.passwordFieldTitle=Please enter your password
 signinTwoStep.dividetext=or
+signinTwoStep.unknownEmailTitle=We couldn''t find that email address in our records. Did you type it correctly? If this is your first time signing in to The Guardian you might need to create an account.
+signinTwoStep.registerAction=Create an account
+signinTwoStep.setPasswordTitle=To continue we need to confirm this is you. Click ''Set a password'' and we''ll send you an email to your registered address to confirm your identity.
+signinTwoStep.setPasswordAction=Set a password
 
 # com.gu.identity.frontend.models.text.RegisterText
 register.pageTitle=Register

--- a/public/_form.css
+++ b/public/_form.css
@@ -60,6 +60,10 @@ generic input wrapper
   margin-bottom: calc(var(--size-baseline) * 2);
 }
 
+.form-field-wrap > label {
+  display: block;
+}
+
 .form-field-wrap__title {
   @extend %font-text-sans-2;
 }

--- a/public/components/two-step-signin/scriptFile.scala
+++ b/public/components/two-step-signin/scriptFile.scala
@@ -1,0 +1,21 @@
+<form class="two-step-signin-form" method="POST" action="{{ actions.signInWithEmailAndPassword }}">
+
+    {{> components/two-step-signin/_helpers }}
+
+    <div class="form-field-wrap">
+      <input class="u-h" type="email" name="email" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{email}}" />
+      <label class="form-field-wrap__title" for="signin_field_email">{{twoStepSignInPageText.passwordFieldTitle}}</label>
+      <input class="form-input form-field-wrap__field" type="password" name="password" autocomplete="password" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{password}}" />
+      <div class="u-flexrow form-field-wrap__footer">
+        <label class="form-checkbox">
+          <input class="form-checkbox__input" type="checkbox" name="rememberMe" checked="checked" value="true"/>
+          <span class="form-checkbox__label">{{twoStepSignInPageText.rememberMe}}</span>
+        </label>
+        <a class="link" href="{{forgotPasswordUrl}}">{{twoStepSignInPageText.forgottenPassword}}</a>
+      </div>
+    </div>
+    <div class="form-field-wrap">
+      <a class="form-button form-field-wrap__field" type="submit">{{twoStepSignInPageText.changeEmail}} {{> components/icon/arrow-inline }}</a>
+    </div>
+
+</form>

--- a/public/components/two-step-signin/two-step-signin-guest.hbs
+++ b/public/components/two-step-signin/two-step-signin-guest.hbs
@@ -1,0 +1,10 @@
+<form class="two-step-signin-form" method="POST" action="{{ actions.signInWithEmailAndPassword }}">
+
+  {{> components/two-step-signin/_helpers }}
+
+  <div class="form-field-wrap">
+    <label class="form-field-wrap__title" for="signin_field_email">{{twoStepSignInPageText.setPasswordTitle}}</label>
+    <a href="{{forgotPasswordUrl}}" class="form-button form-field-wrap__field">{{twoStepSignInPageText.setPasswordAction}} {{> components/icon/arrow-inline }}</a>
+  </div>
+
+</form>

--- a/public/components/two-step-signin/two-step-signin-new.hbs
+++ b/public/components/two-step-signin/two-step-signin-new.hbs
@@ -1,0 +1,16 @@
+<form class="two-step-signin-form" method="POST" action="{{ actions.signInWithEmailAndPassword }}">
+
+  {{> components/two-step-signin/_helpers }}
+
+  <div class="form-field-wrap">
+    <label class="form-field-wrap__title" for="signin_field_email">{{twoStepSignInPageText.unknownEmailTitle}}</label>
+    <a href="{{registerUrl}}" class="form-button form-field-wrap__field">{{twoStepSignInPageText.registerAction}} {{> components/icon/arrow-inline }}</a>
+  </div>
+
+  <div class="layout-section">
+    <div class="form-field-wrap">
+      <a href="{{signinUrl}}" class="form-button form-button--secondary form-field-wrap__field" type="submit">{{twoStepSignInPageText.changeEmailLink}} {{> components/icon/arrow-inline }}</a>
+    </div>
+  </div>
+
+</form>

--- a/public/reset-password-page.hbs
+++ b/public/reset-password-page.hbs
@@ -20,7 +20,7 @@
 
           <div class="reset-password-form__control--email">
             <label class="reset-password-form__label--email" for="reset-password_field_email">{{resetPasswordText.emailAddressField }}</label>
-            <input class="reset-password-form__field--email" id="reset-password_field_email" type="email" name="email" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{email}}" />
+            <input class="reset-password-form__field--email" id="reset-password_field_email" type="email" name="email" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" />
           </div>
 
           <div class="reset-password-form__control--submit">

--- a/public/reset-password-page.hbs
+++ b/public/reset-password-page.hbs
@@ -20,7 +20,7 @@
 
           <div class="reset-password-form__control--email">
             <label class="reset-password-form__label--email" for="reset-password_field_email">{{resetPasswordText.emailAddressField }}</label>
-            <input class="reset-password-form__field--email" id="reset-password_field_email" type="email" name="email" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" />
+            <input class="reset-password-form__field--email" id="reset-password_field_email" type="email" name="email" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{email}}" />
           </div>
 
           <div class="reset-password-form__control--submit">

--- a/public/two-step-signin-choices-page.hbs
+++ b/public/two-step-signin-choices-page.hbs
@@ -17,10 +17,10 @@
         {{> components/two-step-signin/two-step-signin-existing }}
       {{/signInTypes.isExisting}}
       {{#signInTypes.isNew}}
-        <h1 class="page-heading">Register for The Guardian</h1>
+        {{> components/two-step-signin/two-step-signin-new }}
       {{/signInTypes.isNew}}
       {{#signInTypes.isGuest}}
-        <h1 class="page-heading">Set a password</h1>
+        {{> components/two-step-signin/two-step-signin-guest }}
       {{/signInTypes.isGuest}}
     </section>
 


### PR DESCRIPTION
Makes all three two step sign in pages actually work. The flows and messaging are still somewhat clunky for this PR but this brings it closer to a working prototype.

## Screenshots

### Existing user (email & pwd on file)
![screen shot 2018-03-07 at 6 32 40 pm](https://user-images.githubusercontent.com/11539094/37110945-3fa2ab62-2236-11e8-8164-149c90fccd40.png)

### Guest user (email on file but has no pwd. Users from newsletters and such)
![screen shot 2018-03-07 at 6 32 56 pm](https://user-images.githubusercontent.com/11539094/37110924-319cf310-2236-11e8-81e1-73de0e56e548.png)

### New user (email not on file)
![screen shot 2018-03-07 at 6 33 03 pm](https://user-images.githubusercontent.com/11539094/37110927-33b9801e-2236-11e8-950d-703119d655f2.png)