### PR TITLE
add jobs default url redirect

### DIFF
--- a/app/com/gu/identity/frontend/models/ReturnUrl.scala
+++ b/app/com/gu/identity/frontend/models/ReturnUrl.scala
@@ -51,10 +51,14 @@ object ReturnUrl {
   def defaultForSupport(configuration: Configuration) =
     defaultFromUrl(configuration.preferredSupportUrl)
 
+  def defaultForJobs(configuration: Configuration) =
+    defaultFromUrl(configuration.jobsBaseUrl)
+
   def defaultForClient(configuration: Configuration, clientId: Option[ClientID]) =
     clientId match {
       case Some(GuardianMembersClientID) => defaultForMembership(configuration)
       case Some(GuardianRecurringContributionsClientID) => defaultForSupport(configuration)
+      case Some(GuardianJobsClientID) => defaultForJobs(configuration)
       case _ => default(configuration)
     }
 


### PR DESCRIPTION
On jobs login, there was no default return URL set so users were being returned to theguardian.com. 