### PR TITLE
cf deploy and temporary http origin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ riffRaffPackageName := name.value
 riffRaffManifestProjectName := s"identity:${name.value}"
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
+riffRaffArtifactResources += (file("cloudformation/identity-frontend.yaml"), "cfn/identity-frontend.yaml")
 
 // FIXME: riffraff should automatically detect these but it seems tc-build.sh is interfering with that
 riffRaffBuildIdentifier := Option(System.getenv("BUILD_NUMBER")).getOrElse("unknown")

--- a/cloudformation/identity-frontend.yaml
+++ b/cloudformation/identity-frontend.yaml
@@ -316,6 +316,10 @@ Resources:
         FromPort: '443'
         ToPort: '443'
         CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
+        FromPort: '80'
+        ToPort: '80'
+        CidrIp: 0.0.0.0/0
       SecurityGroupEgress:
       - IpProtocol: tcp
         FromPort: !Ref Port

--- a/cloudformation/identity-frontend.yaml
+++ b/cloudformation/identity-frontend.yaml
@@ -138,6 +138,9 @@ Resources:
         SSLCertificateId: !Sub
           - 'arn:aws:acm:eu-west-1:${AWS::AccountId}:${CertId}'
           - CertId: !FindInMap [CertsMap, !Ref 'Stage', ssl]
+      - LoadBalancerPort: '80'
+        InstancePort: !Ref Port
+        Protocol: HTTP
       CrossZone: 'true'
       HealthCheck:
         Target: !Sub HTTP:${Port}/management/healthcheck

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -21,3 +21,14 @@ deployments:
           Recipe: identity-base
           AmigoStage: PROD
       amiEncrypted: true
+  cfn:
+    type: cloud-formation
+    parameters:
+      cloudFormationStackName: IdentityFrontend
+      templatePath: identity-frontend.yaml
+      prependStackToCloudFormationStackName: false
+      cloudFormationStackByTags: false
+      amiParametersToTags:
+        AMI:
+          Recipe: identity-base
+          AmigoStage: PROD

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -10,17 +10,8 @@ deployments:
       prefixStack: false
     dependencies:
       - update-ami
-  update-ami:
-    type: ami-cloudformation-parameter
-    parameters:
-      cloudFormationStackByTags: false
-      prependStackToCloudFormationStackName: false
-      cloudFormationStackName: IdentityFrontend
-      amiParametersToTags:
-        AMI:
-          Recipe: identity-base
-          AmigoStage: PROD
-      amiEncrypted: true
+      - cfn
+
   cfn:
     type: cloud-formation
     parameters:
@@ -32,3 +23,18 @@ deployments:
         AMI:
           Recipe: identity-base
           AmigoStage: PROD
+    dependencies:
+      - update-ami
+
+  update-ami:
+    type: ami-cloudformation-parameter
+    parameters:
+      cloudFormationStackByTags: false
+      prependStackToCloudFormationStackName: false
+      cloudFormationStackName: IdentityFrontend
+      amiParametersToTags:
+        AMI:
+          Recipe: identity-base
+          AmigoStage: PROD
+      amiEncrypted: true
+


### PR DESCRIPTION
- cf riffraff deploy
- temporarily enable http for identity frontend while changing certificates