### PR TITLE
Setup for S&C sign-in page

### DIFF
--- a/app/com/gu/identity/frontend/models/ClientID.scala
+++ b/app/com/gu/identity/frontend/models/ClientID.scala
@@ -46,8 +46,14 @@ case object GuardianCommentersClientID extends ClientID {
   val id = "comments"
 }
 
+case object SimpleAndCoherentClientID extends ClientID {
+  val id = "simpleAndCoherent"
+
+  override def hasSkin = true
+}
+
 object ClientID {
-  def all: Seq[ClientID] = Seq(GuardianMembersClientID, GuardianCommentersClientID, GuardianJobsClientID, GuardianRecurringContributionsClientID)
+  def all: Seq[ClientID] = Seq(GuardianMembersClientID, GuardianCommentersClientID, GuardianJobsClientID, GuardianRecurringContributionsClientID, SimpleAndCoherentClientID)
 
   def apply(clientId: String): Option[ClientID] =
     all.find(_.id == clientId)

--- a/public/components/simple-and-coherent/_simple-and-coherent.global.css
+++ b/public/components/simple-and-coherent/_simple-and-coherent.global.css
@@ -1,0 +1,17 @@
+@import 'css/_globals.css';
+
+/*To be updated when designs come from S&C*/
+.skin-simpleAndCoherent {
+  & .header {
+    height: auto;
+    padding: 5px 0;
+    background-color: var(--color-bg);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  & .header__logo-link {
+    background-image: inline('');
+    width: 262px;
+    height: 57px;
+  }
+}

--- a/public/components/simple-and-coherent/_simple-and-coherent.global.css
+++ b/public/components/simple-and-coherent/_simple-and-coherent.global.css
@@ -1,17 +1,3 @@
 @import 'css/_globals.css';
 
 /*To be updated when designs come from S&C*/
-.skin-simpleAndCoherent {
-  & .header {
-    height: auto;
-    padding: 5px 0;
-    background-color: var(--color-bg);
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  & .header__logo-link {
-    background-image: inline('');
-    width: 262px;
-    height: 57px;
-  }
-}

--- a/public/js/load-global-css.js
+++ b/public/js/load-global-css.js
@@ -18,7 +18,7 @@ import 'components/react-island/_react-island__fallback.global.css';
 
 /** Skins * */
 import 'components/jobs/_jobs.global.css';
-import 'components/simple-and-coherent/_simple-and-coherent.global.css'
+import 'components/simple-and-coherent/_simple-and-coherent.global.css';
 
 /** Async * */
 import('components/fonts/_fonts.css');

--- a/public/js/load-global-css.js
+++ b/public/js/load-global-css.js
@@ -18,6 +18,7 @@ import 'components/react-island/_react-island__fallback.global.css';
 
 /** Skins * */
 import 'components/jobs/_jobs.global.css';
+import 'components/simple-and-coherent/_simple-and-coherent.global.css'
 
 /** Async * */
 import('components/fonts/_fonts.css');


### PR DESCRIPTION
When designs come through, CSS can go in _simple-and-coherent.global.css. Variations to sign in page use layout specified in two-step-signin-start-page.hbs and text is mapped in Text.scala. 