### PR TITLE
Make npm optionally run sbt too

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If this is the first time using the application you will need to pull down the c
 
 After that, to run the application in development mode and watch for changes you can use
 
-    . watch-frontend.sh
+    npm run watch
 
 This command will automatically pull down all dependencies for the Scala app, and run the client side asset packing and sbt in parallel in the background.
 

--- a/README.md
+++ b/README.md
@@ -32,17 +32,22 @@ Requires:
  - [JDK 8](http://openjdk.java.net)
  - [sbt](http://www.scala-sbt.org)
  - [Node.js](https://nodejs.org) - version is specified by [.nvmrc](.nvmrc), execute [`$ nvm use`](https://github.com/creationix/nvm#nvmrc) to use it
-
-To run the application in development mode use:
-
-    ./start-frontend.sh
-
-This command will automatically pull down all dependencies for the Scala app.
-
-To compile the client side resources locally and watch for changes use
+ 
+If this is the first time using the application you will need to pull down the client side dependencies using
 
     npm install
-    npm run watch
+
+After that, to run the application in development mode and watch for changes you can use
+
+    . watch-frontend.sh
+
+This command will automatically pull down all dependencies for the Scala app, and run the client side asset packing and sbt in parallel in the background.
+
+If you don't need client side assets you can work faster using
+
+    . start-frontend.sh
+    
+This only runs sbt
     
 Test by hitting [https://profile.thegulocal.com/management/healthcheck](https://profile.thegulocal.com/management/healthcheck). 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5538,6 +5538,57 @@
         "supports-color": "5.3.0"
       }
     },
+    "chalk-rainbow": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chalk-rainbow/-/chalk-rainbow-1.0.0.tgz",
+      "integrity": "sha1-kS7wiQ0NI6ZX1byInuFzb++fuPA=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "watch-css": "postcss public/main.css -o target/web/public/main/bundle.css -w -m --verbose",
     "watch-js": "webpack --watch --mode development -o ./target/web/public/main/main.bundle.js",
     "lint-css": "stylelint 'public/**/*.css'",
-    "watch": "concurrently --kill-others \"npm run watch-css\" \"npm run watch-js\""
+    "watch-assets": "concurrently --kill-others \"npm run watch-css\" \"npm run watch-js\"",
+    "watch": "concurrently --kill-others \"npm run watch-assets\" \"./start-frontend.sh\""
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "watch-js": "webpack --watch --mode development -o ./target/web/public/main/main.bundle.js",
     "lint-css": "stylelint 'public/**/*.css'",
     "watch-assets": "concurrently --kill-others \"npm run watch-css\" \"npm run watch-js\"",
-    "watch": "concurrently --kill-others \"npm run watch-assets\" \"./start-frontend.sh\""
+    "watch": "node ./scripts/banner.js && concurrently --kill-others \"npm run watch-assets\" \"./start-frontend.sh\""
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.4",
     "babel-preset-env": "^1.6.1",
+    "chalk-rainbow": "^1.0.0",
     "concurrently": "^3.5.1",
     "cssnano": "^3.10.0",
     "normalize.css": "^3.0.3",

--- a/scripts/banner.js
+++ b/scripts/banner.js
@@ -1,0 +1,22 @@
+const chalkRainbow = require('chalk-rainbow');
+
+const banner =
+`             ┏━━━━━━━━━┅┅~~ ~
+             ┃ $msg
+             ┗━━━━━━━━━┅┅~~ ~
+ /\\**/\\       │
+( o_o  )_     │
+ (u--u   \\_)  │                                         
+  (||___   )==\\                                         
+,dP"/b/=( /P"/b\\                                        
+|8 || 8\\=== || 8                                        
+\`b,  ,P  \`b,  ,P                                        
+  """\`     """\`                                         
+`.split("\n");
+
+banner.forEach(row => {
+  console.log('    '+row.replace('$msg',chalkRainbow('id-front is starting')))
+})
+
+
+//source -> http://www.asciiartfarts.com/

--- a/watch-frontend.sh
+++ b/watch-frontend.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+npm run watch &
+./start-frontend.sh

--- a/watch-frontend.sh
+++ b/watch-frontend.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
 npm run watch &
-./start-frontend.sh
+P1=$!
+./start-frontend.sh &
+P2=$!
+wait $P1 $P2

--- a/watch-frontend.sh
+++ b/watch-frontend.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-npm run watch &
-P1=$!
-./start-frontend.sh &
-P2=$!
-wait $P1 $P2


### PR DESCRIPTION
Updates `npm run watch` to run sbt too. For doing only the assets it's `npm run watch-assets`.

i also put in this badass kitty on first loads, to cheer everybody's day

![screen shot 2018-03-08 at 11 47 31 am](https://user-images.githubusercontent.com/11539094/37149684-d7ed3712-22c6-11e8-8034-b9582f04a994.png)
