### PR TITLE
Remove custom parser hardwiring

### DIFF
--- a/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
+++ b/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
@@ -10,6 +10,7 @@ import com.gu.identity.frontend.errors.ErrorHandler
 import com.gu.identity.frontend.filters._
 import com.gu.identity.frontend.logging._
 import com.gu.identity.frontend.mvt.MultiVariantTestAction
+import com.gu.identity.frontend.request._
 import com.gu.identity.frontend.services._
 import com.gu.identity.service.client.IdentityClient
 import jp.co.bizreach.play2handlebars.HandlebarsComponents
@@ -53,6 +54,14 @@ class ApplicationComponents(context: Context)
 
   lazy val identityCookieDecoder: IdentityCookieDecoder = new IdentityCookieDecoder(IdentityKeys(frontendConfiguration.identityCookiePublicKey))
 
+  // Parsers
+  lazy val formRequestBodyParser = new FormRequestBodyParser(playBodyParsers)
+  lazy val emailResubRequestsParser = new EmailResubRequestsParser(formRequestBodyParser)
+  lazy val signInActionRequestBodyParser = new SignInActionRequestBodyParser(formRequestBodyParser)
+  lazy val resetPasswordActionRequestBodyParser = new ResetPasswordActionRequestBodyParser(formRequestBodyParser)
+  lazy val registerActionRequestBodyParser = new RegisterActionRequestBodyParser(formRequestBodyParser)
+  lazy val resendTokenActionRequestBodyParser = new ResendTokenActionRequestBodyParser(formRequestBodyParser)
+
   // Actions
   lazy val userAuthenticatedAction = new UserAuthenticatedAction(controllerComponents, identityCookieDecoder.getUserDataForScGuU)
   lazy val serviceAction = new ServiceAction(controllerComponents)
@@ -67,13 +76,13 @@ class ApplicationComponents(context: Context)
   lazy val cspReporterController = new CSPViolationReporter()
   lazy val googleRecaptchaServiceHandler = new GoogleRecaptchaServiceHandler(wsClient, frontendConfiguration)
   lazy val googleRecaptchaCheck = new GoogleRecaptchaCheck(googleRecaptchaServiceHandler)
-  lazy val signinController = new SigninAction(identityService, controllerComponents, metricsLoggingActor, analyticsEventActor, frontendConfiguration, serviceAction)
+  lazy val signinController = new SigninAction(identityService, controllerComponents, metricsLoggingActor, analyticsEventActor, frontendConfiguration, serviceAction, emailResubRequestsParser, signInActionRequestBodyParser)
   lazy val signOutController = new SignOutAction(identityService, messagesApi, frontendConfiguration)
-  lazy val registerController = new RegisterAction(identityService, controllerComponents, metricsLoggingActor, analyticsEventActor, frontendConfiguration, serviceAction)
+  lazy val registerController = new RegisterAction(identityService, controllerComponents, metricsLoggingActor, analyticsEventActor, frontendConfiguration, serviceAction, registerActionRequestBodyParser)
   lazy val thirdPartyTsAndCsController = new ThirdPartyTsAndCs(identityService, frontendConfiguration, httpErrorHandler, identityCookieDecoder.getUserDataForScGuU, userAuthenticatedAction, controllerComponents)
-  lazy val resetPasswordController = new ResetPasswordAction(identityService, controllerComponents, serviceAction)
-  lazy val resendConsentTokenController = new ResendConsentTokenAction(identityService, controllerComponents, serviceAction)
-  lazy val resendRepermissionTokenController = new ResendRepermissionTokenAction(identityService, controllerComponents, serviceAction)
+  lazy val resetPasswordController = new ResetPasswordAction(identityService, controllerComponents, serviceAction, resetPasswordActionRequestBodyParser)
+  lazy val resendConsentTokenController = new ResendConsentTokenAction(identityService, controllerComponents, serviceAction, resendTokenActionRequestBodyParser)
+  lazy val resendRepermissionTokenController = new ResendRepermissionTokenAction(identityService, controllerComponents, serviceAction, resendTokenActionRequestBodyParser)
   lazy val repermissionController = new RepermissionController(frontendConfiguration, identityService, messagesApi, ExecutionContext.Implicits.global)
   lazy val signinTokenController = new SigninTokenController(frontendConfiguration, identityService, controllerComponents, ExecutionContext.Implicits.global)
   lazy val optInController = new OptInController()

