### PR TITLE
Change email token page

### DIFF
--- a/app/com/gu/identity/frontend/analytics/client/MeasurementProtocolRequest.scala
+++ b/app/com/gu/identity/frontend/analytics/client/MeasurementProtocolRequest.scala
@@ -93,7 +93,7 @@ private object SigninSecondStepEventRequestBody extends MeasurementProtocolReque
 }
 
 case class ChangeEmailSuccess(request: Request[AnyContent], gaUID: String) extends MeasurementProtocolRequest {
-  override val body: String = ResubSigninSuccessBody(request, gaUID)
+  override val body: String = ChangeEmailSuccessBody(request, gaUID)
 }
 
 case object ChangeEmailSuccessBody extends MeasurementProtocolRequestBody {

--- a/app/com/gu/identity/frontend/analytics/client/MeasurementProtocolRequest.scala
+++ b/app/com/gu/identity/frontend/analytics/client/MeasurementProtocolRequest.scala
@@ -92,6 +92,17 @@ private object SigninSecondStepEventRequestBody extends MeasurementProtocolReque
   )
 }
 
+case class ChangeEmailSuccess(request: Request[AnyContent], gaUID: String) extends MeasurementProtocolRequest {
+  override val body: String = ResubSigninSuccessBody(request, gaUID)
+}
+
+case object ChangeEmailSuccessBody extends MeasurementProtocolRequestBody {
+  override val extraBodyParams = Seq(
+    "ea" -> "ChangeEmailSuccessful",
+    "el" -> "ChangeEmail"
+  )
+}
+
 case class ResubAuthenticationSuccess(request: Request[AnyContent], gaUID: String) extends MeasurementProtocolRequest {
   override val body: String = ResubSigninSuccessBody(request, gaUID)
 }

--- a/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
+++ b/app/com/gu/identity/frontend/configuration/FrontendApplicationLoader.scala
@@ -85,6 +85,7 @@ class ApplicationComponents(context: Context)
   lazy val resendRepermissionTokenController = new ResendRepermissionTokenAction(identityService, controllerComponents, serviceAction, resendTokenActionRequestBodyParser)
   lazy val repermissionController = new RepermissionController(frontendConfiguration, identityService, controllerComponents, ExecutionContext.Implicits.global)
   lazy val signinTokenController = new SigninTokenController(frontendConfiguration, identityService, controllerComponents, analyticsEventActor, ExecutionContext.Implicits.global)
+  lazy val changeEmailController = new ChangeEmailController(frontendConfiguration, identityService, controllerComponents, analyticsEventActor, ExecutionContext.Implicits.global)
   lazy val optInController = new OptInController(controllerComponents)
   lazy val redirects = new Redirects(controllerComponents)
 
@@ -134,6 +135,7 @@ class ApplicationComponents(context: Context)
     optInController,
     assets,
     signinTokenController,
+    changeEmailController,
     redirects
   )
 

--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -99,6 +99,11 @@ class Application(
     renderResetPasswordEmailSent(configuration, clientIdOpt, emailProviderOpt)
   }
 
