### PR TITLE
CSS alterations

### DIFF
--- a/public/components/form/_form.global.css
+++ b/public/components/form/_form.global.css
@@ -51,7 +51,7 @@ prelude
       transparent calc(50%)
     );
   }
-  > * {
+  & > * {
     background: var(--color-bg);
     padding: 0 0.1rem;
   }

--- a/public/components/jobs/_jobs.global.css
+++ b/public/components/jobs/_jobs.global.css
@@ -1,12 +1,12 @@
 @import 'css/_globals.css';
 
 .skin-jobs {
-  .header {
+  & .header {
     height: auto;
     padding: 5px 0;
   }
 
-  .header__logo-link {
+  & .header__logo-link {
     background-image: inline('guardian-jobs-logo.svg');
     width: 262px;
     height: 57px;

--- a/public/components/layout/_layout.global.css
+++ b/public/components/layout/_layout.global.css
@@ -104,9 +104,10 @@
     padding-top: 0;
     border-top: 0;
   }
-  & .layout-header + & {
-    margin-top: 0;
-  }
+}
+
+.layout-header + .layout-section {
+  margin-top: 0;
 }
 
 /*

--- a/public/components/layout/_layout.global.css
+++ b/public/components/layout/_layout.global.css
@@ -31,6 +31,9 @@
   display: block;
   color: inherit;
   text-decoration: none;
+  @media (--viewport-max-mobile-medium) {
+    padding-right: 3em; /*avoid overlaps with the logo*/
+  }
   & + .layout-header {
     margin-top: calc(var(--size-baseline-vertical) / -2);
   }

--- a/public/components/layout/_layout.global.css
+++ b/public/components/layout/_layout.global.css
@@ -42,9 +42,6 @@
   margin: 0;
   color: currentColor;
   text-decoration: none;
-  @media (--viewport-max-mobile-medium) {
-    padding-right: 3em; /*avoid overlaps with the logo*/
-  }
   & a:not([class]) {
     @mixin link;
     color: currentColor;
@@ -60,6 +57,11 @@
     @mixin font-header-standfirst;
     font-weight: 300;
     margin-top: calc(var(--size-baseline) / 2);
+  }
+  &:not(.layout-header__title--standfirst) {
+    @media (--viewport-max-mobile-medium) {
+      padding-right: 3em; /*avoid overlaps with the logo*/
+    }
   }
   &.layout-header__title--has-proxy {
     display: flex;

--- a/public/components/layout/_layout.global.css
+++ b/public/components/layout/_layout.global.css
@@ -31,9 +31,6 @@
   display: block;
   color: inherit;
   text-decoration: none;
-  @media (--viewport-max-mobile-medium) {
-    padding-right: 3em; /*avoid overlaps with the logo*/
-  }
   & + .layout-header {
     margin-top: calc(var(--size-baseline-vertical) / -2);
   }
@@ -45,6 +42,9 @@
   margin: 0;
   color: currentColor;
   text-decoration: none;
+  @media (--viewport-max-mobile-medium) {
+    padding-right: 3em; /*avoid overlaps with the logo*/
+  }
   & a:not([class]) {
     @mixin link;
     color: currentColor;

--- a/public/components/recurringContributions/_recurringContributions.global.css
+++ b/public/components/recurringContributions/_recurringContributions.global.css
@@ -1,8 +1,8 @@
 @import 'css/_globals.css';
 
 :root {
-  --gu-h-spacing: calc(var(--size-baseline) * 5);
-  --gu-v-spacing: calc(var(--size-baseline) * 3);
+  --gu-h-spacing: var(--size-baseline-gutter);
+  --gu-v-spacing: calc(var(--size-baseline-vertical) / 2);
 }
 
 .skin-recurringContributions {

--- a/public/css/globals/_mixins-type.css
+++ b/public/css/globals/_mixins-type.css
@@ -18,32 +18,35 @@
   font-weight: 300;
 }
 
-@define-mixin font-body-copy-small {
+@define-mixin font-body-copy {
   @mixin font-sans-serif;
+  @mixin font-size 16, 20;
+}
+
+@define-mixin font-body-copy-small {
+  @mixin font-body-copy;
   @mixin font-size 14, 20;
 }
 
-@define-mixin font-body-copy {
-  @mixin font-body-copy-small;
-  @media (--viewport-min-mobile-landscape) {
-    @mixin font-size 16, 22;
-  }
-}
-
 @define-mixin font-button {
-  @mixin font-sans-serif;
-  @mixin font-size 16, 20;
+  @mixin font-body-copy;
   font-weight: 500;
 }
 
 @define-mixin font-header {
   @mixin font-heading;
-  @mixin font-size 28, 32;
+  @mixin font-size 20, 26;
   font-weight: 500;
+  @media (--viewport-min-mobile-landscape) {
+    @mixin font-size 28, 32;
+  }
 }
 
 @define-mixin font-header-standfirst {
-  @mixin font-heading;
-  @mixin font-size 20, 26;
-  font-weight: 400;
+  @mixin font-body-copy;
+  @media (--viewport-min-mobile-landscape) {
+    @mixin font-heading;
+    @mixin font-size 20, 26;
+    font-weight: 400;
+  }
 }

--- a/public/css/globals/_vars.css
+++ b/public/css/globals/_vars.css
@@ -1,41 +1,3 @@
-/* Colours */
-:root {
-  --color-brand: #121212;
-  --color-cta: #ffe500;
-
-  --color-border: #abc2c9;
-  --color-border-hover: #839ca3;
-
-  --color-text: #121212;
-
-  --color-error: #c70000;
-  --color-info: #005689;
-
-  --color-link: var(--color-text);
-  --color-link-underline: var(--color-border-hover);
-
-  --color-bg: #e9eff1;
-}
-
-/* Metrics */
-:root {
-  --size-baseline: 0.4rem;
-  --size-baseline-gutter: calc(var(--size-baseline) * 5);
-  --size-baseline-vertical: calc(var(--size-baseline) * 10);
-  --size-header-height: 4.8rem;
-}
-
-/* Z-Index */
-:root {
-  --z-index-banner: 500;
-  --z-index-header: 600;
-}
-
-/* Etc */
-:root {
-  --base-font-size: 10;
-}
-
 /* Breakpoints */
 @custom-media --viewport-min-mobile (min-width: 320px);
 @custom-media --viewport-max-mobile (max-width: 320px);
@@ -59,3 +21,44 @@
 @custom-media --viewport-tablet (--viewport-min-tablet) and (--viewport-max-desktop);
 @custom-media --viewport-desktop (--viewport-min-desktop) and (--viewport-max-leftCol);
 @custom-media --viewport-wide (--viewport-min-leftCol);
+
+/* Colours */
+:root {
+  --color-brand: #121212;
+  --color-cta: #ffe500;
+
+  --color-border: #abc2c9;
+  --color-border-hover: #839ca3;
+
+  --color-text: #121212;
+
+  --color-error: #c70000;
+  --color-info: #005689;
+
+  --color-link: var(--color-text);
+  --color-link-underline: var(--color-border-hover);
+
+  --color-bg: #e9eff1;
+}
+
+/* Metrics */
+:root {
+  --size-baseline: 0.4rem;
+  --size-baseline-gutter: calc(var(--size-baseline) * 5);
+  --size-baseline-vertical: calc(var(--size-baseline) * 5);
+  @media (--viewport-min-tablet) {
+    --size-baseline-vertical: calc(var(--size-baseline) * 10);
+  }
+  --size-header-height: 4.8rem;
+}
+
+/* Z-Index */
+:root {
+  --z-index-banner: 500;
+  --z-index-header: 600;
+}
+
+/* Etc */
+:root {
+  --base-font-size: 10;
+}

--- a/public/css/globals/_vars.css
+++ b/public/css/globals/_vars.css
@@ -20,8 +20,8 @@
 /* Metrics */
 :root {
   --size-baseline: 0.4rem;
-  --size-baseline-gutter: calc(var(--size-baseline) * 4);
-  --size-baseline-vertical: calc(var(--size-baseline) * 8);
+  --size-baseline-gutter: calc(var(--size-baseline) * 5);
+  --size-baseline-vertical: calc(var(--size-baseline) * 10);
   --size-header-height: 4.8rem;
 }
 


### PR DESCRIPTION
- [More compact layouts on mobile](https://trello.com/c/oFJj3NZe/778-review-font-sizes-spacing-layout-on-identity-frontend)
- [Bring back the Guardian Jobs branding](https://trello.com/c/mzWb3gNs/807-guardian-jobs-branding-on-identity-screen-for-jobs)
- Avoid header text overlapping the logo on mobile
- Add back the background behind `or` on the divider so it's no longer crossed out
- Sync up horizontal/vertical rhythm with contributions

<table>
<tr><td width="50%">

![screen shot 2018-07-17 at 10 21 02 am](https://user-images.githubusercontent.com/11539094/42808397-2676844c-89ab-11e8-9a54-7f5c6d920256.png)

</td><td width="50%">

![screen shot 2018-07-17 at 10 21 04 am](https://user-images.githubusercontent.com/11539094/42808387-229e8270-89ab-11e8-9b09-7f2197d828dd.png)

</tr></table>