### PR TITLE
Clean up sentry reporting

### DIFF
--- a/public/components/ajax-step-flow/ajax-step-flow__slide.js
+++ b/public/components/ajax-step-flow/ajax-step-flow__slide.js
@@ -80,7 +80,7 @@ const fetchSlide = (
     .then(response => {
       const errors = getUrlErrors(response.url);
       if (response.status !== 200) {
-        throw new Error([ERR_MALFORMED_RESPONSE, response]);
+        throw new Error([ERR_MALFORMED_RESPONSE, JSON.stringify(response)]);
       }
       if (errors.length) {
         throw new Error([ERR_BACKEND_ERROR, ...errors]);
@@ -92,7 +92,7 @@ const fetchSlide = (
             window.location.href = json.returnUrl;
             return new Promise(() => {});
           }
-          throw new Error([ERR_MALFORMED_RESPONSE, response]);
+          throw new Error([ERR_MALFORMED_RESPONSE, JSON.stringify(response)]);
         } catch (e) {
           return [text, response.url];
         }

--- a/public/components/smartlock-trigger/smartlock-trigger.js
+++ b/public/components/smartlock-trigger/smartlock-trigger.js
@@ -9,15 +9,13 @@ const selector: string = '.smartlock-trigger';
 const ERR_FAILED_SIGNIN = 'Error signing in with smart lock';
 const ERR_MISSING_PARAMS = 'Missing parameters';
 
-type Credential = {
+type PasswordCredential = {
   id: string,
   password: string
 };
 
-type PasswordCredential = Credential;
-
 const smartLockSignIn = (
-  credentials: Credential,
+  credentials: PasswordCredential,
   returnUrl: string,
   csrfToken: string
 ) => {
@@ -55,10 +53,8 @@ const init = ($element: HTMLElement): void => {
   }
 
   // $FlowFixMe
-  if (navigator && navigator.credentials !== null) {
-    const credentialsContainer = (navigator: any).credentials;
-
-    credentialsContainer
+  if (navigator && navigator.credentials && navigator.credentials.get) {
+    navigator.credentials
       .get({
         password: true
       })


### PR DESCRIPTION
Small health task:

I've gone through our Sentry sentry errors and 90% of what we send is smartlock errors for browsers that don't support it, so I'm making those fail silently now because there's nothing for us to do (and they aren't actual errors)

There's also a slight improvement for MALFORMED_RESPONSE where we'll log the full response. I expect these to be the server taking too long to respond and thus returning an empty page but it doesn't hurt to know.

![screen shot 2018-07-10 at 11 40 13 am](https://user-images.githubusercontent.com/11539094/42505512-d2f3155c-8436-11e8-90a6-77d0117b45d2.png)
