### PR TITLE
Replace GU_SIGNIN_EMAIL with value in Session Flash

### DIFF
--- a/app/com/gu/identity/frontend/authentication/CookieService.scala
+++ b/app/com/gu/identity/frontend/authentication/CookieService.scala
@@ -58,18 +58,4 @@ object CookieService {
 
     }
   }
-
-  def signInEmailCookies(email: String)(config: Configuration): Seq[PlayCookie] = {
-    Seq(PlayCookie(
-      name = "GU_SIGNIN_EMAIL",
-      value = email,
-      maxAge = None,
-      path = "/",
-      domain = Some(config.identityCookieDomain),
-      secure = true,
-      httpOnly = false
-    )
-    )
-  }
-
 }

--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -33,7 +33,7 @@ class Application(
       val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"), configuration, _clientId)
       val csrfToken = CSRF.getToken(req)
       val groupCode = GroupCode(group)
-      val email : Option[String] = req.cookies.get("GU_SIGNIN_EMAIL").map(_.value)
+      val email : Option[String] = req.flash.get("email") // set by endpoint /actions/signin/with-email / SigninAction.emailSignInFirstStep
       val userType = Seq(CurrentUser, GuestUser, NewUser).find(_.name == signInType)
       val intcmp = req.getQueryString("INTCMP")
 

--- a/app/com/gu/identity/frontend/controllers/SigninAction.scala
+++ b/app/com/gu/identity/frontend/controllers/SigninAction.scala
@@ -111,17 +111,15 @@ class SigninAction(
       case Left(errors) => Left(errors)
       case Right(response) =>
         signInFirstStepMetricsLogger(request)
-        val emailLoginCookie = CookieService.signInEmailCookies(body.email)(config)
         Right(
           successfulFirstStepResponse(
             response.userType,
             successfulReturnUrl,
-            emailLoginCookie,
             body.skipConfirmation,
             body.clientId,
             body.groupCode,
             body.skipValidationReturn
-          )
+          ).flashing("email" -> body.email) // used by endpoint /signin/:signInType / Application.twoStepSignInChoices
         )
     }
   }
@@ -212,10 +210,9 @@ class SigninAction(
       .withCookies(cookies: _*)
 
 
-  def successfulFirstStepResponse(userType: String, successfulReturnUrl: ReturnUrl, cookies: Seq[Cookie], skipConfirmation: Option[Boolean], clientId: Option[ClientID], group: Option[GroupCode], skipValidationReturn: Option[Boolean]): Result ={
+  def successfulFirstStepResponse(userType: String, successfulReturnUrl: ReturnUrl, skipConfirmation: Option[Boolean], clientId: Option[ClientID], group: Option[GroupCode], skipValidationReturn: Option[Boolean]): Result ={
     val secondStepUrl = UrlBuilder(s"${config.identityProfileBaseUrl}/signin/$userType", Some(successfulReturnUrl), skipConfirmation, clientId, group, skipValidationReturn)
     SeeOther(secondStepUrl)
-      .withCookies(cookies: _*)
   }
 
   def successfulSmartLockSignInResponse(cookies: Seq[Cookie]): Result =


### PR DESCRIPTION
Since we are only using the cookie in the next request, this seems like a perfect use case for [ScalaSessionFlash](https://www.playframework.com/documentation/2.6.x/ScalaSessionFlash). This solves the problem of the `GU_SIGNIN_EMAIL` cookie lasting for a whole session, which potentially lead to confusing behaviour for the user.

I also took the time to refactor the action `emailSignInFirstStep` - motivation included in the comments.