### PR TITLE
Return url in consent Controller

### DIFF
--- a/app/com/gu/identity/frontend/controllers/ConsentController.scala
+++ b/app/com/gu/identity/frontend/controllers/ConsentController.scala
@@ -20,10 +20,11 @@ class ConsentController(
     with Logging
     with I18nSupport {
 
-  def confirmConsents(consentToken: String): Action[AnyContent] = Action.async { implicit request =>
+  def confirmConsents(consentToken: String, returnUrl: Option[String] = None): Action[AnyContent] = Action.async { implicit request =>
     identityService.authenticateConsentToken(consentToken).map {
       case Right(playCookies) =>
-        Redirect("/consents/thank-you").withCookies(playCookies: _*)
+        val redirect = returnUrl.getOrElse("/consents/thank-you")
+        Redirect(redirect).withCookies(playCookies: _*)
       case Left(ConsentTokenUnauthorizedException :: _) => Redirect(routes.Application.invalidConsentToken(consentToken = consentToken))
       case Left(_) => renderErrorPage(configuration, NotFoundError("The requested page was not found."), NotFound.apply)
     }.recover {

--- a/conf/routes
+++ b/conf/routes
@@ -17,8 +17,8 @@ POST       /actions/signin/smartlock                    com.gu.identity.frontend
 POST       /actions/signin/with-email                   com.gu.identity.frontend.controllers.SigninAction.emailSignInFirstStep
 GET        /actions/signin/consents/:token              com.gu.identity.frontend.controllers.SigninAction.permissionAuth(token:String, journey: Option[String])
 POST       /actions/register                            com.gu.identity.frontend.controllers.RegisterAction.register
-GET        /accept-consent/:consentToken                com.gu.identity.frontend.controllers.ConsentController.confirmConsents(consentToken: String)
-GET        /consent-token/:consentToken/accept          com.gu.identity.frontend.controllers.ConsentController.confirmConsents(consentToken: String)
+GET        /accept-consent/:consentToken                com.gu.identity.frontend.controllers.ConsentController.confirmConsents(consentToken: String, returnUrl: Option[String] ?= None)
+GET        /consent-token/:consentToken/accept          com.gu.identity.frontend.controllers.ConsentController.confirmConsents(consentToken: String, returnUrl: Option[String] ?= None)
 GET        /consent-token/:consentToken/invalid         com.gu.identity.frontend.controllers.Application.invalidConsentToken(error: Seq[String] ?= Seq.empty, consentToken: String)
 GET        /consent-token/resend                        com.gu.identity.frontend.controllers.ResendConsentTokenAction.resend
 GET        /consent-token/resent                        com.gu.identity.frontend.controllers.Application.resendConsentTokenSent(error: Seq[String] ?= Seq.empty)


### PR DESCRIPTION
Need to pass return URL when following the consent magic link flow

Relevant IDAPI change : https://github.com/guardian/identity/pull/1427/files#diff-efb0c32dce7e8337c306d05648974000L8