### PR TITLE
Remove reset password page from /signin/guest flow

### DIFF
--- a/app/com/gu/identity/frontend/views/models/TwoStepSignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/TwoStepSignInViewModel.scala
@@ -37,6 +37,7 @@ case class TwoStepSignInViewModel private(
 
   actions: Map[String, String] = Map(
     "signInWithEmailAndPassword" -> routes.SigninAction.signIn().url,
+    "resetPassword" -> routes.ResetPasswordAction.reset().url,
     "signInWithEmail" -> routes.SigninAction.emailSignInFirstStep().url
   ),
   resources: Seq[PageResource with Product],

--- a/public/components/two-step-signin/two-step-signin-guest.hbs
+++ b/public/components/two-step-signin/two-step-signin-guest.hbs
@@ -1,10 +1,10 @@
-<form class="two-step-signin-form" method="POST" action="{{ actions.signInWithEmailAndPassword }}">
+<div class="two-step-signin-form">
 
-  {{> components/two-step-signin/_helpers }}
-
-  <div class="form-field-wrap">
+  <form method="POST" action="{{ actions.resetPassword }}" class="form-field-wrap">
+    {{> components/two-step-signin/_helpers }}
+    <input name="email" type="hidden" value="{{email}}" />
     <label class="form-field-wrap__title" for="signin_field_email">{{twoStepSignInPageText.setPasswordTitle}}</label>
-    <a href="{{forgotPasswordUrl}}" class="form-button form-field-wrap__field">{{twoStepSignInPageText.setPasswordAction}} {{> components/icon/arrow-inline }}</a>
-  </div>
+    <button type="submit" class="form-button form-field-wrap__field">{{twoStepSignInPageText.setPasswordAction}} {{> components/icon/arrow-inline }}</button>
+  </form>
 
-</form>
+</div>


### PR DESCRIPTION
Clicking the set password button will automatically send the email and drive the user to the confirmation page