### PR TITLE
Tighter breakpoint for the [sign up] link

### DIFF
--- a/public/_html.css
+++ b/public/_html.css
@@ -173,7 +173,7 @@ body > section:last-of-type {
       @extend %font-text-sans-3;
       color: var(--color-text);
     }
-    @media (--viewport-min-tablet) {
+    @media (--viewport-min-mobile-landscape) {
       display: flex;
       align-items: center;
       .form-button {


### PR DESCRIPTION
Prevent the button from jumping to two lines (ugly!) until the viewport reaches phone sizes. Requested by @katyabeer

![screen shot 2018-03-29 at 12 55 14 pm](https://user-images.githubusercontent.com/11539094/38087578-89dee08a-3350-11e8-8799-4a12a4a03103.png)
