### PR TITLE
Remove "| Identity" from page titles

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1,4 +1,4 @@
-layout.pagetitle=Identity | The Guardian
+layout.pagetitle=The Guardian
 layout.skip=Skip to main content
 
 signin.title=Sign in to The Guardian


### PR DESCRIPTION
Super tiny update to sync up our titles with gu.com