--- a/app/com/gu/identity/frontend/controllers/RegisterAction.scala
+++ b/app/com/gu/identity/frontend/controllers/RegisterAction.scala
@@ -7,7 +7,7 @@ import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.errors.RedirectOnError
 import com.gu.identity.frontend.logging.{LogOnErrorAction, Logging, MetricsLoggingActor}
 import com.gu.identity.frontend.models._
-import com.gu.identity.frontend.request.RegisterActionRequestBody
+import com.gu.identity.frontend.request.{RegisterActionRequestBody, RegisterActionRequestBodyParser}
 import com.gu.identity.frontend.services.{IdentityService, ServiceAction, ServiceActionBuilder}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{AbstractController, BodyParser, ControllerComponents, Request, Cookie => PlayCookie}
@@ -23,7 +23,9 @@ class RegisterAction(
     metricsLoggingActor: MetricsLoggingActor,
     analyticsEventActor: AnalyticsEventActor,
     val config: Configuration,
-    serviceAction: ServiceAction)(implicit executionContext: ExecutionContext)
+    serviceAction: ServiceAction,
+    registerActionRequestBodyParser: RegisterActionRequestBodyParser)
+    (implicit executionContext: ExecutionContext)
   extends AbstractController(cc)
     with Logging
     with I18nSupport {
@@ -35,7 +37,7 @@ class RegisterAction(
       RedirectOnError(redirectRoute, cc) andThen
       (new LogOnErrorAction(logger, cc))
 
-  val bodyParser: BodyParser[RegisterActionRequestBody] = RegisterActionRequestBody.bodyParser
+  val bodyParser: BodyParser[RegisterActionRequestBody] = registerActionRequestBodyParser.bodyParser
 
   def register = RegisterServiceAction(bodyParser) { implicit request =>
     val clientIp = ClientIp(request)

--- a/app/com/gu/identity/frontend/controllers/ResendConsentTokenAction.scala
+++ b/app/com/gu/identity/frontend/controllers/ResendConsentTokenAction.scala
@@ -2,17 +2,17 @@ package com.gu.identity.frontend.controllers
 
 import com.gu.identity.frontend.errors.RedirectOnError
 import com.gu.identity.frontend.logging.{LogOnErrorAction, Logging}
-import com.gu.identity.frontend.request.ResendTokenActionRequestBody
+import com.gu.identity.frontend.request.ResendTokenActionRequestBodyParser
 import com.gu.identity.frontend.services.{IdentityService, ServiceAction, ServiceActionBuilder}
 import play.api.mvc.{AbstractController, ControllerComponents, Request}
 
 import scala.concurrent.ExecutionContext
 
-
 case class ResendConsentTokenAction(
     identityService: IdentityService,
     cc: ControllerComponents,
-    serviceAction: ServiceAction)
+    serviceAction: ServiceAction,
+    resendTokenActionRequestBodyParser: ResendTokenActionRequestBodyParser)
     (implicit executionContext: ExecutionContext) extends AbstractController(cc) with Logging {
 
   val redirectRoute: String = routes.Application.resendConsentTokenSent().url
@@ -22,7 +22,7 @@ case class ResendConsentTokenAction(
       RedirectOnError(redirectRoute, cc) andThen
       (new LogOnErrorAction(logger, cc))
 
-  val bodyParser = ResendTokenActionRequestBody.bodyParser
+  val bodyParser = resendTokenActionRequestBodyParser.bodyParser
 
   def resend = ResendConsentTokenServiceAction(bodyParser) { request =>
     identityService.resendConsentToken(request.body).map { eitherResponse =>

--- a/app/com/gu/identity/frontend/controllers/ResendRepermissionTokenAction.scala
+++ b/app/com/gu/identity/frontend/controllers/ResendRepermissionTokenAction.scala
@@ -2,7 +2,7 @@ package com.gu.identity.frontend.controllers
 
 import com.gu.identity.frontend.errors.RedirectOnError
 import com.gu.identity.frontend.logging.{LogOnErrorAction, Logging}
-import com.gu.identity.frontend.request.ResendTokenActionRequestBody
+import com.gu.identity.frontend.request.ResendTokenActionRequestBodyParser
 import com.gu.identity.frontend.services.{IdentityService, ServiceAction, ServiceActionBuilder}
 import play.api.mvc.{AbstractController, ControllerComponents, Request}
 
@@ -11,7 +11,9 @@ import scala.concurrent.ExecutionContext
 case class ResendRepermissionTokenAction(
     identityService: IdentityService,
     cc: ControllerComponents,
-    serviceAction: ServiceAction)(implicit executionContext: ExecutionContext)
+    serviceAction: ServiceAction,
+    resendTokenActionRequestBodyParser: ResendTokenActionRequestBodyParser)
+    (implicit executionContext: ExecutionContext)
     extends AbstractController(cc) with Logging {
 
   val redirectRoute: String = routes.Application.resendRepermissionTokenSent().url
@@ -21,7 +23,7 @@ case class ResendRepermissionTokenAction(
       RedirectOnError(redirectRoute, cc) andThen
       (new LogOnErrorAction(logger, cc))
 
-  val bodyParser = ResendTokenActionRequestBody.bodyParser
+  val bodyParser = resendTokenActionRequestBodyParser.bodyParser
 
   def resend = ResendRepermissionTokenServiceAction(bodyParser) { request =>
 

--- a/app/com/gu/identity/frontend/controllers/ResetPasswordAction.scala
+++ b/app/com/gu/identity/frontend/controllers/ResetPasswordAction.scala
@@ -3,7 +3,7 @@ package com.gu.identity.frontend.controllers
 import com.gu.identity.frontend.errors.RedirectOnError
 import com.gu.identity.frontend.logging.{LogOnErrorAction, Logging}
 import com.gu.identity.frontend.models.ClientIp
-import com.gu.identity.frontend.request.ResetPasswordActionRequestBody
+import com.gu.identity.frontend.request.ResetPasswordActionRequestBodyParser
 import com.gu.identity.frontend.services.{IdentityService, ServiceAction, ServiceActionBuilder}
 import play.api.mvc.{AbstractController, ControllerComponents, Request}
 
@@ -13,7 +13,9 @@ import scala.concurrent.ExecutionContext
 case class ResetPasswordAction(
     identityService: IdentityService,
     cc: ControllerComponents,
-    serviceAction: ServiceAction)(implicit executionContext: ExecutionContext)
+    serviceAction: ServiceAction,
+    resetPasswordActionRequestBodyParser: ResetPasswordActionRequestBodyParser)
+    (implicit executionContext: ExecutionContext)
     extends AbstractController(cc) with Logging {
 
   val redirectRoute: String = routes.Application.reset().url
@@ -23,7 +25,7 @@ case class ResetPasswordAction(
       RedirectOnError(redirectRoute, cc) andThen
       (new LogOnErrorAction(logger, cc))
 
-  val bodyParser = ResetPasswordActionRequestBody.bodyParser
+  val bodyParser = resetPasswordActionRequestBodyParser.bodyParser
 
   def reset = ResetPasswordServiceAction(bodyParser) { request =>
     val ip = ClientIp(request)

--- a/app/com/gu/identity/frontend/request/EmailResubRequests.scala
+++ b/app/com/gu/identity/frontend/request/EmailResubRequests.scala
@@ -8,18 +8,20 @@ import play.api.mvc.BodyParser
 
 case class EmailResubscribeRequest(email: String, returnUrl: Option[String], clientId: Option[ClientID])
 
-trait EmailResubRequests {
+class EmailResubRequestsParser(formRequestBodyParser: FormRequestBodyParser) {
 
   import ClientID.FormMapping.clientId
 
-  protected lazy val emailResubFormMapping: Mapping[EmailResubscribeRequest] = Forms.mapping(
+  private val emailResubFormMapping: Mapping[EmailResubscribeRequest] = Forms.mapping(
     "email" -> email,
     "returnUrl" -> optional(nonEmptyText),
     "clientId" -> optional(clientId)
   )(EmailResubscribeRequest.apply)(EmailResubscribeRequest.unapply)
-  protected lazy val emailResubForm: Form[EmailResubscribeRequest] = Form(emailResubFormMapping)
-  protected lazy val emailResubFormParser: BodyParser[EmailResubscribeRequest] = FormRequestBodyParser("email_signin")(_ => emailResubForm)(e => SignInInvalidCredentialsAppException)
+
+  private val emailResubForm: Form[EmailResubscribeRequest] = Form(emailResubFormMapping)
+
+  val bodyParser: BodyParser[EmailResubscribeRequest] =
+    formRequestBodyParser.form("email_signin")(_ => emailResubForm)(e => SignInInvalidCredentialsAppException)
 
 }
 
-object EmailResubRequests extends EmailResubRequests

--- a/app/com/gu/identity/frontend/request/FormRequestBodyParser.scala
+++ b/app/com/gu/identity/frontend/request/FormRequestBodyParser.scala
@@ -1,18 +1,18 @@
 package com.gu.identity.frontend.request
 
 import com.gu.identity.frontend.errors.{AppException, SeqAppExceptions}
-import play.api.data.{FormError, Form}
-import play.api.mvc.{Result, BodyParsers, RequestHeader, BodyParser}
+import play.api.data.{Form, FormError}
+import play.api.mvc._
 
 /**
  * Wrapper on Play's Form Body Parser to provide a simpler interface for
  * transforming form parse errors.
  */
-object FormRequestBodyParser {
+class FormRequestBodyParser(playBodyParser: PlayBodyParsers) {
 
-  def apply[T](debugName: String)(form: RequestHeader => Form[T])(errorHandler: FormError => AppException): BodyParser[T] =
+  def form[T](debugName: String)(form: RequestHeader => Form[T])(errorHandler: FormError => AppException): BodyParser[T] =
     BodyParser(s"FormRequestBodyParser:$debugName") { requestHeader =>
-      BodyParsers.parse.form(
+      playBodyParser.form(
         form(requestHeader),
         onErrors = onParserErrors(errorHandler)
       ).apply(requestHeader)

--- a/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
+++ b/app/com/gu/identity/frontend/request/RegisterActionRequestBody.scala
@@ -44,16 +44,16 @@ case class RegisterActionRequestBody private(
   val rememberMe = true
 }
 
-object RegisterActionRequestBody {
+class RegisterActionRequestBodyParser(formRequestBodyParser: FormRequestBodyParser) {
 
   lazy val bodyParser: BodyParser[RegisterActionRequestBody] =
-    FormRequestBodyParser("RegisterActionRequestBody")(registerForm)(handleFormErrors)
+    formRequestBodyParser.form("RegisterActionRequestBody")(registerForm)(handleFormErrors)
 
-  def registerForm(requestHeader: RequestHeader): Form[RegisterActionRequestBody] =
+  private def registerForm(requestHeader: RequestHeader): Form[RegisterActionRequestBody] =
     registerForm(requestHeader.headers.get(HeaderNames.REFERER))
 
-  def registerForm(refererHeader: Option[String]): Form[RegisterActionRequestBody] =
-    Form(FormMapping.registerFormMapping(refererHeader))
+  private def registerForm(refererHeader: Option[String]): Form[RegisterActionRequestBody] =
+    Form(RegisterActionRequestBodyFormMapping.registerFormMapping(refererHeader))
 
 
   private def handleFormErrors(formError: FormError): AppException = formError match {
@@ -67,7 +67,10 @@ object RegisterActionRequestBody {
     case e => RegisterActionBadRequestAppException(s"Unexpected error: ${e.message}")
   }
 
-  object FormMapping {
+
+}
+
+object RegisterActionRequestBodyFormMapping {
     import ClientID.FormMapping.clientId
     import GroupCode.FormMappings.groupCode
     import ReturnUrl.FormMapping.returnUrl
@@ -119,4 +122,3 @@ object RegisterActionRequestBody {
         "gaClientId" -> optional(text)
       )(RegisterActionRequestBody.apply)(RegisterActionRequestBody.unapply)
   }
-}

--- a/app/com/gu/identity/frontend/request/ResendTokenActionRequestBody.scala
+++ b/app/com/gu/identity/frontend/request/ResendTokenActionRequestBody.scala
@@ -11,11 +11,12 @@ case class ResendTokenActionRequestBody(
   extends CSRFTokenRequestParameter
 
 
-object ResendTokenActionRequestBody {
+class ResendTokenActionRequestBodyParser(formRequestBodyParser: FormRequestBodyParser) {
 
-  lazy val bodyParser = FormRequestBodyParser("ResendTokenActionRequestBody")(_ => resendTokenForm)(handleFormErrors)
+  lazy val bodyParser =
+    formRequestBodyParser.form("ResendTokenActionRequestBody")(_ => resendTokenForm)(handleFormErrors)
 
-  lazy val resendTokenForm = Form(FormMapping.resetMapping)
+  private lazy val resendTokenForm = Form(FormMapping.resetMapping)
 
   private def handleFormErrors(formError: FormError): AppException = formError match {
     case FormError("token", messages, _) => ResendTokenBadTokenException(messages.headOption.getOrElse("Unknown"))
@@ -23,7 +24,7 @@ object ResendTokenActionRequestBody {
     case e => ResendTokenBadRequestAppException(e.message)
   }
 
-  object FormMapping {
+  private object FormMapping {
     import play.api.data.Forms._
 
     val resetMapping =

--- a/app/com/gu/identity/frontend/request/ResetPasswordActionRequestBody.scala
+++ b/app/com/gu/identity/frontend/request/ResetPasswordActionRequestBody.scala
@@ -11,11 +11,12 @@ case class ResetPasswordActionRequestBody(
   extends CSRFTokenRequestParameter
 
 
-object ResetPasswordActionRequestBody {
+class ResetPasswordActionRequestBodyParser(formRequestBodyParser: FormRequestBodyParser) {
 
-  lazy val bodyParser = FormRequestBodyParser("ResetPasswordActionRequestBody")(_ => resetPasswordForm)(handleFormErrors)
+  lazy val bodyParser =
+    formRequestBodyParser.form("ResetPasswordActionRequestBody")(_ => resetPasswordForm)(handleFormErrors)
 
-  lazy val resetPasswordForm = Form(FormMapping.resetPasswordMapping)
+  private lazy val resetPasswordForm = Form(FormMapping.resetPasswordMapping)
 
   private def handleFormErrors(formError: FormError): AppException = formError match {
     case FormError("email", messages, _) => ResetPasswordInvalidEmailAppException(messages.headOption.getOrElse("Unknown"))
@@ -23,7 +24,7 @@ object ResetPasswordActionRequestBody {
     case e => ResetPasswordActionBadRequestAppException(e.message)
   }
 
-  object FormMapping {
+  private object FormMapping {
     import play.api.data.Forms._
 
     val resetPasswordMapping =

--- a/app/com/gu/identity/frontend/request/SignInActionRequestBody.scala
+++ b/app/com/gu/identity/frontend/request/SignInActionRequestBody.scala
@@ -28,16 +28,16 @@ case class SignInActionRequestBody private(
   with GaClientIdRequestParameter
 
 
-object SignInActionRequestBody {
+class SignInActionRequestBodyParser(formRequestBodyParser: FormRequestBodyParser) {
 
-  lazy val bodyParser =
-    FormRequestBodyParser("SignInActionRequestBody")(signInForm)(handleFormErrors)
+  val bodyParser =
+    formRequestBodyParser.form("SignInActionRequestBody")(signInForm)(handleFormErrors)
 
 
-  def signInForm(requestHeader: RequestHeader): Form[SignInActionRequestBody] =
+  private def signInForm(requestHeader: RequestHeader): Form[SignInActionRequestBody] =
     signInForm(requestHeader.headers.get(HeaderNames.REFERER))
 
-  def signInForm(refererHeader: Option[String]): Form[SignInActionRequestBody] =
+  private def signInForm(refererHeader: Option[String]): Form[SignInActionRequestBody] =
     Form {
       FormMapping.signInFormMapping(refererHeader)
     }
@@ -51,7 +51,7 @@ object SignInActionRequestBody {
   }
 
 
-  object FormMapping {
+  private object FormMapping {
     import play.api.data.Forms.{boolean, default, mapping, optional, text}
     import ClientID.FormMapping.clientId
     import GroupCode.FormMappings.groupCode

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -6,7 +6,7 @@ import com.gu.identity.frontend.controllers.routes
 import com.gu.identity.frontend.models._
 import com.gu.identity.frontend.models.text.RegisterText
 import com.gu.identity.frontend.mvt._
-import com.gu.identity.frontend.request.RegisterActionRequestBody.FormMapping
+import com.gu.identity.frontend.request.RegisterActionRequestBodyFormMapping
 import play.api.i18n.Messages
 import play.filters.csrf.CSRF.Token
 
@@ -104,7 +104,7 @@ object RegisterViewModel {
 
       countryCodes = codes,
       gitCommitId = BuildInfo.gitCommitId,
-      emailValidationRegex = FormMapping.dotlessDomainEmailRegex.pattern.toString
+      emailValidationRegex = RegisterActionRequestBodyFormMapping.dotlessDomainEmailRegex.pattern.toString
     )
   }
 

--- a/test/com/gu/identity/frontend/controllers/RegisterActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/RegisterActionSpec.scala
@@ -7,6 +7,7 @@ import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.errors.{RegisterServiceBadRequestException, RegisterServiceGatewayAppException}
 import com.gu.identity.frontend.logging.MetricsLoggingActor
 import com.gu.identity.frontend.models.{ClientIp, TrackingData}
+import com.gu.identity.frontend.request.{FormRequestBodyParser, RegisterActionRequestBodyParser}
 import com.gu.identity.frontend.services.{IdentityService, ServiceAction}
 import com.gu.identity.frontend.utils.UrlDecoder
 import com.gu.identity.service.client.{ClientBadRequestError, ClientGatewayError}
@@ -34,9 +35,11 @@ class RegisterActionSpec extends PlaySpec with MockitoSugar {
     val eventActor = mock[AnalyticsEventActor]
     val cc = Helpers.stubControllerComponents()
     val serviceAction = new ServiceAction(cc)
+    val formRequestBodyParser = new FormRequestBodyParser(Helpers.stubPlayBodyParsers)
+    val parser = new RegisterActionRequestBodyParser(formRequestBodyParser)
 
     val controller =
-      new RegisterAction(mockIdentityService, cc, metricsActor, eventActor, config, serviceAction)
+      new RegisterAction(mockIdentityService, cc, metricsActor, eventActor, config, serviceAction, parser)
   }
 
   def fakeRegisterRequest(

--- a/test/com/gu/identity/frontend/controllers/ResetPasswordActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/ResetPasswordActionSpec.scala
@@ -5,7 +5,7 @@ import akka.stream.{ActorMaterializer, Materializer}
 import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.errors.ResetPasswordServiceGatewayAppException
 import com.gu.identity.frontend.models.ClientIp
-import com.gu.identity.frontend.request.ResetPasswordActionRequestBody
+import com.gu.identity.frontend.request.{FormRequestBodyParser, ResetPasswordActionRequestBody, ResetPasswordActionRequestBodyParser}
 import com.gu.identity.frontend.services.{IdentityService, ServiceAction}
 import com.gu.identity.service.client.{ClientGatewayError, SendResetPasswordEmailResponse}
 import org.scalatest.mockito.MockitoSugar
@@ -27,7 +27,9 @@ class ResetPasswordActionSpec extends PlaySpec with MockitoSugar {
     val config = Configuration.testConfiguration
     val cc = Helpers.stubControllerComponents()
     val serviceAction = new ServiceAction(cc)
-    val controller = new ResetPasswordAction(mockIdentityService, cc, serviceAction)
+    val formRequestBodyParser = new FormRequestBodyParser(Helpers.stubPlayBodyParsers)
+    val parser = new ResetPasswordActionRequestBodyParser(formRequestBodyParser)
+    val controller = new ResetPasswordAction(mockIdentityService, cc, serviceAction, parser)
   }
 
   def fakeRequest(email: String) =
@@ -43,12 +45,10 @@ class ResetPasswordActionSpec extends PlaySpec with MockitoSugar {
       val config = Configuration.testConfiguration
       val cc = Helpers.stubControllerComponents()
       val serviceAction = new ServiceAction(cc)
-
-      lazy val controller = new ResetPasswordAction(
-        mockIdentityService,
-        cc,
-        serviceAction
-      )
+      val formRequestBodyParser = new FormRequestBodyParser(Helpers.stubPlayBodyParsers)
+      val parser = new ResetPasswordActionRequestBodyParser(formRequestBodyParser)
+      lazy val controller =
+        new ResetPasswordAction(mockIdentityService, cc, serviceAction, parser)
 
       val email = "example@gu.com"
 

--- a/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
+++ b/test/com/gu/identity/frontend/models/EmailValidationSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.identity.frontend.models
 
-import com.gu.identity.frontend.request.RegisterActionRequestBody.FormMapping.dotlessDomainEmail
+import com.gu.identity.frontend.request.RegisterActionRequestBodyFormMapping.dotlessDomainEmail
 import org.scalatest.{AppendedClues, FlatSpec, Matchers}
 import play.api.data.Forms._
 import play.api.data._


### PR DESCRIPTION
Addresses `BodyParsers.parse` deprecation warning:

```
@deprecated("Inject PlayBodyParsers or use AbstractController instead", "2.6.0")
```