### PR TITLE
Take logstash into account in memory calculation

### DIFF
--- a/cloudformation/identity-frontend.yaml
+++ b/cloudformation/identity-frontend.yaml
@@ -235,7 +235,7 @@ Resources:
 
             # systemd stuff
             total_mem=$(grep MemTotal /proc/meminfo | awk '{ print $2 }')
-            heap_size_in_mb=$(python -c "print int($total_mem * 0.8 / 1024)")
+            heap_size_in_mb=$(python -c "print int(($total_mem / 1024 - 500) * 0.65)")
 
             sed -i "s/<APP>/${App}/g" /etc/systemd/system/${App}.service
             sed -i "s/<STAGE>/${Stage}/g" /etc/systemd/system/${App}.service


### PR DESCRIPTION
Kinesis plugin for logstash appears to bump memory usage, so allowing for that should stop the app crashing.