### PR TITLE
prevent returnUrl from being /signin/{anything}

### DIFF
--- a/app/com/gu/identity/frontend/models/ReturnUrl.scala
+++ b/app/com/gu/identity/frontend/models/ReturnUrl.scala
@@ -79,7 +79,7 @@ object ReturnUrl {
 
   private[models] def validUrlPath(uri: URI, invalidUrlPaths: List[String]): Boolean = {
     val urlPath = uri.getPath
-    !invalidUrlPaths.contains(urlPath)
+    !invalidUrlPaths.exists(urlPath.startsWith(_))
   }
 
 

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -45,7 +45,7 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
     validUrlPath(new URI("http://theguardian.com/signin"), defaultInvalidUrlPaths) should be(false)
     validUrlPath(new URI("http://theguardian.com/register"), defaultInvalidUrlPaths) should be(false)
     validUrlPath(new URI("http://theguardian.com/register"), List("/signin")) should be(true)
-    validUrlPath(new URI("http://theguardian.com/register/confirm"), defaultInvalidUrlPaths) should be(true)
+    validUrlPath(new URI("http://theguardian.com/register/sub-route"), defaultInvalidUrlPaths) should be(false)
     validUrlPath(new URI("http://theguardian.com"), defaultInvalidUrlPaths) should be(true)
     validUrlPath(new URI("http://theguardian.com/politics"), defaultInvalidUrlPaths) should be(true)
   }


### PR DESCRIPTION
Change the returnUrl parser so all urls whose path begins with `/signin` or `/register` count as invalid now, instead of only exact matches