+  def changeEmail(clientId: Option[String]) = Action { implicit request =>
+    val clientIdOpt = ClientID(clientId)
+    renderEmailChange(configuration, clientIdOpt)
+  }
+
   def invalidConsentToken(errorIds: Seq[String], token: String) = Action { implicit req =>
     val csrfToken = CSRF.getToken(req)
     renderInvalidConsentToken(configuration, token, csrfToken, errorIds)

--- a/app/com/gu/identity/frontend/controllers/ChangeEmailController.scala
+++ b/app/com/gu/identity/frontend/controllers/ChangeEmailController.scala
@@ -20,11 +20,11 @@ class ChangeEmailController(
                              implicit val executionContext: ExecutionContext
                            ) extends AbstractController(cc) with Logging with I18nSupport {
 
-  def changeEmailAndSignIn(token: String, returnUrl: Option[String]) = Action.async { implicit request =>
+  def changeEmail(token: String, returnUrl: Option[String]) = Action.async { implicit request =>
     identityService.changeEmailWithToken(token).map {
-      case Right(cookies) =>
+      case Right(okResponse) =>
         eventActor.forward(ChangeEmailSuccess(request, configuration.gaUID))
-        SeeOther(returnUrl.getOrElse(configuration.dotcomBaseUrl)).withCookies(cookies: _*)
+        SeeOther(returnUrl.getOrElse(configuration.dotcomBaseUrl))
       case Left(_) =>
         ViewRenderer.renderErrorPage(configuration, EmailChangeTokenRejected("The link was expired or invalid, please request a new one."), Results.Unauthorized.apply)
     }

--- a/app/com/gu/identity/frontend/controllers/ChangeEmailController.scala
+++ b/app/com/gu/identity/frontend/controllers/ChangeEmailController.scala
@@ -1,0 +1,33 @@
+package com.gu.identity.frontend.controllers
+
+import com.gu.identity.frontend.analytics.AnalyticsEventActor
+import com.gu.identity.frontend.analytics.client.{ChangeEmailSuccess, ResubAuthenticationSuccess}
+import com.gu.identity.frontend.configuration.Configuration
+import com.gu.identity.frontend.errors.{EmailChangeTokenRejected, RedirectOnError, SigninTokenRejected}
+import com.gu.identity.frontend.logging.{LogOnErrorAction, Logging}
+import com.gu.identity.frontend.services.{IdentityService, ServiceAction}
+import com.gu.identity.frontend.views.ViewRenderer
+import play.api.i18n.I18nSupport
+import play.api.mvc._
+
+import scala.concurrent.ExecutionContext
+
+class ChangeEmailController(
+                             configuration: Configuration,
+                             identityService: IdentityService,
+                             cc: ControllerComponents,
+                             eventActor: AnalyticsEventActor,
+                             implicit val executionContext: ExecutionContext
+                           ) extends AbstractController(cc) with Logging with I18nSupport {
+
+  def changeEmailAndSignIn(token: String, returnUrl: Option[String]) = Action.async { implicit request =>
+    identityService.changeEmailWithToken(token).map {
+      case Right(cookies) =>
+        eventActor.forward(ChangeEmailSuccess(request, configuration.gaUID))
+        SeeOther(returnUrl.getOrElse(configuration.dotcomBaseUrl)).withCookies(cookies: _*)
+      case Left(_) =>
+        ViewRenderer.renderErrorPage(configuration, EmailChangeTokenRejected("The link was expired or invalid, please request a new one."), Results.Unauthorized.apply)
+    }
+  }
+
+}

--- a/app/com/gu/identity/frontend/controllers/ChangeEmailController.scala
+++ b/app/com/gu/identity/frontend/controllers/ChangeEmailController.scala
@@ -24,7 +24,7 @@ class ChangeEmailController(
     identityService.changeEmailWithToken(token).map {
       case Right(okResponse) =>
         eventActor.forward(ChangeEmailSuccess(request, configuration.gaUID))
-        SeeOther(returnUrl.getOrElse(configuration.dotcomBaseUrl))
+        NoCache(SeeOther(routes.Application.changeEmail().url))
       case Left(_) =>
         ViewRenderer.renderErrorPage(configuration, EmailChangeTokenRejected("The link was expired or invalid, please request a new one."), Results.Unauthorized.apply)
     }

--- a/app/com/gu/identity/frontend/errors/ChangeEmailTokenAppException.scala
+++ b/app/com/gu/identity/frontend/errors/ChangeEmailTokenAppException.scala
@@ -1,0 +1,34 @@
+package com.gu.identity.frontend.errors
+
+import com.gu.identity.frontend.errors.ErrorIDs._
+import com.gu.identity.service.client._
+
+sealed trait ChangeEmailTokenAppException extends AppException
+
+object ChangeEmailTokenAppException {
+  def apply(clientError: IdentityClientError): ChangeEmailTokenAppException =
+    clientError match {
+      case ClientInvalidTokenError => ChangeEmailTokenUnauthorizedException
+      case err: ClientBadRequestError => ChangeEmailTokenBadRequestAppException(err)
+      case err: ClientGatewayError => ChangeEmailTokenGatewayAppException(err)
+    }
+}
+
+case class ChangeEmailTokenBadRequestAppException(clientError: IdentityClientError)
+  extends ServiceBadRequestAppException(clientError)
+    with ChangeEmailTokenAppException {
+
+  val id = SignInInvalidCredentialsErrorID
+}
+
+case class ChangeEmailTokenGatewayAppException(clientError: IdentityClientError)
+  extends ServiceGatewayAppException(clientError)
+    with ChangeEmailTokenAppException {
+  override val id = ChangeEmailTokenGatewayErrorID
+}
+
+case object ChangeEmailTokenUnauthorizedException
+  extends ServiceBadRequestAppException(ClientInvalidTokenError)
+    with ChangeEmailTokenAppException {
+  override val id = UnauthorizedChangeEmailTokenErrorID
+}

--- a/app/com/gu/identity/frontend/errors/ErrorID.scala
+++ b/app/com/gu/identity/frontend/errors/ErrorID.scala
@@ -138,6 +138,14 @@ object ErrorIDs {
     val key = "unauthorized-repermission-token-error-gateway"
   }
 
+  case object ChangeEmailTokenGatewayErrorID extends ErrorID {
+    val key = "change-email-token-error-gateway"
+  }
+
+  case object UnauthorizedChangeEmailTokenErrorID extends ErrorID {
+    val key = "unauthorized-change-email-token-error-gateway"
+  }
+
   case object GetUserGatewayErrorID extends ErrorID {
     val key = "getuser-error-gateway"
   }

--- a/app/com/gu/identity/frontend/errors/HttpError.scala
+++ b/app/com/gu/identity/frontend/errors/HttpError.scala
@@ -8,6 +8,7 @@ case class NotFoundError(message: String) extends HttpError
 case class BadRequestError(message: String, statusCode: Int = 400) extends HttpError
 case class ForbiddenError(message: String) extends HttpError
 case class SigninTokenRejected(message: String) extends HttpError
+case class EmailChangeTokenRejected(message: String) extends HttpError
 
 case class UnexpectedError private(id: String, title: String, description: String) extends HttpError
 

--- a/app/com/gu/identity/frontend/models/text/ChangeEmailText.scala
+++ b/app/com/gu/identity/frontend/models/text/ChangeEmailText.scala
@@ -1,0 +1,19 @@
+package com.gu.identity.frontend.models.text
+
+import play.api.i18n.Messages
+
+case class ChangeEmailText private(
+                                               pageTitle: String,
+                                               title: String,
+                                               description: String,
+                                               error:String)
+
+object ChangeEmailText {
+  def apply()(implicit messages: Messages): ChangeEmailText =
+    ChangeEmailText(
+      pageTitle = messages("changeEmailSuccessful.pageTitle"),
+      title = messages("changeEmailSuccessful.title"),
+      description = messages("changeEmailSuccessful.description"),
+      error = messages("changeEmailSuccessful.unexpectedTitle")
+    )
+}

--- a/app/com/gu/identity/frontend/models/text/ChangeEmailText.scala
+++ b/app/com/gu/identity/frontend/models/text/ChangeEmailText.scala
@@ -14,8 +14,8 @@ object ChangeEmailText {
     ChangeEmailText(
       pageTitle = messages("changeEmailSuccessful.pageTitle"),
       title = messages("changeEmailSuccessful.title"),
-      button1 = messages("changeEmailSuccessful.button1"),
-      button2 = messages("changeEmailSuccessful.button2"),
+      button1 = messages("changeEmailSuccessful.backToAccountAction"),
+      button2 = messages("changeEmailSuccessful.returnToGuardianAction"),
       error = messages("changeEmailSuccessful.unexpectedTitle")
     )
 }

--- a/app/com/gu/identity/frontend/models/text/ChangeEmailText.scala
+++ b/app/com/gu/identity/frontend/models/text/ChangeEmailText.scala
@@ -5,8 +5,8 @@ import play.api.i18n.Messages
 case class ChangeEmailText private(
                                                pageTitle: String,
                                                title: String,
-                                               button1: String,
-                                               button2: String,
+                                               backToAccountAction: String,
+                                               returnToGuardianAction: String,
                                                error:String)
 
 object ChangeEmailText {
@@ -14,8 +14,8 @@ object ChangeEmailText {
     ChangeEmailText(
       pageTitle = messages("changeEmailSuccessful.pageTitle"),
       title = messages("changeEmailSuccessful.title"),
-      button1 = messages("changeEmailSuccessful.backToAccountAction"),
-      button2 = messages("changeEmailSuccessful.returnToGuardianAction"),
+      backToAccountAction = messages("changeEmailSuccessful.backToAccountAction"),
+      returnToGuardianAction = messages("changeEmailSuccessful.returnToGuardianAction"),
       error = messages("changeEmailSuccessful.unexpectedTitle")
     )
 }

--- a/app/com/gu/identity/frontend/models/text/ChangeEmailText.scala
+++ b/app/com/gu/identity/frontend/models/text/ChangeEmailText.scala
@@ -5,7 +5,8 @@ import play.api.i18n.Messages
 case class ChangeEmailText private(
                                                pageTitle: String,
                                                title: String,
-                                               description: String,
+                                               button1: String,
+                                               button2: String,
                                                error:String)
 
 object ChangeEmailText {
@@ -13,7 +14,8 @@ object ChangeEmailText {
     ChangeEmailText(
       pageTitle = messages("changeEmailSuccessful.pageTitle"),
       title = messages("changeEmailSuccessful.title"),
-      description = messages("changeEmailSuccessful.description"),
+      button1 = messages("changeEmailSuccessful.button1"),
+      button2 = messages("changeEmailSuccessful.button2"),
       error = messages("changeEmailSuccessful.unexpectedTitle")
     )
 }

--- a/app/com/gu/identity/frontend/models/text/ErrorPageText.scala
+++ b/app/com/gu/identity/frontend/models/text/ErrorPageText.scala
@@ -14,6 +14,7 @@ object ErrorPageText {
     case NotFoundError(_) => NotFoundErrorPageText()
     case ForbiddenError(_) => ForbiddenErrorPageText()
     case SigninTokenRejected(_) => SigninLinkFailedText()
+    case EmailChangeTokenRejected(_) => EmailChangeFailedText()
     case err: BadRequestError => BadRequestErrorPageText(err)
     case err: UnexpectedError => UnexpectedErrorPageText(err)
   }
@@ -86,6 +87,20 @@ object SigninLinkFailedText {
     )
 }
 
+case class EmailChangeFailedText private(
+                                         pageTitle: String,
+                                         title: String,
+                                         description: String)
+  extends ErrorPageText
+
+object EmailChangeFailedText {
+  def apply()(implicit messages: Messages): EmailChangeFailedText =
+    EmailChangeFailedText(
+      pageTitle = messages("errors.emailChange.pageTitle"),
+      title = messages("errors.emailChange.title"),
+      description = messages("errors.emailChange.description")
+    )
+}
 
 /** 5xx Unexpected text */
 case class UnexpectedErrorPageText private(

--- a/app/com/gu/identity/frontend/services/IdentityService.scala
+++ b/app/com/gu/identity/frontend/services/IdentityService.scala
@@ -26,7 +26,7 @@ trait IdentityService {
   def authenticateConsentToken(token: String)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, PlayCookies]]
   def authenticateRepermissionToken(token: String)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, PlayCookies]]
   def authenticateResubToken(loginToken: String)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, PlayCookies]]
-  def changeEmailWithToken(changeEmailToken: String)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, PlayCookies]]
+  def changeEmailWithToken(changeEmailToken: String)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, SendChangeEmailResponse]]
   def deauthenticate(cookie: PlayCookie, trackingData: TrackingData)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, PlayCookies]]
   def registerThenSignIn(request: RegisterActionRequestBody, clientIp: ClientIp, trackingData: TrackingData)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, PlayCookies]]
   def register(request: RegisterActionRequestBody, clientIp: ClientIp, trackingData: TrackingData)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, RegisterResponseUser]]
