### PR TITLE
Remove signin email on login and logout

### DIFF
--- a/app/com/gu/identity/frontend/authentication/AuthenticationService.scala
+++ b/app/com/gu/identity/frontend/authentication/AuthenticationService.scala
@@ -19,7 +19,9 @@ object AuthenticationService {
     IdentityCookie(CookieName.GU_ID_CSRF),
     IdentityCookie(CookieName.GU_PROFILE_CSRF),
     IdentityCookie(CookieName.SC_GU_U),
-    IdentityCookie(CookieName.SC_GU_RP)
+    IdentityCookie(CookieName.SC_GU_RP),
+    IdentityCookie(CookieName.GU_SIGNIN_EMAIL),
+    IdentityCookie(CookieName.SC_GU_LA),
   )
 
   implicit def cookieNameToString(cookieName: Name): String = cookieName.toString

--- a/app/com/gu/identity/frontend/authentication/CookieName.scala
+++ b/app/com/gu/identity/frontend/authentication/CookieName.scala
@@ -4,7 +4,7 @@ package com.gu.identity.frontend.authentication
 object CookieName extends Enumeration {
 
   type Name = Value
-  val GU_U, SC_GU_U, SC_GU_LA, GU_SO, GU_ID_CSRF, GU_PROFILE_CSRF, gu_user_features_expiry, gu_paying_member, gu_recurring_contributor, gu_digital_subscriber, SC_GU_RP = Value
+  val GU_U, SC_GU_U, SC_GU_LA, GU_SO, GU_ID_CSRF, GU_PROFILE_CSRF, gu_user_features_expiry, gu_paying_member, gu_recurring_contributor, gu_digital_subscriber, GU_SIGNIN_EMAIL, SC_GU_RP = Value
 
   val SECURE_COOKIE_PREFIX = "SC"
   def isHttpOnly(cookieName: String) = cookieName.startsWith(SECURE_COOKIE_PREFIX)

--- a/app/com/gu/identity/frontend/controllers/SigninAction.scala
+++ b/app/com/gu/identity/frontend/controllers/SigninAction.scala
@@ -202,7 +202,7 @@ class SigninAction(
   def successfulSignInResponse(successfulReturnUrl: ReturnUrl, cookies: Seq[Cookie]): Result =
     SeeOther(successfulReturnUrl.url)
       .withCookies(cookies: _*)
-
+    .discardingCookies(DiscardingCookie("GU_SIGNIN_EMAIL", "/", Some(config.identityCookieDomain)))
 
   def successfulAjaxSignInResponse(successfulReturnUrl: ReturnUrl, cookies: Seq[Cookie]): Result =
     Ok(Json.obj(
@@ -210,7 +210,7 @@ class SigninAction(
       "returnUrl" -> successfulReturnUrl.url.toString
     ))
       .withCookies(cookies: _*)
-
+      .discardingCookies(DiscardingCookie("GU_SIGNIN_EMAIL", "/", Some(config.identityCookieDomain)))
 
   def successfulFirstStepResponse(userType: String, successfulReturnUrl: ReturnUrl, cookies: Seq[Cookie], skipConfirmation: Option[Boolean], clientId: Option[ClientID], group: Option[GroupCode], skipValidationReturn: Option[Boolean]): Result ={
     val secondStepUrl = UrlBuilder(s"${config.identityProfileBaseUrl}/signin/$userType", Some(successfulReturnUrl), skipConfirmation, clientId, group, skipValidationReturn)

--- a/test/com/gu/identity/frontend/controllers/SignOutActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/SignOutActionSpec.scala
@@ -19,6 +19,7 @@ import play.api.test.Helpers._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
+
 class SignOutActionSpec extends PlaySpec with MockitoSugar {
 
   implicit lazy val materializer: Materializer = ActorMaterializer()(ActorSystem())
@@ -30,6 +31,8 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
   }
 
   val secureCookie = Cookie(name = CookieName.SC_GU_U.toString, value = "SC_GU_U_data", maxAge = None, path = "/", domain = Some("dev-theguardian.com"), secure = true, httpOnly = true)
+  val cookiesToUnset = CookieName.values.map(_.toString)
+
 
   val signedInCookies = Seq(
     secureCookie,
@@ -67,6 +70,8 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
       status(result) mustEqual SEE_OTHER
       redirectLocation(result) mustEqual returnUrl
 
+      cookiesToUnset.forall(resultCookies.map(_.name).toList.contains)
+      resultCookies.map(_.name).toList
       resultCookies.size mustEqual 12
     }
 
@@ -85,6 +90,8 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result) mustEqual returnUrl
+
+      cookiesToUnset.forall(resultCookies.map(_.name).toList.contains)
 
       resultCookies.size mustEqual 11
     }
@@ -119,6 +126,7 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
       captor.getValue.name mustEqual secureCookie.name
       captor.getValue.value mustEqual secureCookie.value
 
+      cookiesToUnset.forall(resultCookies.map(_.name).toList.contains)
       resultCookies.size mustEqual 12
       resultCookies.get("GU_SO").get.name == "GU_SO"
       resultCookies.get("GU_SO").get.value == "data_for_GU_SO"
@@ -146,6 +154,7 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
     status(result) mustEqual SEE_OTHER
     redirectLocation(result) mustEqual Some(referer)
 
+    cookiesToUnset.forall(resultCookies.map(_.name).toList.contains)
     resultCookies.size mustEqual 12
   }
 }

