### PR TITLE
Fix text contrast

### DIFF
--- a/public/components/form/_form.css
+++ b/public/components/form/_form.css
@@ -110,7 +110,7 @@ generic input wrapper
   @extend %font-body-copy-small;
   &,
   .link {
-    color: var(--color-text-light);
+    color: var(--color-text);
   }
 }
 

--- a/public/components/layout/_layout.css
+++ b/public/components/layout/_layout.css
@@ -41,7 +41,6 @@
   &.layout-header__title--standfirst {
     @extend %font-header-standfirst;
     font-weight: 300;
-    color: var(--color-text-light);
     margin-top: calc(var(--size-baseline) / 2);
   }
   &.layout-header__title--has-proxy {
@@ -100,6 +99,5 @@ texty text
   }
   &.layout-text--small {
     @extend %font-body-copy-small;
-    color: var(--color-text-light);
   }
 }

--- a/public/css/_html.css
+++ b/public/css/_html.css
@@ -106,7 +106,6 @@ body > main {
   @extend %content-container;
   padding-bottom: 2rem;
   padding-top: 0.5rem;
-  color: var(--color-text-light);
 
   a:not(.form-button) {
     @extend .link;

--- a/public/css/_vars.css
+++ b/public/css/_vars.css
@@ -7,7 +7,6 @@
   --color-border-hover: #839ca3;
 
   --color-text: #121212;
-  --color-text-light: #3a3c3c;
 
   --color-error: #c70000;
   --color-info: #005689;


### PR DESCRIPTION
Remove `--color-text-light ` and make all text `#121212` instead. The visual changes are barely noticeable but this one passes WAI AAA contrast standards