### PR TITLE
Break up emails in better places

### DIFF
--- a/app/com/gu/identity/frontend/views/models/TwoStepSignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/TwoStepSignInViewModel.scala
@@ -6,8 +6,9 @@ import com.gu.identity.frontend.csrf.CSRFToken
 import com.gu.identity.frontend.models._
 import com.gu.identity.frontend.models.Text._
 import com.gu.identity.frontend.mvt.ActiveMultiVariantTests
-import com.gu.identity.model.{UserType, NewUser, GuestUser, CurrentUser}
+import com.gu.identity.model.{CurrentUser, GuestUser, NewUser, UserType}
 import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
 
 case class TwoStepSignInViewModel private(
   layout: LayoutViewModel,
@@ -79,7 +80,7 @@ object TwoStepSignInViewModel {
       skipConfirmation = skipConfirmation.getOrElse(false),
       clientId = clientId,
       group = group,
-      email = email,
+      email = email.map(breakEmailWords),
 
       registerUrl = UrlBuilder(routes.Application.register(), returnUrl, skipConfirmation, clientId, group.map(_.id)),
       signinUrl = UrlBuilder(routes.Application.twoStepSignIn(), returnUrl, skipConfirmation, clientId, group.map(_.id)),
@@ -96,6 +97,15 @@ object TwoStepSignInViewModel {
       resources = resources,
       indirectResources = layout.indirectResources
     )
+  }
+
+  private def breakEmailWords(email: String) = {
+    HtmlFormat.escape(email).toString.flatMap {
+      case '@' => s"<wbr>@"
+      case '+' => s"<wbr>+"
+      case '.' => s"<wbr>."
+      case c   => s"$c"
+    }
   }
 
   private def getResources(layout: LayoutViewModel, recaptchaViewModel: Option[GoogleRecaptchaViewModel]): Seq[PageResource with Product] ={

--- a/public/_layout.css
+++ b/public/_layout.css
@@ -29,14 +29,19 @@
   }
   &.layout-header__title--has-proxy {
     display: flex;
-    align-items: baseline;
-    justify-content: space-between;
+    flex-direction: column;
+    @media (--viewport-min-mobile-landscape) {
+      align-items: baseline;
+      justify-content: space-between;
+      flex-direction: row;
+    }
     > div:nth-child(1) {
       overflow: hidden;
       word-wrap: break-word;
     }
     > .layout-header__title__proxy {
       flex: 0 0 auto;
+      align-self: flex-end;
       margin-left: var(--size-baseline);
     }
   }

--- a/public/components/form-foundations/_form_foundations.css
+++ b/public/components/form-foundations/_form_foundations.css
@@ -79,8 +79,7 @@
   text-align: left;
   transition: 0.15s;
   padding: 0 1.75rem;
-  line-height: 4.2rem;
-  height: 4.2rem;
+  min-height: 4.2rem;
   display: block;
   display: flex;
   align-items: center;

--- a/public/two-step-signin-choices-page.hbs
+++ b/public/two-step-signin-choices-page.hbs
@@ -8,7 +8,7 @@
       <a class="layout-header" href="{{signinUrl}}" >
         <h1 class="layout-header__title">{{ twoStepSignInPageText.welcome }}</h1>
         <div class="layout-header__title layout-header__title--has-proxy layout-header__title--standfirst">
-          <div>{{email}}</div>
+          <div>{{{email}}}</div>
           <div class="layout-header__title__proxy">{{twoStepSignInPageText.changeEmailLink}}</div>
         </div>
       </a>


### PR DESCRIPTION
![screen shot 2018-03-22 at 1 38 31 pm](https://user-images.githubusercontent.com/11539094/37774019-02b0df88-2dd7-11e8-9248-ead8a0317728.png)

When an email address can't fit on the screen, try to break it up at `@`, `+`, and `.` characters first