### PR TITLE
Make the register page slightly narrower

### DIFF
--- a/app/com/gu/identity/frontend/models/Text.scala
+++ b/app/com/gu/identity/frontend/models/Text.scala
@@ -65,50 +65,7 @@ object Text {
       )
     }
   }
-
-
-  object TwoStepSignInChoicesPageText {
-    def toMap()(implicit messages: Messages): Map[String, String] = {
-      Map (
-        "title" -> messages("signin.title"),
-        "pageTitle" -> messages("signin.pagetitle"),
-        "prelude" -> messages("signin.prelude"),
-        "preludeMoreInfo" -> messages("signin.prelude.moreinfo"),
-        "preludeFaq" -> messages("signin.prelude.faq"),
-        "email" -> messages("signin.email"),
-        "signInWithEmail" -> messages("signinTwoStep.signInWithEmailAction"),
-        "password" -> messages("signin.password"),
-        "forgottenPassword" -> messages("signin.forgottenpassword"),
-        "rememberMe" -> messages("signinTwoStep.rememberme"),
-        "signIn" -> messages("signin.signin"),
-        "noAccount" -> messages("signin.noaccount"),
-        "signUp" -> messages("signin.signup"),
-        "conditions" -> messages("signin.conditions"),
-        "continue" -> messages("signin.continue"),
-        "termsOfService" -> messages("signin.termsofservice"),
-        "privacyPolicy" -> messages("signin.privacypolicy"),
-
-        "emailFieldTitle" -> messages("signinTwoStep.emailFieldTitle"),
-        "setPasswordTitle" -> messages("signinTwoStep.setPasswordTitle"),
-        "setPasswordAction" -> messages("signinTwoStep.setPasswordAction"),
-        "recoverPasswordAction" -> messages("signinTwoStep.recoverPasswordAction"),
-        "divideText" -> messages("signinTwoStep.dividetext"),
-        "welcome" -> messages("signinTwoStep.welcome"),
-        "changeEmailLinkShort" -> messages("signinTwoStep.changeEmailLinkShort"),
-        "changeEmailLink" -> messages("signinTwoStep.changeEmailLink"),
-        "signInAction" -> messages("signinTwoStep.signInAction"),
-        "continueAction" -> messages("signinTwoStep.continueAction"),
-        "registerAction" -> messages("signinTwoStep.registerAction"),
-        "passwordFieldTitle" -> messages("signinTwoStep.passwordFieldTitle"),
-        "oauthStepTwoFieldTitle" -> messages("signinTwoStep.oauthStepTwoFieldTitle"),
-        "signInCtaEmailAction" -> messages("signinTwoStep.signInCtaEmailAction"),
-
-        "newUserCreateAccountAction" -> messages("signinTwoStep.newUserCreateAccountAction"),
-        "newUserCreateSocialAccountAction" -> messages("signinTwoStep.newUserCreateSocialAccountAction")
-      )
-    }
-  }
-
+  
   object LayoutText {
     def toMap(implicit messages: Messages): Map[String, String] = {
       Map(

--- a/app/com/gu/identity/frontend/models/text/RegisterText.scala
+++ b/app/com/gu/identity/frontend/models/text/RegisterText.scala
@@ -4,70 +4,41 @@ import com.gu.identity.frontend.models.{ClientID, GuardianMembersClientID}
 import play.api.i18n.Messages
 import com.gu.identity.model.Consent._
 
-case class RegisterText private(
-   createAccount: String,
-   continue: String,
-   divideText: String,
-   email: String,
-   emailHelp: String,
-   firstName: String,
-   lastName: String,
-   firstOrLastNameHelp: String,
-   name: String,
-   pageTitle: String,
-   password: String,
-   passwordHelp: String,
-   signIn: String,
-   signInCta: String,
-   standfirst: String,
-   title: String,
-   displayNameNote: String,
-   displayNameHelp: String,
-   displayNameHelpShortened: String,
-   displayNameHelpExpanded: String,
-   phone: String,
-   countryCode: String,
-
-   whyPhone: String,
-   becausePhone: String,
-   consent: ConsentRegisterText
-)
-
 object RegisterText {
-  def loadText(clientId : Option[ClientID])(implicit messages: Messages): RegisterText =
-    RegisterText(
-      createAccount = messages("register.createAccount"),
-      continue = messages("register.continue"),
-      divideText = messages("register.divideText"),
-      email = messages("register.email"),
-      emailHelp = messages("register.emailHelp"),
-      firstName = messages("register.firstName"),
-      lastName = messages("register.lastName"),
-      firstOrLastNameHelp = messages("register.firstOrLastNameHelp"),
-      name = messages("register.name"),
-      pageTitle = messages("register.pageTitle"),
-      password = messages("register.password"),
-      passwordHelp = messages("register.passwordHelp"),
-      signIn = messages("register.signIn"),
-      signInCta = messages("register.signInCta"),
-      standfirst = clientId match {
+  def toMap(clientId: Option[ClientID])(implicit messages: Messages): Map[String, _] = {
+    Map(
+      "createAccount" -> messages("register.createAccount"),
+      "continue" -> messages("register.continue"),
+      "divideText" -> messages("register.divideText"),
+      "email" -> messages("register.email"),
+      "emailHelp" -> messages("register.emailHelp"),
+      "firstName" -> messages("register.firstName"),
+      "lastName" -> messages("register.lastName"),
+      "firstOrLastNameHelp" -> messages("register.firstOrLastNameHelp"),
+      "name" -> messages("register.name"),
+      "pageTitle" -> messages("register.pageTitle"),
+      "password" -> messages("register.password"),
+      "passwordHelp" -> messages("register.passwordHelp"),
+      "signIn" -> messages("register.signIn"),
+      "signInCta" -> messages("register.signInCta"),
+      "standfirst" -> (clientId match {
         case Some(GuardianMembersClientID) => messages("register.title")
         case _ => messages("register.standfirst")
-      },
-      title = clientId match {
+      }),
+      "title" -> (clientId match {
         case Some(GuardianMembersClientID) => messages("register.title.supporter")
         case _ => messages("register.title")
-      },
-      displayNameNote = messages("register.displayNameNote"),
-      displayNameHelp = messages("register.displayNameHelp"),
-      displayNameHelpShortened = messages("register.displayNameHelpShortened"),
-      displayNameHelpExpanded = messages("register.displayNameHelpExpanded"),
-      phone = messages("register.phone"),
-      countryCode = messages("register.countryCode"),
-      whyPhone = messages("register.whyPhone"),
-      becausePhone = messages("register.becausePhone"),
-      consent = ConsentRegisterText()
+      }),
+      "displayNameHelp" -> messages("register.displayNameHelp"),
+      "displayNameHelpShortened" -> messages("register.displayNameHelpShortened"),
+      "displayNameHelpExpanded" -> messages("register.displayNameHelpExpanded"),
+      "phone " -> messages("register.phone"),
+      "countryCode" -> messages("register.countryCode"),
+      "whyPhone" -> messages("register.whyPhone"),
+      "becausePhone" -> messages("register.becausePhone"),
+      "consent" -> ConsentRegisterText()
     )
+  }
 }
 
 // FIXME: Warning, these are placeholder consents and should be changed or verified before changing the config to display them!

--- a/app/com/gu/identity/frontend/models/text/RegisterText.scala
+++ b/app/com/gu/identity/frontend/models/text/RegisterText.scala
@@ -4,21 +4,38 @@ import com.gu.identity.frontend.models.{ClientID, GuardianMembersClientID}
 import play.api.i18n.Messages
 import com.gu.identity.model.Consent._
 
-object RegisterText {
-  def toMap(clientId: Option[ClientID])(implicit messages: Messages): Map[String, _] = {
+object RegisterFormText {
+  def toMap()(implicit messages: Messages): Map[String, _] = {
     Map(
       "createAccount" -> messages("register.createAccount"),
       "continue" -> messages("register.continue"),
-      "divideText" -> messages("register.divideText"),
       "email" -> messages("register.email"),
       "emailHelp" -> messages("register.emailHelp"),
       "firstName" -> messages("register.firstName"),
       "lastName" -> messages("register.lastName"),
       "firstOrLastNameHelp" -> messages("register.firstOrLastNameHelp"),
       "name" -> messages("register.name"),
-      "pageTitle" -> messages("register.pageTitle"),
       "password" -> messages("register.password"),
       "passwordHelp" -> messages("register.passwordHelp"),
+      "signIn" -> messages("register.signIn"),
+      "signInCta" -> messages("register.signInCta"),
+      "displayNameHelp" -> messages("register.displayNameHelp"),
+      "displayNameHelpShortened" -> messages("register.displayNameHelpShortened"),
+      "displayNameHelpExpanded" -> messages("register.displayNameHelpExpanded"),
+      "phone" -> messages("register.phone"),
+      "countryCode" -> messages("register.countryCode"),
+      "whyPhone" -> messages("register.whyPhone"),
+      "becausePhone" -> messages("register.becausePhone"),
+      "consent" -> ConsentRegisterText()
+    )
+  }
+}
+
+object RegisterText {
+  def toMap(clientId: Option[ClientID] = None)(implicit messages: Messages): Map[String, _] = {
+    Map(
+      "divideText" -> messages("register.divideText"),
+      "pageTitle" -> messages("register.pageTitle"),
       "signIn" -> messages("register.signIn"),
       "signInCta" -> messages("register.signInCta"),
       "standfirst" -> (clientId match {
@@ -29,14 +46,6 @@ object RegisterText {
         case Some(GuardianMembersClientID) => messages("register.title.supporter")
         case _ => messages("register.title")
       }),
-      "displayNameHelp" -> messages("register.displayNameHelp"),
-      "displayNameHelpShortened" -> messages("register.displayNameHelpShortened"),
-      "displayNameHelpExpanded" -> messages("register.displayNameHelpExpanded"),
-      "phone " -> messages("register.phone"),
-      "countryCode" -> messages("register.countryCode"),
-      "whyPhone" -> messages("register.whyPhone"),
-      "becausePhone" -> messages("register.becausePhone"),
-      "consent" -> ConsentRegisterText()
     )
   }
 }

--- a/app/com/gu/identity/frontend/models/text/TwoStepSignInChoicesPageText.scala
+++ b/app/com/gu/identity/frontend/models/text/TwoStepSignInChoicesPageText.scala
@@ -1,0 +1,45 @@
+package com.gu.identity.frontend.models.text
+
+import play.api.i18n.Messages
+
+object TwoStepSignInChoicesPageText {
+  def toMap()(implicit messages: Messages): Map[String, String] = {
+    Map (
+      "title" -> messages("signin.title"),
+      "pageTitle" -> messages("signin.pagetitle"),
+      "prelude" -> messages("signin.prelude"),
+      "preludeMoreInfo" -> messages("signin.prelude.moreinfo"),
+      "preludeFaq" -> messages("signin.prelude.faq"),
+      "email" -> messages("signin.email"),
+      "signInWithEmail" -> messages("signinTwoStep.signInWithEmailAction"),
+      "password" -> messages("signin.password"),
+      "forgottenPassword" -> messages("signin.forgottenpassword"),
+      "rememberMe" -> messages("signinTwoStep.rememberme"),
+      "signIn" -> messages("signin.signin"),
+      "noAccount" -> messages("signin.noaccount"),
+      "signUp" -> messages("signin.signup"),
+      "conditions" -> messages("signin.conditions"),
+      "continue" -> messages("signin.continue"),
+      "termsOfService" -> messages("signin.termsofservice"),
+      "privacyPolicy" -> messages("signin.privacypolicy"),
+
+      "emailFieldTitle" -> messages("signinTwoStep.emailFieldTitle"),
+      "setPasswordTitle" -> messages("signinTwoStep.setPasswordTitle"),
+      "setPasswordAction" -> messages("signinTwoStep.setPasswordAction"),
+      "recoverPasswordAction" -> messages("signinTwoStep.recoverPasswordAction"),
+      "divideText" -> messages("signinTwoStep.dividetext"),
+      "welcome" -> messages("signinTwoStep.welcome"),
+      "changeEmailLinkShort" -> messages("signinTwoStep.changeEmailLinkShort"),
+      "changeEmailLink" -> messages("signinTwoStep.changeEmailLink"),
+      "signInAction" -> messages("signinTwoStep.signInAction"),
+      "continueAction" -> messages("signinTwoStep.continueAction"),
+      "registerAction" -> messages("signinTwoStep.registerAction"),
+      "passwordFieldTitle" -> messages("signinTwoStep.passwordFieldTitle"),
+      "oauthStepTwoFieldTitle" -> messages("signinTwoStep.oauthStepTwoFieldTitle"),
+      "signInCtaEmailAction" -> messages("signinTwoStep.signInCtaEmailAction"),
+
+      "newUserCreateAccountAction" -> messages("signinTwoStep.newUserCreateAccountAction"),
+      "newUserCreateSocialAccountAction" -> messages("signinTwoStep.newUserCreateSocialAccountAction")
+    )
+  }
+}

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -4,7 +4,7 @@ import buildinfo.BuildInfo
 import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.controllers.routes
 import com.gu.identity.frontend.models._
-import com.gu.identity.frontend.models.text.RegisterText
+import com.gu.identity.frontend.models.text.{RegisterFormText, RegisterText}
 import com.gu.identity.frontend.mvt._
 import com.gu.identity.frontend.request.RegisterActionRequestBodyFormMapping
 import play.api.i18n.Messages
@@ -17,6 +17,7 @@ case class RegisterViewModel(
                               oauth: OAuthRegistrationViewModel,
 
                               registerPageText: Map[String, _],
+                              registerFormText: Map[String, _],
                               terms: TermsViewModel,
 
                               hasErrors: Boolean,
@@ -76,6 +77,7 @@ object RegisterViewModel {
       oauth = OAuthRegistrationViewModel(configuration, returnUrl, skipConfirmation, clientId, group, activeTests),
 
       registerPageText = RegisterText.toMap(clientId),
+      registerFormText = RegisterFormText.toMap(),
       terms = Terms.getTermsModel(group),
 
       hasErrors = errors.nonEmpty,

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -16,7 +16,7 @@ case class RegisterViewModel(
 
                               oauth: OAuthRegistrationViewModel,
 
-                              registerPageText: RegisterText,
+                              registerPageText: Map[String, _],
                               terms: TermsViewModel,
 
                               hasErrors: Boolean,
@@ -75,7 +75,7 @@ object RegisterViewModel {
 
       oauth = OAuthRegistrationViewModel(configuration, returnUrl, skipConfirmation, clientId, group, activeTests),
 
-      registerPageText = RegisterText.loadText(clientId),
+      registerPageText = RegisterText.toMap(clientId),
       terms = Terms.getTermsModel(group),
 
       hasErrors = errors.nonEmpty,

--- a/app/com/gu/identity/frontend/views/models/TwoStepSignInChoicesViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/TwoStepSignInChoicesViewModel.scala
@@ -41,7 +41,8 @@ case class TwoStepSignInChoicesViewModel private(
   actions: Map[String, String] = Map(
     "signInWithEmailAndPassword" -> routes.SigninAction.signIn().url,
     "resetPassword" -> routes.ResetPasswordAction.reset().url,
-    "signInSecondStepCurrent" -> routes.SigninAction.signInSecondStepCurrent().url
+    "signInSecondStepCurrent" -> routes.SigninAction.signInSecondStepCurrent().url,
+    "register" -> routes.RegisterAction.register().url
   ),
   resources: Seq[PageResource with Product],
   indirectResources: Seq[PageResource with Product])

--- a/app/com/gu/identity/frontend/views/models/TwoStepSignInChoicesViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/TwoStepSignInChoicesViewModel.scala
@@ -4,6 +4,7 @@ import com.gu.identity.frontend.configuration.Configuration
 import com.gu.identity.frontend.controllers.routes
 import com.gu.identity.frontend.models.Text._
 import com.gu.identity.frontend.models._
+import com.gu.identity.frontend.models.text.TwoStepSignInChoicesPageText
 import com.gu.identity.frontend.mvt.ActiveMultiVariantTests
 import com.gu.identity.model.{CurrentUser, GuestUser, NewUser, UserType}
 import play.api.i18n.Messages

--- a/public/components/register-form/_form-field-email.hbs
+++ b/public/components/register-form/_form-field-email.hbs
@@ -1,0 +1,5 @@
+<div class="form-field-wrap">
+  <label class="form-field-wrap__title" for="register_field_email">{{ text.email }}</label>
+  <input class="form-field-wrap__field form-input" id="register_field_email" type="email" pattern="{{ emailValidationRegex }}" name="email" placeholder="{{ text.emailHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off"
+         spellcheck="false" value="{{email}}" required />
+</div>

--- a/public/components/register-form/_form-field-name.hbs
+++ b/public/components/register-form/_form-field-name.hbs
@@ -1,7 +1,5 @@
 <div class="form-field-wrap">
   <label class="form-field-wrap__title" for="register_field_firstname">{{ text.name }}</label>
-  <div class="u-flexrow u-flexrow--half form-field-wrap__field">
-    <input class="form-input" id="register_field_firstname" type="text" name="firstName" placeholder="{{ text.firstName }}" title="{{ text.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="^[^:/]*$" />
-    <input class="form-input" id="register_field_lastname" type="text" name="lastName" placeholder="{{ text.lastName }}" title="{{ text.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="^[^:/]*$" />
-  </div>
+  <input class="form-input form-field-wrap__field" id="register_field_firstname" type="text" name="firstName" placeholder="{{ text.firstName }}" title="{{ text.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="^[^:/]*$" />
+  <input class="form-input form-field-wrap__field" id="register_field_lastname" type="text" name="lastName" placeholder="{{ text.lastName }}" title="{{ text.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="^[^:/]*$" />
 </div>

--- a/public/components/register-form/_form-field-name.hbs
+++ b/public/components/register-form/_form-field-name.hbs
@@ -1,0 +1,7 @@
+<div class="form-field-wrap">
+  <label class="form-field-wrap__title" for="register_field_firstname">{{ text.name }}</label>
+  <div class="u-flexrow u-flexrow--half form-field-wrap__field">
+    <input class="form-input" id="register_field_firstname" type="text" name="firstName" placeholder="{{ text.firstName }}" title="{{ text.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="^[^:/]*$" />
+    <input class="form-input" id="register_field_lastname" type="text" name="lastName" placeholder="{{ text.lastName }}" title="{{ text.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="^[^:/]*$" />
+  </div>
+</div>

--- a/public/components/register-form/_form-field-password.hbs
+++ b/public/components/register-form/_form-field-password.hbs
@@ -1,0 +1,4 @@
+<div class="form-field-wrap">
+  <label class="form-field-wrap__title" for="register_field_password">{{ text.password }}</label>
+  <input class="form-field-wrap__field form-input" id="register_field_password" type="password" name="password" placeholder="{{ text.passwordHelp }}" required minlength="6" />
+</div>

--- a/public/components/register-form/_form-field-phone.hbs
+++ b/public/components/register-form/_form-field-phone.hbs
@@ -1,0 +1,29 @@
+{{# askForPhoneNumber }}
+  <div class="form-field-wrap form-field-wrap--phone">
+
+    <div>
+      <label class="form-field-wrap__title" for="register_field_countryCode">
+        {{ text.countryCode }}
+      </label>
+      <input type="hidden" id="register_field_countryIsoName" />
+      <select class="form-field-wrap__field form-input" id="register_field_countryCode" type="tel"
+              name="countryCode" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false">
+        {{#each countryCodes.codes }}
+          <option value="{{ code }}">+ {{ code }}</option>
+        {{/ each }}
+      </select>
+    </div>
+
+    <label class="form-field-wrap__title" for="register_field_localNumber">
+      {{ text.phone }}
+      <a hidden class="register-form__link--why-phone-number">{{ text.whyPhone }}</a>
+    </label>
+    <input class="form-field-wrap__field form-input" id="register_field_localNumber" type="tel"
+           name="localNumber" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false"
+           required minlength="3" maxlength="20"/>
+
+    <div class="form-field-wrap__footer">
+      {{ text.becausePhone }}
+    </div>
+  </div>
+{{/ askForPhoneNumber }}

--- a/public/components/register-form/_form-fields.hbs
+++ b/public/components/register-form/_form-fields.hbs
@@ -1,14 +1,14 @@
 <div class="form-field-wrap">
-  <label class="form-field-wrap__title" for="register_field_firstname">{{ registerPageText.name }}</label>
+  <label class="form-field-wrap__title" for="register_field_firstname">{{ registerFormText.name }}</label>
   <div class="u-flexrow u-flexrow--half form-field-wrap__field">
-    <input class="form-input" id="register_field_firstname" type="text" name="firstName" placeholder="{{ registerPageText.firstName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="^[^:/]*$" />
-    <input class="form-input" id="register_field_lastname" type="text" name="lastName" placeholder="{{ registerPageText.lastName }}" title="{{ registerPageText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="^[^:/]*$" />
+    <input class="form-input" id="register_field_firstname" type="text" name="firstName" placeholder="{{ registerFormText.firstName }}" title="{{ registerFormText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="^[^:/]*$" />
+    <input class="form-input" id="register_field_lastname" type="text" name="lastName" placeholder="{{ registerFormText.lastName }}" title="{{ registerFormText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="^[^:/]*$" />
   </div>
 </div>
 
 <div class="form-field-wrap">
-  <label class="form-field-wrap__title" for="register_field_email">{{ registerPageText.email }}</label>
-  <input class="form-field-wrap__field form-input" id="register_field_email" type="email" pattern="{{ emailValidationRegex }}" name="email" placeholder="{{ registerPageText.emailHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off"
+  <label class="form-field-wrap__title" for="register_field_email">{{ registerFormText.email }}</label>
+  <input class="form-field-wrap__field form-input" id="register_field_email" type="email" pattern="{{ emailValidationRegex }}" name="email" placeholder="{{ registerFormText.emailHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off"
          spellcheck="false" value="{{email}}" required />
   {{#each errors.emailErrors }}
     <p data-feedback-id="{{ id }}" class="form-feedback form-feedback--error form-feedback--hydratable form-field-wrap__field">{{ message }}</p>
@@ -21,7 +21,7 @@
 
     <div>
       <label class="form-field-wrap__title" for="register_field_countryCode">
-        {{ registerPageText.countryCode }}
+        {{ registerFormText.countryCode }}
       </label>
       <input type="hidden" id="register_field_countryIsoName" />
       <select class="form-field-wrap__field form-input" id="register_field_countryCode" type="tel"
@@ -33,22 +33,22 @@
     </div>
 
     <label class="form-field-wrap__title" for="register_field_localNumber">
-      {{ registerPageText.phone }}
-        <a hidden class="register-form__link--why-phone-number">{{ registerPageText.whyPhone }}</a>
+      {{ registerFormText.phone }}
+        <a hidden class="register-form__link--why-phone-number">{{ registerFormText.whyPhone }}</a>
     </label>
     <input class="form-field-wrap__field form-input" id="register_field_localNumber" type="tel"
            name="localNumber" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false"
            required minlength="3" maxlength="20"/>
 
     <div class="form-field-wrap__footer">
-      {{ registerPageText.becausePhone }}
+      {{ registerFormText.becausePhone }}
     </div>
   </div>
 {{/ askForPhoneNumber }}
 
 <div class="form-field-wrap">
-    <label class="form-field-wrap__title" for="register_field_password">{{ registerPageText.password }}</label>
-    <input class="form-field-wrap__field form-input" id="register_field_password" type="password" name="password" placeholder="{{ registerPageText.passwordHelp }}" required minlength="6" />
+    <label class="form-field-wrap__title" for="register_field_password">{{ registerFormText.password }}</label>
+    <input class="form-field-wrap__field form-input" id="register_field_password" type="password" name="password" placeholder="{{ registerFormText.passwordHelp }}" required minlength="6" />
   {{#each errors.passwordErrors }}
     <p data-feedback-id="{{ id }}" class="form-feedback form-feedback--error form-feedback--hydratable form-field-wrap__field">{{ message }}</p>
   {{/ each }}
@@ -60,9 +60,9 @@
   {{#if shouldCollectV2Consents}}
     <div class="form-checkbox">
       <input type="hidden" id="consents_0_actor" name="consents[0].actor" value="user">
-      <input type="hidden" id="consents_0_id" name="consents[0].id" value={{ registerPageText.consent.SupporterConsentIdentifier }}>
+      <input type="hidden" id="consents_0_id" name="consents[0].id" value={{ registerFormText.consent.SupporterConsentIdentifier }}>
       <input class="form-checkbox__input" id="register_field_supporter_consent" type="checkbox" name="consents[0].consented" value="true"/>
-      <label class="form-checkbox__label" for="register_field_supporter_consent">{{ registerPageText.consent.SupporterConsentText }}</label>
+      <label class="form-checkbox__label" for="register_field_supporter_consent">{{ registerFormText.consent.SupporterConsentText }}</label>
     </div>
 
   {{/if}}

--- a/public/components/register-form/_form-fields.hbs
+++ b/public/components/register-form/_form-fields.hbs
@@ -1,59 +1,19 @@
-<div class="form-field-wrap">
-  <label class="form-field-wrap__title" for="register_field_firstname">{{ registerFormText.name }}</label>
-  <div class="u-flexrow u-flexrow--half form-field-wrap__field">
-    <input class="form-input" id="register_field_firstname" type="text" name="firstName" placeholder="{{ registerFormText.firstName }}" title="{{ registerFormText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="^[^:/]*$" />
-    <input class="form-input" id="register_field_lastname" type="text" name="lastName" placeholder="{{ registerFormText.lastName }}" title="{{ registerFormText.firstOrLastNameHelp }}" required maxlength="25" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="^[^:/]*$" />
-  </div>
-</div>
+{{> components/register-form/_form-field-name text=registerFormText }}
 
-<div class="form-field-wrap">
-  <label class="form-field-wrap__title" for="register_field_email">{{ registerFormText.email }}</label>
-  <input class="form-field-wrap__field form-input" id="register_field_email" type="email" pattern="{{ emailValidationRegex }}" name="email" placeholder="{{ registerFormText.emailHelp }}" autocomplete="on" autocapitalize="off" autocorrect="off"
-         spellcheck="false" value="{{email}}" required />
-  {{#each errors.emailErrors }}
-    <p data-feedback-id="{{ id }}" class="form-feedback form-feedback--error form-feedback--hydratable form-field-wrap__field">{{ message }}</p>
-  {{/ each }}
-</div>
+{{> components/register-form/_form-field-email
+    text=registerFormText emailValidationRegex=emailValidationRegex email=email }}
+{{# each errors.emailErrors }}
+  <p data-feedback-id="{{ id }}" class="form-feedback form-feedback--error form-feedback--hydratable form-field-wrap__field">{{ message }}</p>
+{{/ each }}
 
+{{> components/register-form/_form-field-phone
+    text=registerFormText askForPhoneNumber=askForPhoneNumber countryCodes=countryCodes
+}}
 
-{{# askForPhoneNumber }}
-  <div class="form-field-wrap form-field-wrap--phone">
-
-    <div>
-      <label class="form-field-wrap__title" for="register_field_countryCode">
-        {{ registerFormText.countryCode }}
-      </label>
-      <input type="hidden" id="register_field_countryIsoName" />
-      <select class="form-field-wrap__field form-input" id="register_field_countryCode" type="tel"
-              name="countryCode" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false">
-        {{#each countryCodes.codes }}
-          <option value="{{ code }}">+ {{ code }}</option>
-        {{/ each }}
-      </select>
-    </div>
-
-    <label class="form-field-wrap__title" for="register_field_localNumber">
-      {{ registerFormText.phone }}
-        <a hidden class="register-form__link--why-phone-number">{{ registerFormText.whyPhone }}</a>
-    </label>
-    <input class="form-field-wrap__field form-input" id="register_field_localNumber" type="tel"
-           name="localNumber" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false"
-           required minlength="3" maxlength="20"/>
-
-    <div class="form-field-wrap__footer">
-      {{ registerFormText.becausePhone }}
-    </div>
-  </div>
-{{/ askForPhoneNumber }}
-
-<div class="form-field-wrap">
-    <label class="form-field-wrap__title" for="register_field_password">{{ registerFormText.password }}</label>
-    <input class="form-field-wrap__field form-input" id="register_field_password" type="password" name="password" placeholder="{{ registerFormText.passwordHelp }}" required minlength="6" />
-  {{#each errors.passwordErrors }}
-    <p data-feedback-id="{{ id }}" class="form-feedback form-feedback--error form-feedback--hydratable form-field-wrap__field">{{ message }}</p>
-  {{/ each }}
-</div>
-
+{{> components/register-form/_form-field-password text=registerFormText }}
+{{# each errors.passwordErrors }}
+  <p data-feedback-id="{{ id }}" class="form-feedback form-feedback--error form-feedback--hydratable form-field-wrap__field">{{ message }}</p>
+{{/ each }}
 
 {{#if shouldCollectConsents }}
 

--- a/public/components/register-form/_register-form.hbs
+++ b/public/components/register-form/_register-form.hbs
@@ -27,7 +27,7 @@
 
   {{> components/register-form/_form-fields}}
   <div class="form-field-wrap">
-    <button class="form-button form-button--main form-field-wrap__field" id="register_submit" type="submit">{{ registerPageText.createAccount }} {{> components/icon/arrow-inline }}</button>
+    <button class="form-button form-button--main form-field-wrap__field" id="register_submit" type="submit">{{ registerFormText.createAccount }} {{> components/icon/arrow-inline }}</button>
   </div>
 
 </form>

--- a/public/components/two-step-signin/two-step-signin-new.hbs
+++ b/public/components/two-step-signin/two-step-signin-new.hbs
@@ -1,4 +1,4 @@
-<form class="two-step-signin" method="POST" action="{{ actions.signInWithEmailAndPassword }}">
+<form class="two-step-signin" method="POST" action="{{ actions.signInSecondStepCurrent }}">
 
   {{> components/two-step-signin/_email-header }}
 

--- a/public/register-page.hbs
+++ b/public/register-page.hbs
@@ -2,7 +2,7 @@
 
 {{# partial "content" }}
 
-  <section class="layout-wrap-width layout-wrap-width--wide">
+  <section class="layout-wrap-width">
 
     <header class="layout-header">
       <h1 data-commitId="{{ gitCommitId }}" class="layout-header__title">{{ registerPageText.title }}</h1>


### PR DESCRIPTION
## What does this change?
Makes the register page slightly narrower

![screen shot 2018-06-20 at 1 46 33 pm](https://user-images.githubusercontent.com/11539094/41659169-6e7d3bda-7490-11e8-8abc-7301edd8249e.png)

## 13 files? What is seriously going on here?
This is all prep work to put the registration form in the 2 step sign-in flow. To do that I have fixed a long-standing gripe I had with the template code. namely, while all our sub templates are split up in components, those components inherit globals such as text strings from the page.

I have refactored the ones relating to sign up so they can be dropped into the new flow without relying on global variables. I've also started explicitly naming all parameters inside so you can easily tell what values they get from their signature.

Also the form became narrower because…well, the 2 step one is narrower and this way I can reuse the new `_form-field-name` partial. 