### PR TITLE
remove http from loadbalancer

### DIFF
--- a/cloudformation/identity-frontend.yaml
+++ b/cloudformation/identity-frontend.yaml
@@ -138,9 +138,6 @@ Resources:
         SSLCertificateId: !Sub
           - 'arn:aws:acm:eu-west-1:${AWS::AccountId}:${CertId}'
           - CertId: !FindInMap [CertsMap, !Ref 'Stage', ssl]
-      - LoadBalancerPort: '80'
-        InstancePort: !Ref Port
-        Protocol: HTTP
       CrossZone: 'true'
       HealthCheck:
         Target: !Sub HTTP:${Port}/management/healthcheck
@@ -315,10 +312,6 @@ Resources:
       - IpProtocol: tcp
         FromPort: '443'
         ToPort: '443'
-        CidrIp: 0.0.0.0/0
-      - IpProtocol: tcp
-        FromPort: '80'
-        ToPort: '80'
         CidrIp: 0.0.0.0/0
       SecurityGroupEgress:
       - IpProtocol: tcp


### PR DESCRIPTION
remove http from loadbalancer
- This was added while changing the ssl certificate, it is no longer needed