### PR TITLE
Add CSRF token T&Cs agree form

### DIFF
--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -247,8 +247,8 @@ object ViewRenderer {
   def renderErrorPage(configuration: Configuration, error: HttpError, resultGenerator: Html => Result)(implicit messages: Messages) =
     renderViewModel("error-page", ErrorPageViewModel(configuration, error), resultGenerator)
 
-  def renderTsAndCs(configuration: Configuration, clientId: Option[ClientID], group: GroupCode, returnUrl: ReturnUrl, signOutLink: URI)(implicit messages: Messages) = {
-    val model = TsAndCsViewModel(configuration, clientId, group, returnUrl, signOutLink)
+  def renderTsAndCs(configuration: Configuration, clientId: Option[ClientID], group: GroupCode, returnUrl: ReturnUrl, signOutLink: URI, csrfToken: Option[Token])(implicit messages: Messages) = {
+    val model = TsAndCsViewModel(configuration, clientId, group, returnUrl, signOutLink, csrfToken)
     renderViewModel("third-party-ts-and-cs-page", model)
   }
 

--- a/app/com/gu/identity/frontend/views/models/TsAndCsViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/TsAndCsViewModel.scala
@@ -8,6 +8,7 @@ import com.gu.identity.frontend.models.text._
 import com.gu.identity.frontend.controllers._
 import com.gu.identity.frontend.models._
 import play.api.i18n.Messages
+import play.filters.csrf.CSRF.Token
 
 case class TsAndCsViewModel private(
     layout: LayoutViewModel,
@@ -17,7 +18,8 @@ case class TsAndCsViewModel private(
     tsAndCsPageText: ThirdPartyTsAndCsText,
     returnUrl: String,
     groupCode: String,
-    continueFormUrl: String = routes.ThirdPartyTsAndCs.addToGroupAction.url
+    continueFormUrl: String = routes.ThirdPartyTsAndCs.addToGroupAction.url,
+    csrfToken: Option[Token]
 ) extends ViewModel with ViewModelResources
 
 object TsAndCsViewModel {
@@ -26,7 +28,8 @@ object TsAndCsViewModel {
     clientId: Option[ClientID],
     group: GroupCode,
     returnUrl: ReturnUrl,
-    signOutLink: URI)(implicit messages: Messages): TsAndCsViewModel = {
+    signOutLink: URI,
+    csrfToken: Option[Token])(implicit messages: Messages): TsAndCsViewModel = {
 
     val layout = LayoutViewModel(configuration, clientId, Some(returnUrl))
     TsAndCsViewModel(
@@ -36,7 +39,8 @@ object TsAndCsViewModel {
       clientId = clientId,
       tsAndCsPageText = TsAndCsPageText.getPageText(group, signOutLink),
       groupCode = group.id,
-      returnUrl = returnUrl.url
+      returnUrl = returnUrl.url,
+      csrfToken = csrfToken
     )
   }
 }

--- a/public/third-party-ts-and-cs-page.hbs
+++ b/public/third-party-ts-and-cs-page.hbs
@@ -25,6 +25,7 @@
     <section class="layout-section layout-section--no-border">
 
       <form method="POST" action="{{continueFormUrl}}" >
+        <input type="hidden" name="csrfToken" value="{{ csrfToken.value }}">
         <input type="hidden" name="groupCode" value="{{ groupCode }}">
         <input type="hidden" name="returnUrl" value="{{ returnUrl }}">
         <div class="form-field-wrap">

--- a/test/com/gu/identity/frontend/controllers/ThirdPartyTsAndCsSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/ThirdPartyTsAndCsSpec.scala
@@ -180,7 +180,7 @@ class ThirdPartyTsAndCsSpec extends PlaySpec with MockitoSugar {
           }
         }
 
-      val future = thirdPartyTsAndCsController.confirm(group, returnUrl, clientId = None, skipConfirmation = false, cookie)
+      val future = thirdPartyTsAndCsController.confirm(group, returnUrl, clientId = None, skipConfirmation = false, cookie, None)
       val result = Await.result(future, timeout.duration)
       val r = Future.successful(result.right.get)
       redirectLocation(r) mustEqual url
@@ -213,7 +213,7 @@ class ThirdPartyTsAndCsSpec extends PlaySpec with MockitoSugar {
           }
         }
 
-      val future = thirdPartyTsAndCsController.confirm(group, returnUrl, clientId = None, skipConfirmation = true, cookie)
+      val future = thirdPartyTsAndCsController.confirm(group, returnUrl, clientId = None, skipConfirmation = true, cookie, None)
       val result = Await.result(future, timeout.duration)
       val r = Future.successful(result.right.get)
       redirectLocation(r) mustEqual url
@@ -241,7 +241,7 @@ class ThirdPartyTsAndCsSpec extends PlaySpec with MockitoSugar {
           }
         }
 
-      val future = thirdPartyTsAndCsController.confirm(group, returnUrl, clientId = None, skipConfirmation = false, cookie)
+      val future = thirdPartyTsAndCsController.confirm(group, returnUrl, clientId = None, skipConfirmation = false, cookie, None)
       val result = Await.result(future, timeout.duration)
       val r = result.left.get
       r mustEqual Seq(stubbedError)


### PR DESCRIPTION
Fix regression - After enabling global CSRF filter, `POST /actions/agree` was returning 403.