### PR TITLE
Send error code -> error text mapping to javascript

### DIFF
--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -115,7 +115,7 @@ object LayoutViewModel {
         "twoStepSignIn" -> routes.Application.twoStepSignIn().url,
         "smartlockSignIn" -> routes.SigninAction.signInWithSmartLock().url
       ),
-      localisedErrors = ErrorViewModel.errorMessages.map{t => (t._1.key, t._2)},
+      localisedErrors = ErrorViewModel.errorMessages.map{case (errId, errMsg) => (errId.key, errMsg)},
       gaUID = configuration.gaUID
     )
 

--- a/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/LayoutViewModel.scala
@@ -57,6 +57,7 @@ case class JavascriptConfig(
     sentryDsn: String,
     mvtTests: Seq[MultiVariantTest],
     routes: Map[String, String],
+    localisedErrors: Map[String, String],
     appVersion: String = BuildInfo.gitCommitId,
     gaUID: String) {
   self =>
@@ -114,6 +115,7 @@ object LayoutViewModel {
         "twoStepSignIn" -> routes.Application.twoStepSignIn().url,
         "smartlockSignIn" -> routes.SigninAction.signInWithSmartLock().url
       ),
+      localisedErrors = ErrorViewModel.errorMessages.map{t => (t._1.key, t._2)},
       gaUID = configuration.gaUID
     )
 

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -21,4 +21,10 @@ const route = routeToGet => {
   throw new Error(ERR_MISSING_KEY);
 };
 
-export { get, route };
+const localisedError = localisedErrorToGet => {
+  if (config.localisedErrors && config.localisedErrors[localisedErrorToGet])
+    return config.localisedErrors[localisedErrorToGet];
+  throw new Error(ERR_MISSING_KEY);
+};
+
+export { get, route, localisedError };

--- a/public/js/get-url-errors.js
+++ b/public/js/get-url-errors.js
@@ -1,0 +1,16 @@
+// @flow
+
+import { localisedError as getLocalisedError } from './config';
+
+const getUrlErrors = (url: string): string[] => {
+  const parsedUrl = new URL(url);
+  const errorParams = parsedUrl.searchParams.get('error');
+
+  if (errorParams) {
+    return errorParams.split(',').map(getLocalisedError);
+  }
+  return [];
+};
+
+export { getUrlErrors };
+export default getUrlErrors;


### PR DESCRIPTION
This PR sends over to the client the error messages for all possible errors, this will let the 2 step sign in javascript flow pick them up and display them without an extra pageload

There's also a helper method that takes a url as a string and returns an array of errors found within it. This is all prep for the 2 step signin js code.

![screen shot 2018-03-21 at 1 10 35 pm](https://user-images.githubusercontent.com/11539094/37711663-54033c38-2d09-11e8-8e73-195081dd9a28.png)