@@ -86,11 +86,11 @@ class IdentityServiceImpl(config: Configuration, adapter: IdentityServiceRequest
     }
   }
 
-  def changeEmailWithToken(changeEmailToken: String)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, PlayCookies]] = {
+  def changeEmailWithToken(changeEmailToken: String)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, SendChangeEmailResponse]] = {
     client.changeEmailWithToken(changeEmailToken) map {
       case Left(errors) =>
-        Left(errors.map(SignInServiceAppException.apply))
-      case Right(cookies) => Right(CookieService.signInCookies(cookies, rememberMe = false)(config))
+        Left(errors.map(ChangeEmailTokenAppException.apply))
+      case Right(okResponse) => Right(okResponse)
     }
   }
 

--- a/app/com/gu/identity/frontend/services/IdentityService.scala
+++ b/app/com/gu/identity/frontend/services/IdentityService.scala
@@ -26,6 +26,7 @@ trait IdentityService {
   def authenticateConsentToken(token: String)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, PlayCookies]]
   def authenticateRepermissionToken(token: String)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, PlayCookies]]
   def authenticateResubToken(loginToken: String)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, PlayCookies]]
+  def changeEmailWithToken(changeEmailToken: String)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, PlayCookies]]
   def deauthenticate(cookie: PlayCookie, trackingData: TrackingData)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, PlayCookies]]
   def registerThenSignIn(request: RegisterActionRequestBody, clientIp: ClientIp, trackingData: TrackingData)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, PlayCookies]]
   def register(request: RegisterActionRequestBody, clientIp: ClientIp, trackingData: TrackingData)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, RegisterResponseUser]]
