### PR TITLE
Simpler loadComponents signature

### DIFF
--- a/public/components/ajax-step-flow/ajax-step-flow.js
+++ b/public/components/ajax-step-flow/ajax-step-flow.js
@@ -20,7 +20,6 @@ import {
   getSlide
 } from 'components/ajax-step-flow/ajax-step-flow__slide';
 import { loadComponents } from 'js/load-components';
-import { components } from 'js/components';
 import { pageView } from '../analytics/ga';
 
 const selector: string = '.ajax-step-flow';
@@ -185,7 +184,7 @@ const init = ($component: HTMLElement): void => {
       /* push the slide */
       pushSlide($slide, $new, ev.detail.reverse).then(() => {
         onSlide($component, $new, url);
-        loadComponents((($new.parentElement: any): HTMLElement), components);
+        loadComponents((($new.parentElement: any): HTMLElement));
         triggerAutoFocus($new);
       });
     } else {

--- a/public/js/load-components.js
+++ b/public/js/load-components.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import Raven from 'raven-js';
+import { components } from 'js/components';
 
 const ERR_MALFORMED_LOADER = 'Missing loader parts';
 const ERR_COMPONENT_THROW = 'Uncaught component error';
@@ -43,7 +44,7 @@ const loadComponent = ($root: HTMLElement, component: Component): void => {
   }
 };
 
-const loadComponents = ($root: HTMLElement, components: any[]): void => {
+const loadComponents = ($root: HTMLElement): void => {
   components.forEach(component => {
     loadComponent($root, new Component(component));
   });

--- a/public/main.js
+++ b/public/main.js
@@ -1,9 +1,8 @@
 import './components/sentry/sentry';
 import './js/load-global-css';
 
-import { components } from './js/components';
 import { loadComponents } from './js/load-components';
 import { logPageView } from './components/analytics/analytics';
 
 logPageView();
-loadComponents(document, components);
+loadComponents(document);


### PR DESCRIPTION
Makes `loadComponents` always know its components os you don't have to pass them around, which doesn't provide any real benefit. Prep work for #431