### PR TITLE
Load polyfill and main js in parallel

### DIFF
--- a/public/layout.hbs
+++ b/public/layout.hbs
@@ -45,7 +45,7 @@
   {{#each layout.resources}}
     {{#isJavascript}}
       {{^isInHead}}
-        <script src="{{ url }}" type="text/javascript" async defer></script>
+        <script src="{{ url }}" type="text/javascript" defer></script>
       {{/isInHead}}
     {{/isJavascript}}
   {{/each}}

--- a/public/layout.hbs
+++ b/public/layout.hbs
@@ -45,7 +45,7 @@
   {{#each layout.resources}}
     {{#isJavascript}}
       {{^isInHead}}
-        <script src="{{ url }}" type="text/javascript"></script>
+        <script src="{{ url }}" type="text/javascript" async defer></script>
       {{/isInHead}}
     {{/isJavascript}}
   {{/each}}


### PR DESCRIPTION
Changes all the scripts on the footer (at this moment that meaning polyfill.io and the main bundle and nothing else ever, everything else should be loaded via better methods) to use `async` to download in parallel and `defer` to run in order. 

This behaviour changes things a bit but not really:

- In browsers that don't support `async` or `defer` nothing changes
- In browsers that support `async` but not `defer` (that's IE9 and lower) (0.08% of id users btw ☹️) The polyfill might load before and break or it might work, this is a 50-50 chance so really you can look at it as affecting 0.04% of users (on a serious note all id-frontend pages work fine without javascript and they are required to work fine without javascript)
- In pretty much every browser both scripts will now download in parallel, then wait for the page to finish parsing (they were already at the footer so no huge change) then run one after each other, ensuring the polyfills are all there

## Screenshots

<img width="868" alt="screen shot 2018-03-14 at 6 15 23 pm" src="https://user-images.githubusercontent.com/11539094/37422732-cdec88e8-27b3-11e8-8ebe-589ea58293ac.png"> <br>Before: Awful, unpolite, look at that bundle tailgating the poor polyfill


<img width="374" alt="screen shot 2018-03-14 at 6 14 57 pm" src="https://user-images.githubusercontent.com/11539094/37422750-da4072f8-27b3-11e8-9ee2-6249936ae38b.png"> <br>After: The bundle and polyfill are now friends and go hand in hand, and even meet the css in the way!