### PR TITLE
Look for email in query string if not in flash

### DIFF
--- a/app/com/gu/identity/frontend/controllers/Application.scala
+++ b/app/com/gu/identity/frontend/controllers/Application.scala
@@ -33,7 +33,10 @@ class Application(
       val returnUrlActual = ReturnUrl(returnUrl, req.headers.get("Referer"), configuration, _clientId)
       val csrfToken = CSRF.getToken(req)
       val groupCode = GroupCode(group)
-      val email : Option[String] = req.flash.get("email") // set by endpoint /actions/signin/with-email / SigninAction.emailSignInFirstStep
+      // Email flash set by endpoint /actions/signin/with-email / SigninAction.emailSignInFirstStep.
+      // If not defined, we fallback to email query string.q
+      // This second way of providing email is used by support frontend.
+      val email : Option[String] = req.flash.get("email").orElse(req.getQueryString("email"))
       val userType = Seq(CurrentUser, GuestUser, NewUser).find(_.name == signInType)
       val intcmp = req.getQueryString("INTCMP")
 


### PR DESCRIPTION
For use by support frontend. They want to bypass the first stage since they know the user's email address and their user type (current).

Thinking about it, I can't see why passing through email as a query string couldn't work for all cases, but I'll leave that for a another potential PR.