### PR TITLE
Remove dupe smartLockSignIn metric

### DIFF
--- a/public/components/analytics/ga.js
+++ b/public/components/analytics/ga.js
@@ -6,11 +6,6 @@
 import { configuration } from '../configuration/configuration';
 
 const gaTracker = 'IdentityPropertyTracker';
-const events = {
-  metricMap: {
-    SmartLockSignin: 'metric3'
-  }
-};
 
 export function init() {
   const gaUID = configuration.gaUID;
@@ -39,7 +34,7 @@ function record(gaUID) {
 }
 
 function buildGoogleAnalyticsEvent(event) {
-  const fieldsObject = {
+  return {
     eventCategory: 'identity',
     eventAction: event.name,
     eventLabel: event.type,
@@ -48,14 +43,6 @@ function buildGoogleAnalyticsEvent(event) {
     dimension5: window.location.href,
     forceSSL: true
   };
-
-  // Increment the appropriate metric based on the event type
-  const metricId = events.metricMap[event.type];
-  if (metricId) {
-    fieldsObject[metricId] = 1;
-  }
-
-  return fieldsObject;
 }
 
 function loadGA() {

--- a/public/components/signin-form/_signin-form.hbs
+++ b/public/components/signin-form/_signin-form.hbs
@@ -11,6 +11,8 @@
     <input type="hidden" name="clientId" value="{{ clientId.id }}">
   {{/ clientId }}
 
+  <div class="smartlock-trigger" data-csrf-token="{{ csrfToken.value }}" data-return-url="{{ returnUrl }}" role="presentation"></div>
+
   <input id="signin_ga_client_id" type="hidden" name="gaClientId" value="">
 
   <p class="signin-form__prelude">

--- a/public/components/signin-form/signin-form.js
+++ b/public/components/signin-form/signin-form.js
@@ -83,7 +83,6 @@ class SignInFormModel {
       }).then(r => {
         if (r.status == 200) {
           this.updateSmartLockStatus(true);
-          customMetric({ name: 'SigninSuccessful', type: 'SmartLockSignin' });
           this.storeRedirect(c);
         } else {
           r.json().then(j => {

--- a/public/components/signin-form/signin-form.js
+++ b/public/components/signin-form/signin-form.js
@@ -15,7 +15,6 @@ class SignInFormModel {
     this.passwordFieldElement = passwordField;
     this.gaClientIdElement = gaClientIdElement;
     this.addBindings();
-    this.smartLock();
     this.saveClientId();
   }
 
@@ -46,21 +45,6 @@ class SignInFormModel {
         password: this.passwordFieldElement.value()
       });
       this.updateSmartLockStatus(true);
-      this.smartLockSignIn(c);
-    }
-  }
-
-  smartLock() {
-    if (navigator.credentials && navigator.credentials.preventSilentAccess) {
-      navigator.credentials
-        .get({
-          password: true
-        })
-        .then(c => {
-          if (c instanceof PasswordCredential) {
-            this.smartLockSignIn(c);
-          }
-        });
     }
   }
 
@@ -68,30 +52,6 @@ class SignInFormModel {
     navigator.credentials.store(c).then(_ => {
       window.location = getElementById('signin_returnUrl').value();
     });
-  }
-
-  smartLockSignIn(c) {
-    if (this.smartLockStatus.status) {
-      const form = new FormData(document.querySelector('#signin_form'));
-      form.set('email', c.id);
-      form.set('password', c.password);
-
-      fetch('/actions/signin/smartlock', {
-        credentials: 'same-origin',
-        method: 'POST',
-        body: form
-      }).then(r => {
-        if (r.status == 200) {
-          this.updateSmartLockStatus(true);
-          this.storeRedirect(c);
-        } else {
-          r.json().then(j => {
-            this.updateSmartLockStatus(false);
-            window.location = j.url;
-          });
-        }
-      });
-    }
   }
 
   updateSmartLockStatus(status) {

--- a/public/components/smartlock-trigger/smartlock-trigger.js
+++ b/public/components/smartlock-trigger/smartlock-trigger.js
@@ -2,7 +2,6 @@
 
 import qs from 'qs';
 import { route } from 'js/config';
-import { customMetric } from 'components/analytics/ga';
 
 const selector: string = '.smartlock-trigger';
 
@@ -33,7 +32,6 @@ const smartLockSignIn = (
     })
   }).then(r => {
     if (r.status === 200) {
-      customMetric({ name: 'SigninSuccessful', type: 'SmartLockSignin' });
       window.location.href = returnUrl;
     } else {
       throw new Error(ERR_FAILED_SIGNIN);

--- a/public/components/smartlock-trigger/smartlock-trigger.js
+++ b/public/components/smartlock-trigger/smartlock-trigger.js
@@ -31,7 +31,7 @@ const smartLockSignIn = (
         body: qs.stringify({
           email: credentials.id,
           password: credentials.password,
-          clientId: tracker.get('clientId'),
+          gaClientId: tracker.get('clientId'),
           csrfToken
         })
       })

--- a/public/components/smartlock-trigger/smartlock-trigger.js
+++ b/public/components/smartlock-trigger/smartlock-trigger.js
@@ -2,6 +2,7 @@
 
 import qs from 'qs';
 import { route } from 'js/config';
+import { fetchTracker } from 'components/analytics/ga';
 
 const selector: string = '.smartlock-trigger';
 
@@ -21,22 +22,27 @@ const smartLockSignIn = (
   returnUrl: string,
   csrfToken: string
 ) => {
-  fetch(route('smartlockSignIn'), {
-    credentials: 'same-origin',
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: qs.stringify({
-      email: credentials.id,
-      password: credentials.password,
-      csrfToken
-    })
-  }).then(r => {
-    if (r.status === 200) {
-      window.location.href = returnUrl;
-    } else {
-      throw new Error(ERR_FAILED_SIGNIN);
-    }
-  });
+  new Promise(fetchTracker)
+    .then(tracker =>
+      fetch(route('smartlockSignIn'), {
+        credentials: 'same-origin',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: qs.stringify({
+          email: credentials.id,
+          password: credentials.password,
+          clientId: tracker.get('clientId'),
+          csrfToken
+        })
+      })
+    )
+    .then(r => {
+      if (r.status === 200) {
+        window.location.href = returnUrl;
+      } else {
+        throw new Error(ERR_FAILED_SIGNIN);
+      }
+    });
 };
 
 const init = ($element: HTMLElement): void => {

--- a/public/components/smartlock-trigger/smartlock-trigger.js
+++ b/public/components/smartlock-trigger/smartlock-trigger.js
@@ -52,8 +52,6 @@ const init = ($element: HTMLElement): void => {
   if (navigator && navigator.credentials !== null) {
     const credentialsContainer = (navigator: any).credentials;
 
-    credentialsContainer.preventSilentAccess();
-
     credentialsContainer
       .get({
         password: true


### PR DESCRIPTION
The smartlocksignin event is being sent twice to GA at the moment. This removes the client side sending