### PR TITLE
Add alternate text for reset password that serves as a resend

### DIFF
--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -3,7 +3,8 @@ package com.gu.identity.frontend.controllers
 import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.csrf.{CSRFAddToken, CSRFConfig, CSRFToken}
 import com.gu.identity.frontend.logging.Logging
-import com.gu.identity.frontend.models.{ClientID, GroupCode, SignInType, ReturnUrl}
+import com.gu.identity.frontend.models.text.{ResetPasswordResendText, ResetPasswordText}
+import com.gu.identity.frontend.models.{ClientID, GroupCode, ReturnUrl, SignInType}
 import com.gu.identity.frontend.mvt.MultiVariantTestAction
 import com.gu.identity.frontend.views.ViewRenderer._
 import com.gu.identity.model.{CurrentUser, GuestUser, NewUser}
@@ -73,9 +74,19 @@ class Application(
   def reset(error: Seq[String], clientId: Option[String]) = CSRFAddToken(csrfConfig) { req =>
     val clientIdOpt = ClientID(clientId)
     val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
-    val email : Option[String] = req.cookies.get("GU_SIGNIN_EMAIL").map(_.value)
+    val email: Option[String] = req.cookies.get("GU_SIGNIN_EMAIL").map(_.value)
+    val text = ResetPasswordText()
 
-    renderResetPassword(configuration, error, csrfToken, email, clientIdOpt)
+    renderResetPassword(configuration, error, csrfToken, email, text, clientIdOpt)
+  }
+
+  def resetResend(error: Seq[String], clientId: Option[String]) = CSRFAddToken(csrfConfig) { req =>
+    val clientIdOpt = ClientID(clientId)
+    val csrfToken = CSRFToken.fromRequest(csrfConfig, req)
+    val email: Option[String] = req.cookies.get("GU_SIGNIN_EMAIL").map(_.value)
+    val text = ResetPasswordResendText()
+
+    renderResetPassword(configuration, error, csrfToken, email, text, clientIdOpt)
   }
 
   def resetPasswordEmailSent(clientId: Option[String]) = Action {

--- a/app/com/gu/identity/frontend/models/text/ResetPasswordText.scala
+++ b/app/com/gu/identity/frontend/models/text/ResetPasswordText.scala
@@ -2,6 +2,7 @@ package com.gu.identity.frontend.models.text
 
 import play.api.i18n.Messages
 
+
 case class ResetPasswordText private(
   pageTitle: String,
   title: String,
@@ -14,6 +15,15 @@ case class ResetPasswordText private(
   userHelpEmail: String,
   userHelpContent: String
 )
+
+object ResetPasswordResendText {
+  def apply()(implicit messages: Messages): ResetPasswordText =
+    ResetPasswordText().copy(
+      title = messages("resetPassword.resend.title"),
+      subtitle = messages("resetPassword.resend.subtitle"),
+      button = messages("resetPassword.resend.button")
+    )
+}
 
 object ResetPasswordText {
   def apply()(implicit messages: Messages): ResetPasswordText =

--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -7,6 +7,7 @@ import com.gu.identity.frontend.controllers.{NoCache, routes}
 import com.gu.identity.frontend.csrf.CSRFToken
 import com.gu.identity.frontend.errors.{HttpError, NotFoundError, UnexpectedError}
 import com.gu.identity.frontend.models._
+import com.gu.identity.frontend.models.text.ResetPasswordText
 import com.gu.identity.frontend.mvt.{MultiVariantTest, MultiVariantTestVariant}
 import com.gu.identity.frontend.views.models._
 import com.gu.identity.model.UserType
@@ -155,6 +156,7 @@ object ViewRenderer {
     errorIds: Seq[String],
     csrfToken: Option[CSRFToken],
     email: Option[String],
+    text: ResetPasswordText,
     clientId: Option[ClientID])
     (implicit messages: Messages) = {
     val model = ResetPasswordViewModel(
@@ -162,6 +164,7 @@ object ViewRenderer {
       errors = errorIds.map(ErrorViewModel.apply),
       csrfToken = csrfToken,
       email = email,
+      text = text,
       clientId = clientId
     )
     renderViewModel("reset-password-page", model)

--- a/app/com/gu/identity/frontend/views/models/ResetPasswordViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/ResetPasswordViewModel.scala
@@ -31,13 +31,14 @@ object ResetPasswordViewModel {
     errors: Seq[ErrorViewModel],
     csrfToken: Option[CSRFToken],
     email: Option[String],
+    text: ResetPasswordText,
     clientId: Option[ClientID])
     (implicit messages: Messages): ResetPasswordViewModel = {
     val layout = LayoutViewModel(configuration, clientId = clientId, returnUrl = None)
 
     ResetPasswordViewModel(
       layout = layout,
-      resetPasswordText = ResetPasswordText(),
+      resetPasswordText = text,
       errors = errors,
       csrfToken = csrfToken,
       email = email,

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -112,9 +112,12 @@ sendSignInLinkSent.cta=Return to The Guardian
 # com.gu.identity.frontend.models.text.ResetPasswordText
 resetPassword.pageTitle=Reset password
 resetPassword.title=Forgotten or need to set your password?
+resetPassword.resend.title=Oh no! The reset password link has expired
 resetPassword.subtitle=We will email you a link to reset it.
+resetPassword.resend.subtitle=Enter your email address and we'll send you another.
 resetPassword.emailAddressField=Email address
 resetPassword.button=Reset Password
+resetPassword.resend.button=Send me another
 resetPassword.socialNetworksTitle=Unlinked The Guardian from Facebook or Google and want to sign in?
 resetPassword.socialNetworksContent=Use the email address field to send a reset link to your registered Facebook or Google email. You will then be able to add a password to your account.
 resetPassword.userHelpTitle=Something else?
@@ -125,7 +128,7 @@ resetPassword.userHelpContent=who will be able to help you.
 resetPasswordEmailSent.pageTitle=Check your email
 resetPasswordEmailSent.title=Now check your email
 resetPasswordEmailSent.instructions1=Follow the link in the email to reset your password.
-resetPasswordEmailSent.instructions2=Reset password links are valid for 30 minutes. If you do not receive an email there is no account associated with the address.  
+resetPasswordEmailSent.instructions2=Reset password links are valid for 30 minutes. If you do not receive an email there is no account associated with the address.
 
 errors.badRequest.pageTitle=Bad request: {0}
 errors.badRequest.title=Bad request: {0}
@@ -157,7 +160,7 @@ errors.unauthorized.resendTokenLink=You can manage all of your email preferences
 resendTokenSent.pageTitle=Email Sent
 resendTokenSent.title=Email sent
 resendTokenSent.description=Please go to your inbox. If you have not received it please check your spam folder.
-resendTokenSent.unexpectedTitle=Opps there was a problem 
+resendTokenSent.unexpectedTitle=Opps there was a problem
 
 resendConsentLink.pageTitle=Invalid consent token
 resendConsentLink.title=Expired link

--- a/conf/routes
+++ b/conf/routes
@@ -13,6 +13,8 @@ GET        /register                                    com.gu.identity.frontend
 
 GET        /reset                                       com.gu.identity.frontend.controllers.Application.reset(error: Seq[String] ?= Seq.empty, clientId: Option[String] ?= None)
 
+GET        /reset/resend                                com.gu.identity.frontend.controllers.Application.resetResend(error: Seq[String] ?= Seq.empty, clientId: Option[String] ?= None)
+
 GET        /reset/email-sent                            com.gu.identity.frontend.controllers.Application.resetPasswordEmailSent(clientId: Option[String] ?= None)
 
 GET        /signin-token                                com.gu.identity.frontend.controllers.Application.sendSignInLink(error: Seq[String] ?= Seq.empty)


### PR DESCRIPTION
As it turns out, the password reset feature was ported to ID-frontend without remembering to also port the resend password reset feature.  This PR adds that feature by offering a version of the request reset email page with alternate wording at `/reset/resend`.

Frontend PR for using this page on the way.