### PR TITLE
Implement changes for the recurringContributions clientId

### DIFF
--- a/app/com/gu/identity/frontend/configuration/Configuration.scala
+++ b/app/com/gu/identity/frontend/configuration/Configuration.scala
@@ -107,7 +107,7 @@ object Configuration {
 
     preferredMembershipUrl = "https://membership.theguardian.com/supporter",
 
-    preferredSupportUrl = "https://support.theguardian.com/contribute",
+    preferredSupportUrl = "https://support.theguardian.com",
 
     jobsBaseUrl = "https://jobs.theguardian.com",
 

--- a/app/com/gu/identity/frontend/configuration/Configuration.scala
+++ b/app/com/gu/identity/frontend/configuration/Configuration.scala
@@ -19,6 +19,8 @@ case class Configuration(
   dotcomBaseUrl: String,
   preferredMembershipUrl: String,
 
+  preferredSupportUrl: String,
+
   jobsBaseUrl: String,
 
   identityFederationApiHost: String,
@@ -65,6 +67,8 @@ object Configuration {
 
       preferredMembershipUrl = getString("identity.frontend.preferredMembershipUrl"),
 
+      preferredSupportUrl = getString("identity.frontend.preferredSupportUrl"),
+
       jobsBaseUrl = getString("identity.frontend.jobsBaseUrl"),
 
       googleRecaptchaSiteKey = getString("google.recaptcha.site"),
@@ -100,7 +104,11 @@ object Configuration {
     identityProfileBaseUrl = "https://profile.code.dev-theguardian.com",
 
     dotcomBaseUrl = "https://www.theguardian.com",
+
     preferredMembershipUrl = "https://membership.theguardian.com/supporter",
+
+    preferredSupportUrl = "https://support.theguardian.com/contribute",
+
     jobsBaseUrl = "https://jobs.theguardian.com",
 
     googleRecaptchaSiteKey = "--recaptcha-key--",

--- a/app/com/gu/identity/frontend/models/ReturnUrl.scala
+++ b/app/com/gu/identity/frontend/models/ReturnUrl.scala
@@ -48,9 +48,13 @@ object ReturnUrl {
   def defaultForMembership(configuration: Configuration) =
     defaultFromUrl(configuration.preferredMembershipUrl)
 
+  def defaultForSupport(configuration: Configuration) =
+    defaultFromUrl(configuration.preferredSupportUrl)
+
   def defaultForClient(configuration: Configuration, clientId: Option[ClientID]) =
     clientId match {
       case Some(GuardianMembersClientID) => defaultForMembership(configuration)
+      case Some(GuardianRecurringContributionsClientID) => defaultForSupport(configuration)
       case _ => default(configuration)
     }
 

--- a/app/com/gu/identity/frontend/models/Text.scala
+++ b/app/com/gu/identity/frontend/models/Text.scala
@@ -4,9 +4,9 @@ import play.api.i18n.Messages
 
 object Text {
   object SignInPageText {
-    def toMap(isMembership: Boolean)(implicit messages: Messages): Map[String, String] = {
+    def toMap(showSupportMessaging: Boolean)(implicit messages: Messages): Map[String, String] = {
       Map (
-        "title" -> (if(isMembership) messages("signin.title.supporter") else messages("signin.title")),
+        "title" -> (if(showSupportMessaging) messages("signin.title.supporter") else messages("signin.title")),
         "pageTitle" -> messages("signin.pagetitle"),
         "prelude" -> messages("signin.prelude"),
         "preludeMoreInfo" -> messages("signin.prelude.moreinfo"),
@@ -28,9 +28,12 @@ object Text {
   }
 
   object TwoStepSignInStartPageText {
+
+    val showSupportMessaging = (clientId: Option[ClientID]) => clientId.contains(GuardianMembersClientID) || clientId.contains(GuardianRecurringContributionsClientID)
+
     def toMap(clientId: Option[ClientID])(implicit messages: Messages): Map[String, String] = {
       Map (
-        "title" -> (if(clientId.contains(GuardianMembersClientID)) messages("signin.title.supporter") else messages("signinTwoStep.welcomeStepOne")),
+        "title" -> (if(showSupportMessaging(clientId)) messages("signin.title.supporter") else messages("signinTwoStep.welcomeStepOne")),
         "pageTitle" -> messages("signin.pagetitle"),
         "prelude" -> messages("signin.prelude"),
         "preludeMoreInfo" -> messages("signin.prelude.moreinfo"),
@@ -65,7 +68,7 @@ object Text {
       )
     }
   }
-  
+
   object LayoutText {
     def toMap(implicit messages: Messages): Map[String, String] = {
       Map(

--- a/app/com/gu/identity/frontend/models/text/RegisterText.scala
+++ b/app/com/gu/identity/frontend/models/text/RegisterText.scala
@@ -1,6 +1,6 @@
 package com.gu.identity.frontend.models.text
 
-import com.gu.identity.frontend.models.{ClientID, GuardianMembersClientID}
+import com.gu.identity.frontend.models.{ClientID, GuardianMembersClientID, GuardianRecurringContributionsClientID}
 import play.api.i18n.Messages
 import com.gu.identity.model.Consent._
 
@@ -40,10 +40,12 @@ object RegisterText {
       "signInCta" -> messages("register.signInCta"),
       "standfirst" -> (clientId match {
         case Some(GuardianMembersClientID) => messages("register.title")
+        case Some(GuardianRecurringContributionsClientID) => messages("register.title")
         case _ => messages("register.standfirst")
       }),
       "title" -> (clientId match {
         case Some(GuardianMembersClientID) => messages("register.title.supporter")
+        case Some(GuardianRecurringContributionsClientID) => messages("register.title.supporter")
         case _ => messages("register.title")
       }),
     )

--- a/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/RegisterViewModel.scala
@@ -111,7 +111,7 @@ object RegisterViewModel {
   }
 
   def showStandfirst(clientId: Option[ClientID]) =
-    clientId.contains(GuardianJobsClientID) || clientId.contains(GuardianMembersClientID)
+    clientId.contains(GuardianJobsClientID) || clientId.contains(GuardianMembersClientID) || clientId.contains(GuardianRecurringContributionsClientID)
 
   def askForPhoneNumber(clientId: Option[ClientID]) =
     clientId.contains(GuardianCommentersClientID)

--- a/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/SignInViewModel.scala
@@ -56,14 +56,14 @@ object SignInViewModel {
 
     val resources = getResources(layout, recaptchaModel) ++ Seq(IndirectlyLoadedExternalResources(UrlBuilder(configuration.identityProfileBaseUrl,routes.SigninAction.signInWithSmartLock())))
 
-    val isMembership = clientId.exists(_ == GuardianMembersClientID)
+    val showSupportMessaging = clientId.contains(GuardianMembersClientID) || clientId.contains(GuardianRecurringContributionsClientID)
 
     SignInViewModel(
       layout = layout,
 
       oauth = OAuthSignInViewModel(configuration, returnUrl, skipConfirmation, clientId, group, activeTests),
 
-      signInPageText = SignInPageText.toMap(isMembership),
+      signInPageText = SignInPageText.toMap(showSupportMessaging),
       terms = Terms.getTermsModel(group),
 
       hasErrors = errors.nonEmpty,

--- a/app/com/gu/identity/frontend/views/models/TwoStepSignInChoicesViewModel.scala
+++ b/app/com/gu/identity/frontend/views/models/TwoStepSignInChoicesViewModel.scala
@@ -74,9 +74,7 @@ object TwoStepSignInChoicesViewModel {
     val recaptchaModel : Option[GoogleRecaptchaViewModel] = None
 
     val resources = getResources(layout, recaptchaModel) ++ Seq(IndirectlyLoadedExternalResources(UrlBuilder(configuration.identityProfileBaseUrl,routes.SigninAction.signInWithSmartLock())))
-
-    val isMembership = clientId.exists(_ == GuardianMembersClientID)
-
+    
     val oauth = userType match {
       case Some(NewUser) => OAuthRegistrationViewModel(configuration, returnUrl, skipConfirmation, clientId, group, activeTests)
       case _ => OAuthSignInViewModel(configuration, returnUrl, skipConfirmation, clientId, group, activeTests)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -36,6 +36,8 @@ identity {
 
     preferredMembershipUrl = "https://membership.theguardian.com/supporter"
 
+    preferredSupportUrl = "https://support.theguardian.com"
+
     jobsBaseUrl = "https://jobs.theguardian.com"
   }
 

--- a/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
+++ b/test/com/gu/identity/frontend/models/ReturnUrlSpec.scala
@@ -78,4 +78,11 @@ class ReturnUrlSpec extends FlatSpec with Matchers {
     result.url shouldEqual config.preferredMembershipUrl
     result shouldBe 'default
   }
+
+  it should "Use the support return url for clientId=recurringContributions as the default fallback" in {
+    val result = ReturnUrl(None, None, config, Some(GuardianRecurringContributionsClientID))
+
+    result.url shouldEqual config.preferredSupportUrl
+    result shouldBe 'default
+  }
 }


### PR DESCRIPTION
When people hit identity with the new `recurringContributions` client ID, we want them to:

**a)** See the new header on the `/register` and `/signin/start` flows
**b)** See the "Support the guardian" title with a standfirst saying "Create your Guardian account" on the `/register` page
**c)**  See the custom title and copy on the `/signin/start` flow

**a)** and **c)** were implemented in [this PR](https://github.com/guardian/identity-frontend/pull/425). This PR implements **b)**, and also sets the default returnUrl to `support.theguardian.com` (although the returnUrl should be passed through from support frontend so hopefully this won't be needed, I'm just following the pattern for the `members` clientId)

In the near future we should stop sending the `members` clientId from support frontend, and create a new, support specific clientId, as currently the default return url for `members` is the membership site. At the moment we are always passing a returnUrl to the identity site so it isn't causing an issue right now but it may well do in the future.

Below I have attatched screenshots showing the effects of **a)**, **b)** and **c)**

| /register before | /register after |
|----------|--------|
|<img width="830" alt="registerbefore" src="https://user-images.githubusercontent.com/2844554/41973295-74636e3a-7a0c-11e8-8f51-7f3f0febaca1.png">|<img width="789" alt="registerafter" src="https://user-images.githubusercontent.com/2844554/41973294-7435ada6-7a0c-11e8-8bec-45a19d606b68.png">|

| /signup/start before  | /signup/start after |
|----------|--------|
|<img width="774" alt="2stepbefore" src="https://user-images.githubusercontent.com/2844554/41973293-74058676-7a0c-11e8-91b4-dab8eed1067b.png">|<img width="817" alt="2stepafter" src="https://user-images.githubusercontent.com/2844554/41973292-73d4719e-7a0c-11e8-8754-17fa7490248a.png">|






 