@@ -79,6 +80,14 @@ class IdentityServiceImpl(config: Configuration, adapter: IdentityServiceRequest
 
   def authenticateResubToken(loginToken: String)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, PlayCookies]] = {
     client.authenticateResubToken(loginToken) map {
+      case Left(errors) =>
+        Left(errors.map(SignInServiceAppException.apply))
+      case Right(cookies) => Right(CookieService.signInCookies(cookies, rememberMe = false)(config))
+    }
+  }
+
+  def changeEmailWithToken(changeEmailToken: String)(implicit ec: ExecutionContext): Future[Either[ServiceExceptions, PlayCookies]] = {
+    client.changeEmailWithToken(changeEmailToken) map {
       case Left(errors) =>
         Left(errors.map(SignInServiceAppException.apply))
       case Right(cookies) => Right(CookieService.signInCookies(cookies, rememberMe = false)(config))

--- a/app/com/gu/identity/frontend/services/IdentityServiceRequestHandler.scala
+++ b/app/com/gu/identity/frontend/services/IdentityServiceRequestHandler.scala
@@ -72,6 +72,8 @@ class IdentityServiceRequestHandler(
   implicit val resubEmailRequestBodyFormat = Json.format[SendResubEmailApiRequestBody]
   implicit val resubTokenRequestBodyFormat = Json.format[ResubTokenRequestBody]
 
+  implicit val changeEmailRequestBodyFormat = Json.format[ChangeEmailTokenRequestBody]
+
   implicit val assignGroupResponseFormat = Json.format[AssignGroupResponse]
 
   def handleRequest(request: ApiRequest): Future[Either[IdentityClientErrors, ApiResponse]] = {
@@ -105,6 +107,7 @@ class IdentityServiceRequestHandler(
     case b: SendResetPasswordEmailRequestBody => Json.stringify(Json.toJson(b))
     case b: SendResubEmailApiRequestBody => Json.stringify(Json.toJson(b))
     case b: ResubTokenRequestBody => Json.stringify(Json.toJson(b))
+    case b: ChangeEmailTokenRequestBody => Json.stringify(Json.toJson(b))
   }
 
   private def encodeBody(params: (String, String)*) = {

--- a/app/com/gu/identity/frontend/services/IdentityServiceRequestHandler.scala
+++ b/app/com/gu/identity/frontend/services/IdentityServiceRequestHandler.scala
@@ -188,6 +188,14 @@ class IdentityServiceRequestHandler(
         handleUnexpectedResponse(response)
       }
 
+    case r: ChangeEmailTokenRequest =>
+      if (response.status == 200) {
+        Right(SendChangeEmailResponse())
+      }
+      else {
+        handleUnexpectedResponse(response)
+      }
+
     case r: UserTypeRequest =>
       if (response.status == 200) {
         Right(response.json.as[UserTypeResponse])

--- a/app/com/gu/identity/frontend/views/ViewRenderer.scala
+++ b/app/com/gu/identity/frontend/views/ViewRenderer.scala
@@ -184,6 +184,14 @@ object ViewRenderer {
     renderViewModel("reset-password-email-sent-page", model)
   }
 
+  def renderEmailChange(configuration: Configuration, clientId: Option[ClientID])(implicit message: Messages) = {
+    val model = ChangeEmailViewModel(
+      configuration = configuration,
+      clientId = clientId
+    )
+    renderViewModel("change-email-page", model)
+  }
+
   def renderResubLink(
     configuration: Configuration,
     clientId: Option[ClientID],

--- a/app/com/gu/identity/frontend/views/models/ChangeEmailViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/ChangeEmailViewModel.scala
@@ -1,0 +1,30 @@
+package com.gu.identity.frontend.views.models
+
+import com.gu.identity.frontend.configuration.Configuration
+import com.gu.identity.frontend.models.{ClientID, EmailProvider}
+import com.gu.identity.frontend.models.text.{ChangeEmailText, ResetPasswordEmailSentText, SendSignInLinkSentText}
+import play.api.i18n.Messages
+
+case class ChangeEmailViewModel private(
+                                                    layout: LayoutViewModel,
+                                                    ChangeEmailSuccessfulText: ChangeEmailText,
+                                                    resources: Seq[PageResource with Product],
+                                                    indirectResources: Seq[PageResource with Product]
+                                                  )
+  extends ViewModel
+    with ViewModelResources
+
+object ChangeEmailViewModel {
+
+  def apply(configuration: Configuration, clientId: Option[ClientID])(implicit messages: Messages): ChangeEmailViewModel = {
+    val layout = LayoutViewModel(configuration, clientId, returnUrl = None)
+
+    ChangeEmailViewModel(
+      layout = layout,
+      ChangeEmailSuccessfulText = ChangeEmailText(),
+      resources = layout.resources,
+      indirectResources = layout.indirectResources
+    )
+  }
+}
+

--- a/app/com/gu/identity/frontend/views/models/ChangeEmailViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/ChangeEmailViewModel.scala
@@ -1,8 +1,8 @@
 package com.gu.identity.frontend.views.models
 
 import com.gu.identity.frontend.configuration.Configuration
-import com.gu.identity.frontend.models.{ClientID, EmailProvider}
-import com.gu.identity.frontend.models.text.{ChangeEmailText, ResetPasswordEmailSentText, SendSignInLinkSentText}
+import com.gu.identity.frontend.models.{ClientID}
+import com.gu.identity.frontend.models.text.ChangeEmailText
 import play.api.i18n.Messages
 
 case class ChangeEmailViewModel private(

--- a/app/com/gu/identity/service/client/ApiResponses.scala
+++ b/app/com/gu/identity/service/client/ApiResponses.scala
@@ -24,6 +24,8 @@ case object ConsentTokenUsed extends ApiResponse
 
 case class SendResetPasswordEmailResponse() extends ApiResponse
 
+case class SendChangeEmailResponse() extends ApiResponse
+
 case class SendSignInTokenEmailResponse() extends ApiResponse
 
 case class ResendTokenResponse() extends ApiResponse

--- a/app/com/gu/identity/service/client/IdentityClient.scala
+++ b/app/com/gu/identity/service/client/IdentityClient.scala
@@ -25,6 +25,15 @@ class IdentityClient extends Logging {
     }
   }
 
+  def changeEmailWithToken(token: String)(implicit configuration: IdentityClientConfiguration, ec: ExecutionContext): Future[Either[IdentityClientErrors, Seq[IdentityApiCookie]]] = {
+    configuration.requestHandler.handleRequest(ChangeEmailTokenRequest(token, configuration)).map {
+      case Left(error) => Left(error)
+      case Right(AuthenticationCookiesResponse(cookies)) =>
+        Right(cookies.values.map(IdentityApiCookie(_, cookies.expiresAt)))
+      case Right(other) => Left(Seq(ClientGatewayError("Unknown response")))
+    }
+  }
+
   def authenticateTokenCookies(token: String, trackingData: TrackingData)(implicit configuration: IdentityClientConfiguration, ec: ExecutionContext): Future[Either[IdentityClientErrors, Seq[IdentityApiCookie]]] =
     AuthenticateCookiesApiRequest(None, None, false, Some(token), trackingData) match {
       case Right(request) => authenticateCookies(request)

--- a/app/com/gu/identity/service/client/IdentityClient.scala
+++ b/app/com/gu/identity/service/client/IdentityClient.scala
@@ -25,11 +25,11 @@ class IdentityClient extends Logging {
     }
   }
 
-  def changeEmailWithToken(token: String)(implicit configuration: IdentityClientConfiguration, ec: ExecutionContext): Future[Either[IdentityClientErrors, Seq[IdentityApiCookie]]] = {
+  def changeEmailWithToken(token: String)(implicit configuration: IdentityClientConfiguration, ec: ExecutionContext): Future[Either[IdentityClientErrors, SendChangeEmailResponse]] = {
     configuration.requestHandler.handleRequest(ChangeEmailTokenRequest(token, configuration)).map {
       case Left(error) => Left(error)
-      case Right(AuthenticationCookiesResponse(cookies)) =>
-        Right(cookies.values.map(IdentityApiCookie(_, cookies.expiresAt)))
+      case Right(r: SendChangeEmailResponse) =>
+        Right(r)
       case Right(other) => Left(Seq(ClientGatewayError("Unknown response")))
     }
   }

--- a/app/com/gu/identity/service/client/request/ChangeEmailTokenRequest.scala
+++ b/app/com/gu/identity/service/client/request/ChangeEmailTokenRequest.scala
@@ -8,10 +8,11 @@ final case class ChangeEmailTokenRequestBody(token: String) extends ApiRequestBo
 object ChangeEmailTokenRequest {
   def apply(token: String, config: IdentityClientConfiguration): ChangeEmailTokenRequest = {
     val pathComponents = Seq("auth", "change-email")
-    new ChangeEmailTokenRequest(ApiRequest.apiEndpoint(pathComponents: _*)(config) + "?format=cookies") {
+    new ChangeEmailTokenRequest(ApiRequest.apiEndpoint(pathComponents: _*)(config)) {
       override val method: HttpMethod = POST
       override val headers = Iterable(ApiRequest.apiKeyHeader(config))
       override val body = Some(ChangeEmailTokenRequestBody(token))
+      override val parameters: HttpParameters = List("token" -> token)
     }
   }
 }

--- a/app/com/gu/identity/service/client/request/ChangeEmailTokenRequest.scala
+++ b/app/com/gu/identity/service/client/request/ChangeEmailTokenRequest.scala
@@ -1,0 +1,17 @@
+package com.gu.identity.service.client.request
+
+import com.gu.identity.service.client._
+
+case class ChangeEmailTokenRequest private(override val url: String) extends ApiRequest
+final case class ChangeEmailTokenRequestBody(token: String) extends ApiRequestBody
+
+object ChangeEmailTokenRequest {
+  def apply(token: String, config: IdentityClientConfiguration): ChangeEmailTokenRequest = {
+    val pathComponents = Seq("auth", "change-email")
+    new ChangeEmailTokenRequest(ApiRequest.apiEndpoint(pathComponents: _*)(config) + "?format=cookies") {
+      override val method: HttpMethod = POST
+      override val headers = Iterable(ApiRequest.apiKeyHeader(config))
+      override val body = Some(ChangeEmailTokenRequestBody(token))
+    }
+  }
+}

--- a/app/com/gu/identity/service/client/request/ChangeEmailTokenRequest.scala
+++ b/app/com/gu/identity/service/client/request/ChangeEmailTokenRequest.scala
@@ -7,7 +7,7 @@ final case class ChangeEmailTokenRequestBody(token: String) extends ApiRequestBo
 
 object ChangeEmailTokenRequest {
   def apply(token: String, config: IdentityClientConfiguration): ChangeEmailTokenRequest = {
-    val pathComponents = Seq("auth", "change-email")
+    val pathComponents = Seq("user", "change-email")
     new ChangeEmailTokenRequest(ApiRequest.apiEndpoint(pathComponents: _*)(config)) {
       override val method: HttpMethod = POST
       override val headers = Iterable(ApiRequest.apiKeyHeader(config))

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -1,6 +1,6 @@
 include "application"
 
-identity.api.host=idapi.thegulocal.com
+identity.api.host=idapi.code.dev-theguardian.com
 
 identity.frontend.cookieDomain=.thegulocal.com
 

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -1,6 +1,6 @@
 include "application"
 
-identity.api.host=idapi.code.dev-theguardian.com
+identity.api.host=idapi.thegulocal.com
 
 identity.frontend.cookieDomain=.thegulocal.com
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -140,6 +140,11 @@ resetPasswordEmailSent.instructions2=Click the ‘Set a password’ button in th
 resetPasswordEmailSent.instructions3=Please note that the link is valid for 30 minutes, so be sure to use it soon.
 resetPasswordEmailSent.instructions4=Please check your inbox!
 
+changeEmailSuccessful.pageTitle=Successfully changed your email address
+changeEmailSuccessful.title=Successfully changed your email address
+changeEmailSuccessful.description=Go to your account page to edit preferences
+changeEmailSuccessful.unexpectedTitle=PROBLEM
+
 errors.badRequest.pageTitle=Bad request: {0}
 errors.badRequest.title=Bad request: {0}
 errors.badRequest.description=Your request was not recognised. Please try again.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -157,6 +157,10 @@ errors.signinLink.pageTitle=Sign in Failed
 errors.signinLink.title=Sign In Failed
 errors.signinLink.description=Sorry - that sign in link is expired or invalid. Please request a new one.
 
+errors.emailChange.pageTitle=Email change Failed
+errors.emailChange.title=Email change Failed
+errors.emailChange.description=Sorry - that email change link failed.
+
 errors.unexpected.pageTitle=Unexpected error
 errors.unexpected.title=Unexpected error: {0}
 errors.unexpected.description=Sorry - an unexpected error has occurred, please try again later.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -142,8 +142,8 @@ resetPasswordEmailSent.instructions4=Please check your inbox!
 
 changeEmailSuccessful.pageTitle=Email changed
 changeEmailSuccessful.title=Success! Your email address has been updated.
-changeEmailSuccessful.button1=Back to Account details
-changeEmailSuccessful.button2=Continue to The Guardian homepage
+changeEmailSuccessful.backToAccountAction=Back to Account details
+changeEmailSuccessful.returnToGuardianAction=Continue to The Guardian homepage
 changeEmailSuccessful.unexpectedTitle=Sorry there was a problem
 
 errors.badRequest.pageTitle=Bad request: {0}

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -140,10 +140,11 @@ resetPasswordEmailSent.instructions2=Click the ‘Set a password’ button in th
 resetPasswordEmailSent.instructions3=Please note that the link is valid for 30 minutes, so be sure to use it soon.
 resetPasswordEmailSent.instructions4=Please check your inbox!
 
-changeEmailSuccessful.pageTitle=Successfully changed your email address
-changeEmailSuccessful.title=Successfully changed your email address
-changeEmailSuccessful.description=Go to your account page to edit preferences
-changeEmailSuccessful.unexpectedTitle=PROBLEM
+changeEmailSuccessful.pageTitle=Email changed
+changeEmailSuccessful.title=Success! Your email address has been updated.
+changeEmailSuccessful.button1=Back to Account details
+changeEmailSuccessful.button2=Continue to The Guardian homepage
+changeEmailSuccessful.unexpectedTitle=Sorry there was a problem
 
 errors.badRequest.pageTitle=Bad request: {0}
 errors.badRequest.title=Bad request: {0}
@@ -162,9 +163,9 @@ errors.signinLink.pageTitle=Sign in Failed
 errors.signinLink.title=Sign In Failed
 errors.signinLink.description=Sorry - that sign in link is expired or invalid. Please request a new one.
 
-errors.emailChange.pageTitle=Email change Failed
+errors.emailChange.pageTitle=Email change failed
 errors.emailChange.title=Email change Failed
-errors.emailChange.description=Sorry - that email change link failed.
+errors.emailChange.description=Sorry - that email change link was expired or invalid.
 
 errors.unexpected.pageTitle=Unexpected error
 errors.unexpected.title=Unexpected error: {0}

--- a/conf/routes
+++ b/conf/routes
@@ -79,7 +79,7 @@ GET        /robots.txt                                  controllers.Assets.at(pa
 
 GET        /resub-email/:token                          com.gu.identity.frontend.controllers.SigninTokenController.signinWithResubToken(token: String, returnUrl: Option[String] ?= None)
 
-GET        /change-email/:token                         com.gu.identity.frontend.controllers.ChangeEmailController.changeEmailAndSignIn(token: String, returnUrl: Option[String] ?= None)
+GET        /change-email/:token                         com.gu.identity.frontend.controllers.ChangeEmailController.changeEmail(token: String, returnUrl: Option[String] ?= None)
 
 # Redirects
 GET        /                                            com.gu.identity.frontend.controllers.Redirects.indexRedirect

--- a/conf/routes
+++ b/conf/routes
@@ -79,6 +79,8 @@ GET        /robots.txt                                  controllers.Assets.at(pa
 
 GET        /resub-email/:token                          com.gu.identity.frontend.controllers.SigninTokenController.signinWithResubToken(token: String, returnUrl: Option[String] ?= None)
 
+GET        /change-email/:token                         com.gu.identity.frontend.controllers.ChangeEmailController.changeEmailAndSignIn(token: String, returnUrl: Option[String] ?= None)
+
 # Redirects
 GET        /                                            com.gu.identity.frontend.controllers.Redirects.indexRedirect
 GET        /signin/                                     com.gu.identity.frontend.controllers.Redirects.signInPageTrailingSlash

--- a/conf/routes
+++ b/conf/routes
@@ -81,7 +81,7 @@ GET        /resub-email/:token                          com.gu.identity.frontend
 
 GET        /change-email/:token                         com.gu.identity.frontend.controllers.ChangeEmailController.changeEmail(token: String, returnUrl: Option[String] ?= None)
 
-GET        /change-email-succesful                      com.gu.identity.frontend.controllers.Application.changeEmail(clientId: Option[String] ?= None)
+GET        /change-email-successful                      com.gu.identity.frontend.controllers.Application.changeEmail(clientId: Option[String] ?= None)
 
 # Redirects
 GET        /                                            com.gu.identity.frontend.controllers.Redirects.indexRedirect

--- a/conf/routes
+++ b/conf/routes
@@ -81,6 +81,8 @@ GET        /resub-email/:token                          com.gu.identity.frontend
 
 GET        /change-email/:token                         com.gu.identity.frontend.controllers.ChangeEmailController.changeEmail(token: String, returnUrl: Option[String] ?= None)
 
+GET        /change-email-succesful                      com.gu.identity.frontend.controllers.Application.changeEmail(clientId: Option[String] ?= None)
+
 # Redirects
 GET        /                                            com.gu.identity.frontend.controllers.Redirects.indexRedirect
 GET        /signin/                                     com.gu.identity.frontend.controllers.Redirects.signInPageTrailingSlash

--- a/public/change-email-page.hbs
+++ b/public/change-email-page.hbs
@@ -2,28 +2,34 @@
 
 {{# partial "content" }}
 
-  {{# unless errors}}
-    <h1 class="page-heading">{{ ChangeEmailSuccessfulText.title }}</h1>
-    <section class="page-standfirst">
-      <div class="form-field-wrap">
-        <a href="account/edit" data-link-name="change-email-cta1 : {{ChangeEmailSuccessfulText.button1}}" class="form-button form-button--main form-field-wrap__field">{{ChangeEmailSuccessfulText.button1}}
-          {{>components/icon/arrow-inline
-        }}</a>
-        <a href="https://www.theguardian.com" data-link-name="change-email-cta2 : {{ChangeEmailSuccessfulText.button2}}" class="form-button form-button--secondary form-field-wrap__field">{{ChangeEmailSuccessfulText.button2}} {{>
-        components/icon/arrow-inline }}</a>
-      </div>
+  <div class="layout-wrap-width">
+
+    {{# unless errors}}
+      <header class="layout-header">
+        <h1 class="layout-header__title">{{ ChangeEmailSuccessfulText.title }}</h1>
+      </header>
+
+      <section class="layout-section layout-section--no-border">
+        <div class="form-field-wrap">
+          <a href="account/edit" data-link-name="change-email-cta1 : {{ChangeEmailSuccessfulText.button1}}" class="form-button form-button--main form-field-wrap__field">{{ChangeEmailSuccessfulText.button1}}
+            {{>components/icon/arrow-inline
+          }}</a>
+          <a href="https://www.theguardian.com" data-link-name="change-email-cta2 : {{ChangeEmailSuccessfulText.button2}}" class="form-button form-button--secondary form-field-wrap__field">{{ChangeEmailSuccessfulText.button2}} {{>
+          components/icon/arrow-inline }}</a>
+        </div>
+      </section>
+    {{/unless}}
+
+    <section class="layout-header">
+      {{#if errors}}
+        <h1 class="layout-header__title">{{ ChangeEmailSuccessfulText.unexpectedTitle }}</h1>
+      {{/if}}
+
+      {{#each errors}}
+        <p id="{{id}}" class="form__error">{{message}}</p>
+      {{/each}}
     </section>
-  {{/unless}}
 
-  <section class="page-content">
-    {{#if errors}}
-      <h1 class="page-heading">{{ ChangeEmailSuccessfulText.unexpectedTitle }}</h1>
-    {{/if}}
-
-    {{#each errors}}
-      <p id="{{id}}" class="resend-consent-form__error">{{message}}</p>
-    {{/each}}
-  </section>
-
+  </div>
 {{/partial}}
 {{> layout}}

--- a/public/change-email-page.hbs
+++ b/public/change-email-page.hbs
@@ -11,11 +11,10 @@
 
       <section class="layout-section layout-section--no-border">
         <div class="form-field-wrap">
-          <a href="account/edit" data-link-name="change-email-cta1 : {{ChangeEmailSuccessfulText.button1}}" class="form-button form-button--main form-field-wrap__field">{{ChangeEmailSuccessfulText.button1}}
+          <button href="account/edit" data-link-name="change-email-backToAccountAction : {{ChangeEmailSuccessfulText.backToAccountAction}}" class="form-button form-button--main form-field-wrap__field">{{ChangeEmailSuccessfulText.backToAccountAction}}
             {{>components/icon/arrow-inline
-          }}</a>
-          <a href="https://www.theguardian.com" data-link-name="change-email-cta2 : {{ChangeEmailSuccessfulText.button2}}" class="form-button form-button--secondary form-field-wrap__field">{{ChangeEmailSuccessfulText.button2}} {{>
-          components/icon/arrow-inline }}</a>
+          }}</button>
+          <button href="https://www.theguardian.com" data-link-name="change-email-returnToGuardianAction : {{ChangeEmailSuccessfulText.returnToGuardianAction}}" class="form-button form-button--secondary form-field-wrap__field">{{ChangeEmailSuccessfulText.returnToGuardianAction}} {{>components/icon/arrow-inline }}</button>
         </div>
       </section>
     {{/unless}}

--- a/public/change-email-page.hbs
+++ b/public/change-email-page.hbs
@@ -5,7 +5,13 @@
   {{# unless errors}}
     <h1 class="page-heading">{{ ChangeEmailSuccessfulText.title }}</h1>
     <section class="page-standfirst">
-      <p class="page-standfirst__paragraph resend-link-description">{{ChangeEmailSuccessfulText.description}}</p>
+      <div class="form-field-wrap">
+        <a href="account/edit" data-link-name="change-email-cta1 : {{ChangeEmailSuccessfulText.button1}}" class="form-button form-button--main form-field-wrap__field">{{ChangeEmailSuccessfulText.button1}}
+          {{>components/icon/arrow-inline
+        }}</a>
+        <a href="https://www.theguardian.com" data-link-name="change-email-cta2 : {{ChangeEmailSuccessfulText.button2}}" class="form-button form-button--secondary form-field-wrap__field">{{ChangeEmailSuccessfulText.button2}} {{>
+        components/icon/arrow-inline }}</a>
+      </div>
     </section>
   {{/unless}}
 

--- a/public/change-email-page.hbs
+++ b/public/change-email-page.hbs
@@ -26,7 +26,7 @@
       {{/if}}
 
       {{#each errors}}
-        <p id="{{id}}" class="form__error">{{message}}</p>
+        <p id="{{id}}" class="form-feedback form-feedback--error form-field-wrap">{{message}}</p>
       {{/each}}
     </section>
 

--- a/public/change-email-page.hbs
+++ b/public/change-email-page.hbs
@@ -1,0 +1,23 @@
+{{# partial "pageTitle" }}{{ ChangeEmailSuccessfulText.pageTitle }}{{/ partial }}
+
+{{# partial "content" }}
+
+  {{# unless errors}}
+    <h1 class="page-heading">{{ ChangeEmailSuccessfulText.title }}</h1>
+    <section class="page-standfirst">
+      <p class="page-standfirst__paragraph resend-link-description">{{ChangeEmailSuccessfulText.description}}</p>
+    </section>
+  {{/unless}}
+
+  <section class="page-content">
+    {{#if errors}}
+      <h1 class="page-heading">{{ ChangeEmailSuccessfulText.unexpectedTitle }}</h1>
+    {{/if}}
+
+    {{#each errors}}
+      <p id="{{id}}" class="resend-consent-form__error">{{message}}</p>
+    {{/each}}
+  </section>
+
+{{/partial}}
+{{> layout}}


### PR DESCRIPTION
Related PR's:
- Identity: https://github.com/guardian/identity/pull/1241
- Frontend : https://github.com/guardian/frontend/pull/19888

- Page for forwarding change email tokens to the API
Success : 
![image](https://user-images.githubusercontent.com/14179210/41715630-fb005946-754b-11e8-8bc4-7de0941ad200.png)

Failure : 
![image](https://user-images.githubusercontent.com/14179210/41666814-4e016fb2-74a3-11e8-94ea-b467f04f172c.png)
 