### PR TITLE
Visible email fields for 2nd steps

### DIFF
--- a/app/com/gu/identity/frontend/models/text/TwoStepSignInChoicesPageText.scala
+++ b/app/com/gu/identity/frontend/models/text/TwoStepSignInChoicesPageText.scala
@@ -24,6 +24,7 @@ object TwoStepSignInChoicesPageText {
       "privacyPolicy" -> messages("signin.privacypolicy"),
 
       "emailFieldTitle" -> messages("signinTwoStep.emailFieldTitle"),
+      "emailTitle" -> messages("signinTwoStep.emailTitle"),
       "setPasswordTitle" -> messages("signinTwoStep.setPasswordTitle"),
       "setPasswordAction" -> messages("signinTwoStep.setPasswordAction"),
       "recoverPasswordAction" -> messages("signinTwoStep.recoverPasswordAction"),

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -34,6 +34,7 @@ signinTwoStep.registerAction=Create an account
 signinTwoStep.setPasswordTitle=To continue, first you need to verify it’s you. Just click the button below and we’ll email you a link.
 signinTwoStep.setPasswordAction=Send me a confirmation link
 signinTwoStep.recoverPasswordAction=Forgot password?
+signinTwoStep.emailTitle=Email
 
 signinTwoStep.signInCtaEmailAction=Sign in with Email
 signinTwoStep.oauthStepTwoFieldTitle=You can sign in with your social accounts:

--- a/public/components/form/_form.global.css
+++ b/public/components/form/_form.global.css
@@ -25,12 +25,18 @@ input
     border-color: color-mod(var(--color-border-hover) lightness(-20%));
     outline: none;
   }
+
 }
 .form-input {
   @mixin form-input;
   &.form-input__display-errors:invalid {
     border-color: var(--color-error);
     color: var(--color-error);
+  }
+  &[disabled] {
+    background: transparent;
+    pointer-events: none;
+    color: var(--color-border-hover);
   }
 }
 

--- a/public/components/form/_form.global.css
+++ b/public/components/form/_form.global.css
@@ -36,7 +36,7 @@ input
   &[disabled] {
     background: transparent;
     pointer-events: none;
-    color: var(--color-border-hover);
+    color: var(--color-text-disabled);
   }
 }
 

--- a/public/components/two-step-signin/two-step-signin-existing.hbs
+++ b/public/components/two-step-signin/two-step-signin-existing.hbs
@@ -3,9 +3,12 @@
   {{> components/two-step-signin/_email-header }}
   {{> components/two-step-signin/_helpers }}
 
-    <div class="form-field-wrap">
-      <input class="u-none" name="email" autocomplete="username" value="{{email}}" />
-      <label class="form-field-wrap__title" for="tsse-password">{{twoStepSignInPageText.passwordFieldTitle}}</label>
+  <div class="form-field-wrap">
+    <label class="form-field-wrap__title" for="tsse-email">{{twoStepSignInPageText.emailTitle}}</label>
+    <input class="form-input form-field-wrap__field" type="email" name="email" id="tsse-email" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" disabled value="{{email}}" />
+  </div>
+  <div class="form-field-wrap">
+    <label class="form-field-wrap__title" for="tsse-password">{{twoStepSignInPageText.passwordFieldTitle}}</label>
       <input class="form-input form-field-wrap__field" type="password" name="password" id="tsse-password" autocomplete="password" autocapitalize="off" autocorrect="off" spellcheck="false" autofocus="autofocus" value="{{password}}" />
       <div class="form-field-wrap__footer">
         <label class="form-checkbox">

--- a/public/components/two-step-signin/two-step-signin-new.hbs
+++ b/public/components/two-step-signin/two-step-signin-new.hbs
@@ -2,13 +2,18 @@
 
   {{> components/two-step-signin/_email-header }}
   {{> components/two-step-signin/_helpers }}
-  <input type="hidden" name="email" value="{{email}}" />
 
   <p class="layout-text">
     {{twoStepSignInPageText.newUserCreateAccountAction}}
   </p>
 
   <div class="layout-section layout-section--no-border">
+
+    <div class="form-field-wrap">
+      <label class="form-field-wrap__title" for="tsse-email">{{twoStepSignInPageText.emailTitle}}</label>
+      <input class="form-input form-field-wrap__field" type="email" name="email" id="tsse-email" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" disabled value="{{email}}" />
+    </div>
+
     {{> components/register-form/_form-field-name text=twoStepSignInPageText.registerForm }}
 
     {{> components/register-form/_form-field-phone

--- a/public/css/globals/_vars.css
+++ b/public/css/globals/_vars.css
@@ -30,6 +30,7 @@
   --color-border: #dcdcdc;
   --color-border-hover: #999999;
   --color-text: #121212;
+  --color-text-disabled: #333333;
 
   --color-error: #c70000;
   --color-info: #005689;


### PR DESCRIPTION
Make the emails fields on second steps of signing invisible (but disabled) so password managers can pick them up more easily and offer to save passwords / sign in with a saved pwd.

The UI is a bit of a mess. I'd personally get rid of the headings (which duplicate the email) and the steps but there's a fair point to be made as to where do we stop with updating the UI, as the global form styles have changed too. For now this fixes a couple of pain points.

## Screenies

![screen shot 2018-10-04 at 10 59 56 am](https://user-images.githubusercontent.com/11539094/46467074-c6f0fe00-c7c4-11e8-9373-7face23df14b.png)

![screen shot 2018-10-04 at 11 01 32 am](https://user-images.githubusercontent.com/11539094/46467113-dcfebe80-c7c4-11e8-9aa7-c8a16111ec19.png)
