### PR TITLE
New endpoint and redirect for existing users to post password to

### DIFF
--- a/app/com/gu/identity/frontend/controllers/SigninAction.scala
+++ b/app/com/gu/identity/frontend/controllers/SigninAction.scala
@@ -17,6 +17,8 @@ import com.gu.identity.frontend.authentication.CookieService
 import com.gu.tip.Tip
 import java.net.URLEncoder.encode
 
+import com.gu.identity.model.CurrentUser
+
 import scala.concurrent.Future
 
 /**
@@ -35,7 +37,7 @@ class SigninAction(
 
   val redirectRoute: String = routes.Application.signIn().url
 
-  val signInSecondStepCurrentRedirectRoute: String = routes.Application.twoStepSignInStepTwo("current").url
+  val signInSecondStepCurrentRedirectRoute: String = routes.Application.twoStepSignInStepTwo(CurrentUser.name).url
 
   val SignInServiceAction =
     ServiceAction andThen

--- a/app/com/gu/identity/frontend/controllers/SigninAction.scala
+++ b/app/com/gu/identity/frontend/controllers/SigninAction.scala
@@ -35,11 +35,19 @@ class SigninAction(
 
   val redirectRoute: String = routes.Application.signIn().url
 
+  val signInSecondStepCurrentRedirectRoute: String = routes.Application.twoStepSignInStepTwo("current").url
+
   val SignInServiceAction =
     ServiceAction andThen
     RedirectOnError(redirectRoute) andThen
     LogOnErrorAction(logger) andThen
     CSRFCheck(csrfConfig)
+
+  val signInSecondStepCurrentServiceAction =
+      ServiceAction andThen
+      RedirectOnError(signInSecondStepCurrentRedirectRoute) andThen
+      LogOnErrorAction(logger) andThen
+      CSRFCheck(csrfConfig)
 
   val SignInSmartLockServiceAction =
     ServiceAction andThen
@@ -67,6 +75,10 @@ class SigninAction(
     } else {
       logger.warn("No GA Client ID passed for sign in request")
     }
+  }
+
+  def signInSecondStepCurrent = signInSecondStepCurrentServiceAction(bodyParser) {
+    signInAction(successfulSignInResponse, signInMetricsLogger)
   }
 
   def signIn = SignInServiceAction(bodyParser) {

--- a/app/com/gu/identity/frontend/views/models/TwoStepSignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/TwoStepSignInViewModel.scala
@@ -40,7 +40,8 @@ case class TwoStepSignInViewModel private(
   actions: Map[String, String] = Map(
     "signInWithEmailAndPassword" -> routes.SigninAction.signIn().url,
     "resetPassword" -> routes.ResetPasswordAction.reset().url,
-    "signInWithEmail" -> routes.SigninAction.emailSignInFirstStep().url
+    "signInWithEmail" -> routes.SigninAction.emailSignInFirstStep().url,
+    "signInSecondStepCurrent" -> routes.SigninAction.signInSecondStepCurrent().url
   ),
   resources: Seq[PageResource with Product],
   indirectResources: Seq[PageResource with Product])

--- a/conf/routes
+++ b/conf/routes
@@ -23,6 +23,8 @@ POST       /actions/agree                               com.gu.identity.frontend
 
 POST       /actions/signin                              com.gu.identity.frontend.controllers.SigninAction.signIn
 
+POST       /actions/signInSecondStepCurrent             com.gu.identity.frontend.controllers.SigninAction.signInSecondStepCurrent
+
 POST       /actions/signin/smartlock                    com.gu.identity.frontend.controllers.SigninAction.signInWithSmartLock
 
 POST       /actions/signin/with-email                   com.gu.identity.frontend.controllers.SigninAction.emailSignInFirstStep

--- a/public/components/two-step-signin/two-step-signin-existing.hbs
+++ b/public/components/two-step-signin/two-step-signin-existing.hbs
@@ -1,4 +1,4 @@
-<form class="two-step-signin-form" method="POST" action="{{ actions.signInWithEmailAndPassword }}">
+<form class="two-step-signin-form" method="POST" action="{{ actions.signInSecondStepCurrent }}">
 
     {{> components/two-step-signin/_helpers }}
 


### PR DESCRIPTION
- When an existing user gets to the second step in the two step sign in , this posts to an endpoint that will redirect back to the second step (/signin/current) if the password is wrong or there is an error. Previously this would result in a redirect to /signin. 