--- a/test/com/gu/identity/frontend/controllers/SignOutActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/SignOutActionSpec.scala
@@ -67,7 +67,7 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
       status(result) mustEqual SEE_OTHER
       redirectLocation(result) mustEqual returnUrl
 
-      resultCookies.size mustEqual 10
+      resultCookies.size mustEqual 12
     }
 
     "redirect to returnUrl when Identity API call fails" in new WithControllerMockedDependencies {
@@ -86,7 +86,7 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
       status(result) mustEqual SEE_OTHER
       redirectLocation(result) mustEqual returnUrl
 
-      resultCookies.size mustEqual 9
+      resultCookies.size mustEqual 11
     }
 
     "redirect to returnUrl despite lack of SC_GU_U cookie" in new WithControllerMockedDependencies {
@@ -98,7 +98,7 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
       status(result) mustEqual SEE_OTHER
       redirectLocation(result) mustEqual returnUrl
 
-      resultCookies.size mustEqual 9
+      resultCookies.size mustEqual 11
     }
 
     "set GU_SO cookie when user has SC_GU_U cookie" in new WithControllerMockedDependencies {
@@ -119,7 +119,7 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
       captor.getValue.name mustEqual secureCookie.name
       captor.getValue.value mustEqual secureCookie.value
 
-      resultCookies.size mustEqual 10
+      resultCookies.size mustEqual 12
       resultCookies.get("GU_SO").get.name == "GU_SO"
       resultCookies.get("GU_SO").get.value == "data_for_GU_SO"
     }
@@ -146,6 +146,6 @@ class SignOutActionSpec extends PlaySpec with MockitoSugar {
     status(result) mustEqual SEE_OTHER
     redirectLocation(result) mustEqual Some(referer)
 
-    resultCookies.size mustEqual 10
+    resultCookies.size mustEqual 12
   }
 }

--- a/test/com/gu/identity/frontend/controllers/SigninActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/SigninActionSpec.scala
@@ -123,6 +123,9 @@ class SigninActionSpec extends PlaySpec with MockitoSugar {
       status(result) mustEqual SEE_OTHER
       redirectLocation(result) mustEqual returnUrl
 
+      // successful sign in should set an unset cookie for GU_SIGNIN_EMAIL cookie
+      resultCookies.count(cookie => cookie.name == "GU_SIGNIN_EMAIL" && cookie.maxAge.contains(0)) mustEqual 1
+
       resultCookies.size mustEqual 2
       resultCookies.head mustEqual testCookie
     }

--- a/test/com/gu/identity/frontend/controllers/SigninActionSpec.scala
+++ b/test/com/gu/identity/frontend/controllers/SigninActionSpec.scala
@@ -123,7 +123,7 @@ class SigninActionSpec extends PlaySpec with MockitoSugar {
       status(result) mustEqual SEE_OTHER
       redirectLocation(result) mustEqual returnUrl
 
-      resultCookies.size mustEqual 1
+      resultCookies.size mustEqual 2
       resultCookies.head mustEqual testCookie
     }
 


### PR DESCRIPTION
- Remove GU_SIGNIN_EMAIL cookie after successful login
- Remove GU_SIGNIN_EMAIL on successful logout
- Also start to remove SC_GU_LA on logout (should have been doing this anyway)
NB:
Decided to leave the signin_email as a session cookie, this way it will still be around if the user navigates away from profile then back to it later. I don't think it is necessary to enforce it's deletion after a certain time.