### PR TITLE
Track email inputs in GA

### DIFF
--- a/app/com/gu/identity/frontend/analytics/AnalyticsEventActor.scala
+++ b/app/com/gu/identity/frontend/analytics/AnalyticsEventActor.scala
@@ -1,7 +1,7 @@
 package com.gu.identity.frontend.analytics
 
 import akka.actor.{Actor, ActorRef, PoisonPill, Props}
-import com.gu.identity.frontend.analytics.client.{MeasurementProtocolClient, MeasurementProtocolRequest, RegisterEventRequest, SigninEventRequest}
+import com.gu.identity.frontend.analytics.client.{MeasurementProtocolClient, MeasurementProtocolRequest, RegisterEventRequest, SigninEventRequest, SigninFirstStepEventRequest}
 import com.gu.identity.frontend.logging.Logging
 
 private sealed trait Message
@@ -12,6 +12,7 @@ private sealed trait Event extends Message {
 private object Terminate extends Message
 private case class SignIn(request: SigninEventRequest) extends Event
 private case class Register(request: RegisterEventRequest) extends Event
+private case class SignInFirstStep(request: SigninFirstStepEventRequest) extends Event
 
 class AnalyticsEventActor(eventActor: ActorRef) {
 
@@ -21,6 +22,10 @@ class AnalyticsEventActor(eventActor: ActorRef) {
 
   def sendSuccessfulSignin(signinEventRequest: SigninEventRequest) = {
     eventActor ! SignIn(signinEventRequest)
+  }
+
+  def sendSuccessfulSigninFirstStep(signinFirstStepEventRequest: SigninFirstStepEventRequest) = {
+    eventActor ! SignInFirstStep(signinFirstStepEventRequest)
   }
 
   def terminateActor() = {
@@ -37,6 +42,7 @@ private class EventActor(measurementProtocolClient: MeasurementProtocolClient) e
 
   override def receive: Receive = {
     case SignIn(event) => measurementProtocolClient.sendSuccessfulSigninEvent(event)
+    case SignInFirstStep(event) => measurementProtocolClient.sendSuccessfulSigninFirstStepEvent(event)
     case Register(event) => measurementProtocolClient.sendSuccessfulRegisterEvent(event)
     case _ =>  logger.warn("Unexpected event received by analytics event actor.")
   }

--- a/app/com/gu/identity/frontend/analytics/client/MeasurementProtocolClient.scala
+++ b/app/com/gu/identity/frontend/analytics/client/MeasurementProtocolClient.scala
@@ -6,7 +6,7 @@ import play.api.libs.ws.WSClient
 
 class MeasurementProtocolClient(ws: WSClient) extends Logging {
   def sendSuccessfulSigninEvent(signinEventRequest: SigninEventRequest) = makeRequest(signinEventRequest)
-
+  def sendSuccessfulSigninFirstStepEvent(signinFirstStepEventRequest: SigninFirstStepEventRequest) = makeRequest(signinFirstStepEventRequest)
   def sendSuccessfulRegisterEvent(registerEventRequest: RegisterEventRequest) = makeRequest(registerEventRequest)
 
   private def makeRequest(request: MeasurementProtocolRequest) =

--- a/app/com/gu/identity/frontend/analytics/client/MeasurementProtocolRequest.scala
+++ b/app/com/gu/identity/frontend/analytics/client/MeasurementProtocolRequest.scala
@@ -69,6 +69,18 @@ case class SigninEventRequest(request: Request[SignInActionRequestBody], gaUID: 
   override val body = SigninEventRequestBody(request, gaUID)
 }
 
+private object SigninFirstStepEventRequestBody extends MeasurementProtocolRequestBody[SignInActionRequestBody] {
+  override val extraBodyParams = Seq(
+    "ea" -> "SigninFirstStepSuccessful",
+    "el" -> "RegularSignin",
+    "cm2" -> "1"
+  )
+}
+
+case class SigninFirstStepEventRequest(request: Request[SignInActionRequestBody], gaUID: String) extends MeasurementProtocolRequest {
+  override val body = SigninFirstStepEventRequestBody(request, gaUID)
+}
+
 private object RegisterEventRequestBody extends MeasurementProtocolRequestBody[RegisterActionRequestBody] {
   override val extraBodyParams = Seq(
     "ea" -> "RegisterSuccessful",

--- a/app/com/gu/identity/frontend/logging/MetricsActor.scala
+++ b/app/com/gu/identity/frontend/logging/MetricsActor.scala
@@ -4,6 +4,7 @@ import akka.actor._
 private sealed trait Message {}
 
 private object SignIn extends Message
+private object SignInFirstStep extends Message
 private object SmartLockSignIn extends Message
 private object EmailSignIn extends Message
 private object Register extends Message
@@ -19,6 +20,10 @@ class MetricsLoggingActor(metricsActor: ActorRef) {
     metricsActor ! SignIn
   }
 
+  def logSuccessfulSigninFirstStep() = {
+    metricsActor ! SignInFirstStep
+  }
+
   def logSuccessfulSmartLockSignin() = {
     metricsActor ! SmartLockSignIn
   }
@@ -32,6 +37,7 @@ class MetricsActor extends Actor with Logging {
 
   override def receive: Receive = {
     case SignIn => SuccessfulActionCloudwatchLogging.putSignIn()
+    case SignInFirstStep => SuccessfulActionCloudwatchLogging.putSignInFirstStep()
     case SmartLockSignIn => SuccessfulActionCloudwatchLogging.putSmartLockSignIn()
     case Register => SuccessfulActionCloudwatchLogging.putRegister()
     case _ =>  logger.info("Unexpected Message received by metrics actor.")

--- a/app/com/gu/identity/frontend/logging/SuccessfulActionCloudwatchLogging.scala
+++ b/app/com/gu/identity/frontend/logging/SuccessfulActionCloudwatchLogging.scala
@@ -57,6 +57,11 @@ object SuccessfulActionCloudwatchLogging {
     cloudwatch.putMetricDataAsync(request, LoggingAsyncHandler)
   }
 
+  def putSignInFirstStep(): Unit = {
+    val request = createRequest("SuccessfulSignIns", "SuccessfulSignInFirstStep")
+    cloudwatch.putMetricDataAsync(request, LoggingAsyncHandler)
+  }
+
   def putSmartLockSignIn(): Unit = {
     val request = createRequest("SuccessfulSmartLockSignIns", "SuccessfulSmartLockSignIn")
     cloudwatch.putMetricDataAsync(request, LoggingAsyncHandler)


### PR DESCRIPTION
Send a `SigninFirstStepSuccessful` to GA when an email is entered in the first field of two step signup. we can use this to track funnels and see how many people drop out after that