### PR TITLE
Minor css & js bugfixes

### DIFF
--- a/public/_layout.css
+++ b/public/_layout.css
@@ -23,6 +23,7 @@
   }
   &.layout-header__title--standfirst {
     @extend %font-heading-0;
+    line-height: 1.2;
     font-weight: 300;
     color: var(--color-text-light);
   }
@@ -32,8 +33,7 @@
     justify-content: space-between;
     > div:nth-child(1) {
       overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      word-wrap: break-word;
     }
     > .layout-header__title__proxy {
       flex: 0 0 auto;

--- a/public/components/register-form/register-form.js
+++ b/public/components/register-form/register-form.js
@@ -257,10 +257,10 @@ class RegisterFormState {
 }
 
 export function init() {
-  checkForCredentials();
   const form = RegisterFormModel.fromDocument();
 
   if (form) {
+    checkForCredentials();
     form.loadState();
 
     if (form.fields.optionalPhoneNumber) {

--- a/public/components/two-step-signin/_two-step-signin.css
+++ b/public/components/two-step-signin/_two-step-signin.css
@@ -51,7 +51,7 @@
 @keyframes two-step-signin-animation__slide-left {
   0% {
     transform: translateX(0);
-    opacity: 1;
+    opacity: 0.5;
   }
   100% {
     transform: translateX(-4em);
@@ -63,7 +63,7 @@
 @keyframes two-step-signin-animation__slide-right {
   0% {
     transform: translateX(0);
-    opacity: 1;
+    opacity: 0.5;
   }
   100% {
     transform: translateX(4em);

--- a/public/components/two-step-signin/two-step-signin-email.hbs
+++ b/public/components/two-step-signin/two-step-signin-email.hbs
@@ -10,7 +10,7 @@
 
   <fieldset class="form-field-wrap">
     <label class="form-field-wrap__title">{{twoStepSignInPageText.emailFieldTitle}}</label>
-    <input class="form-input form-field-wrap__field" type="email" name="email" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{email}}" />
+    <input class="form-input form-field-wrap__field" required="required" type="email" name="email" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{email}}" />
     <input class="form-input form-field-wrap__field u-h" type="password" name="password" autocomplete="password" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{password}}" />
     <button class="form-button form-field-wrap__field" type="submit">{{twoStepSignInPageText.continueAction}} {{> components/icon/arrow-inline }}</button>
   </fieldset>

--- a/public/components/two-step-signin/two-step-signin-existing.hbs
+++ b/public/components/two-step-signin/two-step-signin-existing.hbs
@@ -3,9 +3,9 @@
     {{> components/two-step-signin/_helpers }}
 
     <div class="form-field-wrap">
-      <input class="u-h" type="email" name="email" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{email}}" />
+      <input class="u-h" name="email" autocomplete="username" value="{{email}}" />
       <label class="form-field-wrap__title" for="signin_field_email">{{twoStepSignInPageText.passwordFieldTitle}}</label>
-      <input class="form-input form-field-wrap__field" type="password" name="password" autocomplete="password" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{password}}" />
+      <input class="form-input form-field-wrap__field" type="password" name="password" autocomplete="password" autocapitalize="off" autocorrect="off" spellcheck="false" required="required" value="{{password}}" />
       <div class="u-flexrow form-field-wrap__footer">
         <label class="form-checkbox">
           <input class="form-checkbox__input" type="checkbox" name="rememberMe" checked="checked" value="true"/>


### PR DESCRIPTION
- Makes email titles jump to 2 lines if an email won't fit. This doesn't look good, not gonna lie, but is better than trimming them for now.

- Fixes the slide animation flashing its opacity from 50% (loading) to 100% (animation) then 0% (animation end)

- Fixes `/signin/current` not submitting when a hidden field was using an invalid email

- Makes the smartlock code from register only pop in `/register` instead of all over the place. `/signin` (the old one) already has a handler and it was firing twice.

![screen shot 2018-03-15 at 12 13 19 pm](https://user-images.githubusercontent.com/11539094/37462553-52e4e7a2-284a-11e8-84df-66eaacc30723.png)
