### PR TITLE
Enable asset fingerprinting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,3 +78,7 @@ unmanagedResourceDirectories in Compile += (resourceDirectory in Assets).value
 
 mappings in Assets ++= contentOf(baseDirectory.value / "target/web/build-npm")
 
+// enable asset fingerprinting
+pipelineStages := Seq(digest)
+mappings in Assets ++= contentOf(baseDirectory.value / "target/web/digest")
+


### PR DESCRIPTION
https://www.playframework.com/documentation/2.6.x/AssetsOverview#Reverse-routing-and-fingerprinting-for-public-assets